### PR TITLE
Fix initial install path rough edges

### DIFF
--- a/demo/AgentBlazor.Demo/Components/Pages/Docs/GettingStarted.razor
+++ b/demo/AgentBlazor.Demo/Components/Pages/Docs/GettingStarted.razor
@@ -33,11 +33,17 @@
         <pre class="docs-code"><code>dotnet add ./src/MyBlazorApp/MyBlazorApp.csproj package AgentBlazor --version 0.1.0-preview.10
 
 builder.Services.AddMudServices();
-builder.Services.AddAgentBlazor(...);
+builder.Services.AddAgentBlazor(options =&gt; { ... });
 app.MapAgentBlazorEndpoints();
 
+// You must also register one workflow agent.
+options.ConfigureBuilder(agentBuilder =&gt;
+{
+    agentBuilder.AddWorkflow&lt;HelloWorkflow&gt;("hello-workflow");
+});
+
 @@using AgentBlazor.Components
-&lt;AgentChatWidget Title="Support inbox" /&gt;</code></pre>
+&lt;AgentBlazorShell /&gt;</code></pre>
     </section>
 
     <section class="docs-section">

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,383 +1,121 @@
 # Quickstart
 
-Get one AgentBlazor route working first. Keep the CLI out of the first install.
+Get one working chat route into a fresh Blazor app. AgentBlazor does not create a responding agent by default. You must register one workflow.
 
-## Prerequisites
-
-- `net8.0` through `net10.0` are supported
-- use the .NET 10 SDK when working from this repo or running the included demo/sample apps
-- an OpenAI API key, or Azure OpenAI endpoint/deployment/key or credential
-
-## 1. Install the Package
+## Install
 
 ```bash
-dotnet add package AgentBlazor --version 0.1.0-preview.10
+dotnet add package AgentBlazor --prerelease
 ```
 
-## 2. Configure Services
-
-In `Program.cs`:
+## Program.cs
 
 ```csharp
 using AgentBlazor;
 using MudBlazor.Services;
+using MyApp.Components;
+using MyApp.Workflows;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddRazorComponents()
+    .AddInteractiveServerComponents();
 
 builder.Services.AddMudServices();
 
 builder.Services.AddAgentBlazor(options =>
 {
-    // Choose your LLM provider
     options.UseOpenAI(
         apiKey: builder.Configuration["OpenAI:ApiKey"]!,
-        model: builder.Configuration["OpenAI:Model"]!);
+        model: builder.Configuration["OpenAI:Model"] ?? "gpt-4o-mini");
 
     options.ConfigureBuilder(agentBuilder =>
     {
-        agentBuilder.AddWorkflow<SupportInboxCapabilities>("support-inbox", agent =>
-        {
-            agent.WithRoutePrefixes("/support");
-        });
+        agentBuilder.AddWorkflow<HelloWorkflow>("hello-workflow");
     });
 });
+
+var app = builder.Build();
+
+app.UseHttpsRedirection();
+app.UseAntiforgery();
+app.MapStaticAssets();
+app.MapAgentBlazorEndpoints();
+app.MapRazorComponents<App>()
+    .AddInteractiveServerRenderMode();
+
+app.Run();
 ```
 
-Azure OpenAI API key configuration:
+## Components/_Imports.razor
 
-```csharp
-builder.Services.AddAgentBlazor(options =>
-{
-    options.UseAzureOpenAI(
-        endpoint: builder.Configuration["AzureOpenAI:Endpoint"]!,
-        deploymentName: builder.Configuration["AzureOpenAI:DeploymentName"]!,
-        apiKey: builder.Configuration["AzureOpenAI:ApiKey"]);
-});
+```razor
+@using AgentBlazor.Components
 ```
 
-Azure identity or managed identity configuration:
-
-```csharp
-using Azure.Identity;
-
-builder.Services.AddAgentBlazor(options =>
-{
-    options.UseAzureOpenAI(
-        endpoint: builder.Configuration["AzureOpenAI:Endpoint"]!,
-        deploymentName: builder.Configuration["AzureOpenAI:DeploymentName"]!,
-        credential: new DefaultAzureCredential());
-});
-```
-
-## 3. Add The Host Shell
-
-In `Components/App.razor`, include the MudBlazor and AgentBlazor assets:
+## Components/App.razor
 
 ```razor
 <link rel="stylesheet" href="@Assets["_content/MudBlazor/MudBlazor.min.css"]" />
 <link rel="stylesheet" href="@Assets[AgentBlazorAssetPaths.Css]" />
-...
 <script src="@Assets["_content/MudBlazor/MudBlazor.min.js"]"></script>
 <script src="@Assets[AgentBlazorAssetPaths.Js]"></script>
 ```
 
-In your main layout, add the MudBlazor providers:
+## Components/Layout/MainLayout.razor
 
 ```razor
-@using MudBlazor
+@inherits LayoutComponentBase
 
-<MudThemeProvider />
-<MudPopoverProvider />
-<MudDialogProvider />
-<MudSnackbarProvider />
+<AgentBlazorShell>
+    @Body
+</AgentBlazorShell>
 ```
 
-For a complete runnable shape, copy the host shell from:
-
-- [App.razor](/home/ashdev/workspace/AgentBlazor/samples/AgentBlazor.Starter/Components/App.razor)
-- [MainLayout.razor](/home/ashdev/workspace/AgentBlazor/samples/AgentBlazor.Starter/Components/Layout/MainLayout.razor)
-
-## 4. Map Endpoints
-
-After `builder.Build()`:
+## Workflows/HelloWorkflow.cs
 
 ```csharp
-app.MapRazorComponents<App>()
-    .AddInteractiveServerRenderMode();
-app.MapAgentBlazorEndpoints();
-```
+using AgentBlazor.App;
+using AgentBlazor.Attributes;
 
-Without `MapAgentBlazorEndpoints()`, the chat UI can render but the runtime endpoint will not be available.
-
-## 5. Create a Capability Class
-
-Use `[AgentCapability]` to mark a class as agent-accessible:
-
-```csharp
-[AgentCapability("support_inbox")]
-public sealed class SupportInboxCapabilities
+[AgentCapability("hello_workflow")]
+public sealed class HelloWorkflow
 {
-    [AgentAction("Show open tickets that still need a reply")]
-    public Task<CapabilityResult> ShowOpenTicketsAsync(
-        [AgentParam("Include tickets from the last N days", Required = false)] int days = 7)
-    {
-        return Task.FromResult(
-            CapabilityResult.Success($"Highlighted tickets from the last {days} days.")
-                .WithNextActions("Explain the queue", "Draft a reply"));
-    }
-
-    [AgentAction("Draft a reply for the highlighted tickets", RequiresApproval = true)]
-    public Task<CapabilityResult> DraftReplyAsync()
-    {
-        return Task.FromResult(
-            CapabilityResult.Success("Prepared the reply draft.")
-                .WithNextActions("Review the reply", "Approve the draft"));
-    }
+    [AgentAction("Say hello")]
+    public Task<CapabilityResult> SayHelloAsync()
+        => Task.FromResult(CapabilityResult.Success("Hello from AgentBlazor."));
 }
 ```
 
-## 6. Add a Chat Surface
+## API key
 
-In your layout or page:
+Use either appsettings:
 
-```razor
-@using AgentBlazor.Components
-
-<AgentChatWidget
-    Title="Support inbox"
-    Placeholder="Show open tickets, explain the queue, or draft a reply..."
-    Width="28rem"
-    Height="60vh" />
+```json
+{
+  "OpenAI": {
+    "ApiKey": "sk-...",
+    "Model": "gpt-4o-mini"
+  }
+}
 ```
 
-Use `AgentChatWidget` for a floating assistant.
-Use `AgentChatSurface` when chat should be embedded directly in the page:
-
-```razor
-@using AgentBlazor.Components
-
-<AgentChatSurface
-    Title="Support inbox"
-    Description="Review the current queue and prepare the next safe step."
-    LockAgentToCurrentRoute="true"
-    ShowAgentSelector="false"
-    EnableGeneratedUi="true" />
-```
-
-## Hosted WebAssembly Client Chat
-
-For hosted WebAssembly apps, keep the full AgentBlazor runtime on the server project and use the browser-safe client package in the `.Client` project.
-
-Server project:
-
-```csharp
-app.MapAgentBlazorEndpoints();
-app.MapAgentBlazorRemoteChat();
-```
-
-Client project:
+Or user secrets:
 
 ```bash
-dotnet add ./MyApp.Client/MyApp.Client.csproj package AgentBlazor.Client --version 0.1.0-preview.10
+dotnet user-secrets init
+dotnet user-secrets set "OpenAI:ApiKey" "sk-..."
 ```
 
-Client `_Imports.razor`:
-
-```razor
-@using AgentBlazor.Client.Chat
-```
-
-Client layout or page:
-
-```razor
-<AgentRemoteChatWidget Endpoint="/agentblazor/chat/run" Title="Assistant" />
-```
-
-The browser-safe client package also includes `AgentRemoteChatSurface`, `AgentRemoteChatPanel`, and `AgentRemoteChatBar`. These components call the server runtime over HTTP and do not require the server-first `AgentBlazor` component package or MudBlazor providers in the WebAssembly client.
-
-If your app already has fixed bottom-right controls, move the floating widget with host-owned overrides:
-
-```razor
-<AgentRemoteChatWidget Endpoint="/agentblazor/chat/run"
-                       Title="Assistant"
-                       Style="right: 2rem; bottom: 7rem;" />
-```
-
-The hosted WebAssembly path has been validated in a generated server+client Blazor Web App by installing packed local `AgentBlazor` and `AgentBlazor.Client` packages, mapping `MapAgentBlazorRemoteChat()`, registering client `HttpClient`, submitting prompts through remote widget/surface/panel/bar, and verifying widget minimize/reopen behavior.
-
-## 7. Run Your App
+## Run
 
 ```bash
 dotnet run
 ```
 
-Click the chat widget or embedded chat surface and try prompts that match production Blazor workflows:
+You should see the floating widget. Open it and ask: `Say hello`.
 
-- "Review this order queue, identify stuck orders, and recommend the safest next action."
-- "Find invoices due this week, group them by risk, and draft a collector handoff note."
-- "Check whether order ABC123 can be submitted, explain any missing approvals, and submit it only if policy allows."
-- "Summarize the current user-management page for an auditor and list accounts that need review."
-- "Find recently locked users, explain the likely causes, and draft a remediation checklist."
-- "Prepare a release-readiness checklist from the visible deployment status, failed checks, and pending approvals."
-- "Compare staging and production status, list blockers, and draft the release manager handoff."
-- "Draft a customer-support status update from the current incident screen and include open blockers."
-- "Turn the current incident timeline into a short executive update with customer impact and next owner."
-- "Review this inventory screen, identify low-stock exceptions, and create a purchasing follow-up note."
-- "Inspect this claims workflow, identify missing evidence, and propose the next compliant action."
+## Next
 
-The agent will call your capability methods and handle approvals automatically.
-
-## Attribute Reference
-
-### `[AgentCapability]`
-
-Marks a class as containing agent-callable actions.
-
-```csharp
-[AgentCapability("agent-name")]
-public class MyCapabilities { }
-```
-
-### `[AgentAction]`
-
-Marks a method as agent-callable.
-
-```csharp
-[AgentAction("Description shown to agent")]
-public Task<CapabilityResult> MyActionAsync() { }
-
-// With approval requirement
-[AgentAction("Dangerous action", RequiresApproval = true)]
-public Task<CapabilityResult> DangerousAsync() { }
-```
-
-### `[AgentParam]`
-
-Describes a parameter for the agent.
-
-```csharp
-public Task<CapabilityResult> SearchAsync(
-    [AgentParam("The search query")] string query,
-    [AgentParam("Max results to return")] int limit = 10)
-```
-
-### `[AgentReadable]`
-
-Exposes component state to the agent.
-
-```csharp
-[AgentReadable("Current user selection")]
-public string? SelectedItem { get; set; }
-```
-
-## Return Types
-
-### `CapabilityResult`
-
-All `[AgentAction]` methods should return `Task<CapabilityResult>`:
-
-```csharp
-// Success
-return CapabilityResult.Success("Operation completed.");
-
-// Success with warnings
-return CapabilityResult.Success("Completed.")
-    .WithWarning("One item was skipped.");
-
-// Success with suggested next actions
-return CapabilityResult.Success("Order created.")
-    .WithNextActions("View order", "Create another");
-
-// Failure
-return CapabilityResult.Failure("Could not complete operation.");
-
-// Blocked (needs user action first)
-return CapabilityResult.Blocked("Please select an item first.");
-```
-
-## Using Agentic Components
-
-AgentBlazor includes MudBlazor-backed components the agent can control:
-
-```razor
-<AgentDataGrid @ref="_grid" Items="@_items" T="Product">
-    <Columns>
-        <PropertyColumn Property="x => x.Name" />
-        <PropertyColumn Property="x => x.Price" />
-    </Columns>
-</AgentDataGrid>
-
-<AgentForm @ref="_form" Model="@_model">
-    <AgentTextField @bind-Value="_model.Name" Label="Name" />
-    <AgentButton ButtonType="ButtonType.Submit">Save</AgentButton>
-</AgentForm>
-```
-
-The agent can filter, sort, paginate the grid, and fill form fields automatically.
-
-## Available Components
-
-AgentBlazor includes 14 agentic components:
-
-| Component | Purpose |
-|-----------|---------|
-| `AgentDataGrid` | Filterable, sortable, paginated data grid |
-| `AgentForm` | Validated form with agent-fillable fields |
-| `AgentDialog` | Modal dialogs with approval boundaries |
-| `AgentTabs` | Tab navigation |
-| `AgentNavMenu` | Route navigation |
-| `AgentSelect` | Dropdown selection |
-| `AgentAutocomplete` | Search-as-you-type selection |
-| `AgentDatePicker` | Single date selection |
-| `AgentDateRangePicker` | Date range selection |
-| `AgentTreeView` | Hierarchical selection |
-| `AgentStepper` | Multi-step workflows |
-| `AgentCommandBar` | Action buttons |
-| `AgentFileUpload` | File attachment with policies |
-| `AgentChatWidget` | Floating chat interface |
-
-## Troubleshooting
-
-### Agent not responding
-
-1. Check your OpenAI API key is valid
-2. Confirm `OpenAI:Model` resolves to a tool-capable OpenAI chat model
-3. Ensure `AddAgentBlazor` is called before `builder.Build()`
-4. Ensure `AddMudServices()` is registered
-5. Ensure the MudBlazor providers are present in your layout
-6. Ensure the CSS and JS assets are added in `Components/App.razor`
-7. Ensure `app.MapAgentBlazorEndpoints()` is called after `builder.Build()`
-8. Verify the capability class is registered with `AddWorkflow<T>`
-
-### Actions not appearing
-
-1. Ensure methods are marked with `[AgentAction]`
-2. Check the class has `[AgentCapability("agent-name")]`
-3. Verify the route prefix matches the current page
-
-### `AgentBlazor.App`, `CapabilityResult`, or `AgentCapability` cannot be found
-
-This means the app is compiling against an AgentBlazor package that does not expose the semantic workflow APIs used by the scaffolded `Workflows/AppCapabilities.cs` file.
-
-1. Pin both `AgentBlazor` and `AgentBlazor.Cli` to the same preview version.
-2. Delete `bin`, `obj`, and the cached AgentBlazor package folder.
-3. Restore with `--force-evaluate`.
-4. Confirm `obj/project.assets.json` lists `AgentBlazor.Core.dll` under the `AgentBlazor` compile assets.
-
-PowerShell reset:
-
-```powershell
-Remove-Item -Recurse -Force "$env:USERPROFILE\.nuget\packages\agentblazor" -ErrorAction SilentlyContinue
-Remove-Item -Recurse -Force .\bin, .\obj -ErrorAction SilentlyContinue
-dotnet restore .\MyBlazorApp.csproj --force --force-evaluate
-dotnet build .\MyBlazorApp.csproj
-```
-
-### Component state not visible to agent
-
-1. Add `[AgentReadable]` to properties the agent should see
-2. Ensure the component has a `@ref` reference in the page
-
-## Next Steps
-
-- Run `samples/AgentBlazor.Starter` to see the smallest working route-scoped setup
-- Read [Advanced CLI](advanced/cli.md) if you want scaffold help for an existing app
-- Use OpenAI as the first production provider you validate in a real app
+- Starter sample: [samples/AgentBlazor.Starter](/home/ashdev/workspace/AgentBlazor/samples/AgentBlazor.Starter)
+- Hosted WebAssembly client: [src/AgentBlazor.Client/PACKAGE_README.md](/home/ashdev/workspace/AgentBlazor/src/AgentBlazor.Client/PACKAGE_README.md)

--- a/samples/AgentBlazor.Starter/README.md
+++ b/samples/AgentBlazor.Starter/README.md
@@ -1,21 +1,20 @@
 # AgentBlazor Starter
 
-Last updated: 2026-04-29
+This sample is a reference app, not the onboarding path.
 
-This is the current golden-path starter for AgentBlazor.
+Use the public quickstart first:
 
-It is intentionally small:
+- [docs/quickstart.md](/home/ashdev/workspace/AgentBlazor/docs/quickstart.md)
 
-- one route
+Then use this starter when you want to inspect a slightly fuller route-scoped workflow example with:
+
 - one workflow agent
 - one capability class
 - one service-backed state model
 - one approval boundary
 - one embedded chat surface
 
-## Run It
-
-From the repo root:
+Run it:
 
 ```powershell
 dotnet run --project samples/AgentBlazor.Starter/AgentBlazor.Starter.csproj
@@ -26,66 +25,9 @@ Open:
 - `/`
 - `/ops-review`
 
-## Canonical Quickstart
-
-For a package-first app, start here:
-
-```powershell
-dotnet new blazor
-dotnet add package AgentBlazor --version 0.1.0-preview.10
-```
-
-Then copy the shape from:
-
-- [Program.cs](Program.cs)
-- [OpsReviewCapabilities.cs](Workflows/OpsReviewCapabilities.cs)
-- [OpsReviewService.cs](Services/OpsReviewService.cs)
-- [OpsReview.razor](Components/Pages/OpsReview.razor)
-
-The local source-project mode exists only so this repo can build and validate the sample from source as well as from the published package feed.
-
-## Provider Setup
-
-The starter supports two provider paths:
-
-1. `OpenAI`
-2. `Ollama`
-
-The app prefers OpenAI when `OPENAI_API_KEY` is present.
-If that is not configured, it falls back to Ollama when `OLLAMA_MODEL` or `Ollama:Model` is configured.
-
-Useful environment variables:
-
-```powershell
-$env:OPENAI_API_KEY="sk-..."
-$env:OLLAMA_MODEL="llama3.2"
-$env:OLLAMA_ENDPOINT="http://127.0.0.1:11434/v1"
-```
-
-## What To Replace First
-
-When copying this into a real app, replace these in order:
-
-1. [OpsReviewCapabilities.cs](Workflows/OpsReviewCapabilities.cs)
-2. [OpsReviewService.cs](Services/OpsReviewService.cs)
-3. [OpsReview.razor](Components/Pages/OpsReview.razor)
-4. the route prefix and agent description in [Program.cs](Program.cs)
-
-## What It Proves
-
-This starter is meant to prove the base product:
-
-- route-scoped workflow registration with `AddWorkflow<T>()`
-- structured capability results
-- approval-gated workflow mutation
-- persisted conversation and shared state
-- in-app agent UX inside a live Blazor route
-
-## Maintainer Note
-
 Inside this repo, the starter defaults to local source-project references so the sample can build before packages are published.
 
-To validate the package-first path from inside the repo:
+To validate the published package path from inside the repo:
 
 ```powershell
 dotnet run --project samples/AgentBlazor.Starter/AgentBlazor.Starter.csproj -p:UseLocalAgentBlazorSource=false -p:AgentBlazorPackageVersion=0.1.0-preview.10

--- a/src/AgentBlazor.Components/AgentBlazorServiceExtensions.cs
+++ b/src/AgentBlazor.Components/AgentBlazorServiceExtensions.cs
@@ -103,7 +103,7 @@ public static class AgentBlazorServiceExtensions
         this IEndpointRouteBuilder endpoints,
         string pattern = "/agentblazor/agui/run")
     {
-        return AgentBlazor.Hosting.AgentBlazorAgUiEndpointRouteBuilderExtensions.MapAgentBlazorEndpoints(
+        return AgentBlazor.Hosting.AgentBlazorAgUiEndpointRouteBuilderExtensions.MapAgentBlazorAgUiRun(
             endpoints,
             pattern);
     }

--- a/src/AgentBlazor.Components/AgentBlazorShell.razor
+++ b/src/AgentBlazor.Components/AgentBlazorShell.razor
@@ -5,14 +5,11 @@
         <AgentDialogProvider>
             <AgentSnackbarProvider>
                 <section class="ab-shell">
-                    @if (ChildContent is null)
-                    {
-                        <AgentChatWidget />
-                    }
-                    else
+                    @if (ChildContent is not null)
                     {
                         @ChildContent
                     }
+                    <AgentChatWidget />
                 </section>
             </AgentSnackbarProvider>
         </AgentDialogProvider>

--- a/src/AgentBlazor.Components/Chat/AgentChatPanel.razor
+++ b/src/AgentBlazor.Components/Chat/AgentChatPanel.razor
@@ -1,7 +1,5 @@
 @namespace AgentBlazor.Components
 @using AgentBlazor.Components.Chat
-@using AgentBlazor.Agents
-@inject IAgentRegistry AgentRegistry
 
 <aside class="ab-chat-panel @(Theme?.CssClass) @(Theme?.GetFeatureClasses())"
        data-theme="@(Theme?.DataTheme)"
@@ -114,9 +112,7 @@
     private string EffectiveDescription =>
         !string.IsNullOrWhiteSpace(Description)
             ? Description
-            : AgentRegistry.GetAll().Count > 0
-                ? "Select a registered agent or lock this panel to the current route."
-                : "No agents registered. Call ConfigureBuilder(builder => builder.AddWorkflow<T>(\"agent-name\")) during AddAgentBlazor setup.";
+            : "Register an agent with ConfigureBuilder(builder => builder.AddWorkflow<T>(\"agent-name\")) before expecting the panel to respond.";
 
     private string _panelStyle
     {

--- a/src/AgentBlazor.Components/Chat/AgentChatPanel.razor
+++ b/src/AgentBlazor.Components/Chat/AgentChatPanel.razor
@@ -1,5 +1,7 @@
 @namespace AgentBlazor.Components
 @using AgentBlazor.Components.Chat
+@using AgentBlazor.Agents
+@inject IAgentRegistry AgentRegistry
 
 <aside class="ab-chat-panel @(Theme?.CssClass) @(Theme?.GetFeatureClasses())"
        data-theme="@(Theme?.DataTheme)"
@@ -9,7 +11,7 @@
        role="complementary"
        aria-label="@(Title ?? "Agent chat panel")">
     <AgentChatSurface Title="@Title"
-                      Description="@Description"
+                      Description="@EffectiveDescription"
                       FormName="@FormName"
                       DefaultAgentName="@DefaultAgentName"
                       ShowAgentSelector="@ShowAgentSelector"
@@ -44,8 +46,7 @@
     public string? Title { get; set; } = "Agent Assistant";
 
     [Parameter]
-    public string? Description { get; set; } =
-        "Built-in component-aware agent is active by default. You can also select custom registered agents.";
+    public string? Description { get; set; }
 
     [Parameter]
     public string Placeholder { get; set; } = "Type a message… (Enter to send, Shift+Enter for new line)";
@@ -109,6 +110,13 @@
 
     [Parameter]
     public bool EnableGeneratedUi { get; set; }
+
+    private string EffectiveDescription =>
+        !string.IsNullOrWhiteSpace(Description)
+            ? Description
+            : AgentRegistry.GetAll().Count > 0
+                ? "Select a registered agent or lock this panel to the current route."
+                : "No agents registered. Call ConfigureBuilder(builder => builder.AddWorkflow<T>(\"agent-name\")) during AddAgentBlazor setup.";
 
     private string _panelStyle
     {

--- a/src/AgentBlazor.Components/Chat/AgentChatSurface.razor
+++ b/src/AgentBlazor.Components/Chat/AgentChatSurface.razor
@@ -795,7 +795,13 @@
             return;
 
         if (_agentNames.Count == 0)
+        {
+            _timeline.Add(ChatTimelineItem.Activity(
+                "No agents are registered. Add a workflow with ConfigureBuilder(builder => builder.AddWorkflow<T>(\"agent-name\")) in your AddAgentBlazor setup."));
+            _scrollRequested = true;
+            StateHasChanged();
             return;
+        }
 
         if (TryHandleAgentListCommand(message))
         {

--- a/src/AgentBlazor.Components/Chat/AgentChatWidget.razor
+++ b/src/AgentBlazor.Components/Chat/AgentChatWidget.razor
@@ -1,12 +1,10 @@
 @namespace AgentBlazor.Components
 @using AgentBlazor.Components.Chat
-@using AgentBlazor.Agents
 @using AgentBlazor.Core.Runtime.Agents
 @using AgentBlazor.Runtime
 @using Microsoft.AspNetCore.Components.Web
 @implements IDisposable
 @inject IAgentChatWidgetState WidgetState
-@inject IAgentRegistry AgentRegistry
 
 <section class="ab-chat-widget @(WidgetState.IsOpen ? "ab-chat-widget--open" : null) @(Theme?.CssClass) @(Theme?.GetFeatureClasses())"
          data-theme="@(Theme?.DataTheme)"
@@ -178,9 +176,7 @@
     private string EffectiveDescription =>
         !string.IsNullOrWhiteSpace(Description)
             ? Description
-            : AgentRegistry.GetAll().Count > 0
-                ? "Select a registered agent or lock this widget to the current route."
-                : "No agents registered. Call ConfigureBuilder(builder => builder.AddWorkflow<T>(\"agent-name\")) during AddAgentBlazor setup.";
+            : "Register an agent with ConfigureBuilder(builder => builder.AddWorkflow<T>(\"agent-name\")) before expecting the widget to respond.";
 
     private string HostStyle
     {

--- a/src/AgentBlazor.Components/Chat/AgentChatWidget.razor
+++ b/src/AgentBlazor.Components/Chat/AgentChatWidget.razor
@@ -1,10 +1,12 @@
 @namespace AgentBlazor.Components
 @using AgentBlazor.Components.Chat
+@using AgentBlazor.Agents
 @using AgentBlazor.Core.Runtime.Agents
 @using AgentBlazor.Runtime
 @using Microsoft.AspNetCore.Components.Web
 @implements IDisposable
 @inject IAgentChatWidgetState WidgetState
+@inject IAgentRegistry AgentRegistry
 
 <section class="ab-chat-widget @(WidgetState.IsOpen ? "ab-chat-widget--open" : null) @(Theme?.CssClass) @(Theme?.GetFeatureClasses())"
          data-theme="@(Theme?.DataTheme)"
@@ -36,7 +38,7 @@
 
         <div class="ab-chat-widget__window-body">
             <AgentChatSurface Title="@Title"
-                             Description="@Description"
+                             Description="@EffectiveDescription"
                              FormName="@FormName"
                              DefaultAgentName="@DefaultAgentName"
                              ShowAgentSelector="@ShowAgentSelector"
@@ -80,8 +82,7 @@
     public string? Title { get; set; } = "AgentBlazor Chat Widget";
 
     [Parameter]
-    public string? Description { get; set; } =
-        "Built-in component-aware agent is active by default. You can also select custom registered agents.";
+    public string? Description { get; set; }
 
     [Parameter]
     public string BubbleLabel { get; set; } = "Ask Agent";
@@ -173,6 +174,13 @@
     private string HeaderLabelId => $"ab-chat-widget-header-{_instanceId}";
 
     private readonly string _instanceId = Guid.NewGuid().ToString("N");
+
+    private string EffectiveDescription =>
+        !string.IsNullOrWhiteSpace(Description)
+            ? Description
+            : AgentRegistry.GetAll().Count > 0
+                ? "Select a registered agent or lock this widget to the current route."
+                : "No agents registered. Call ConfigureBuilder(builder => builder.AddWorkflow<T>(\"agent-name\")) during AddAgentBlazor setup.";
 
     private string HostStyle
     {

--- a/src/AgentBlazor.Components/PACKAGE_README.md
+++ b/src/AgentBlazor.Components/PACKAGE_README.md
@@ -46,6 +46,8 @@ app.MapRazorComponents<App>()
 app.MapAgentBlazorEndpoints();
 ```
 
+`AddAgentBlazor(...)` alone does not create a responding agent. Register at least one workflow or agent inside `options.ConfigureBuilder(...)`.
+
 ```csharp
 [AgentCapability("support_inbox")]
 public sealed class SupportInboxCapabilities

--- a/src/AgentBlazor.Hosting/AgentBlazorAgUiEndpointRouteBuilderExtensions.cs
+++ b/src/AgentBlazor.Hosting/AgentBlazorAgUiEndpointRouteBuilderExtensions.cs
@@ -8,11 +8,6 @@ namespace AgentBlazor.Hosting;
 
 public static class AgentBlazorAgUiEndpointRouteBuilderExtensions
 {
-    public static IEndpointConventionBuilder MapAgentBlazorEndpoints(
-        this IEndpointRouteBuilder endpoints,
-        string pattern = "/agentblazor/agui/run")
-        => endpoints.MapAgentBlazorAgUiRun(pattern);
-
     public static IEndpointConventionBuilder MapAgentBlazorAgUiRun(
         this IEndpointRouteBuilder endpoints,
         string pattern = "/agentblazor/agui/run")

--- a/src/AgentBlazor.Hosting/AgentBlazorConfigurationException.cs
+++ b/src/AgentBlazor.Hosting/AgentBlazorConfigurationException.cs
@@ -1,0 +1,9 @@
+namespace AgentBlazor;
+
+public sealed class AgentBlazorConfigurationException : InvalidOperationException
+{
+    public AgentBlazorConfigurationException(string message)
+        : base(message)
+    {
+    }
+}

--- a/src/AgentBlazor.Hosting/AgentBlazorRegistrationOptions.cs
+++ b/src/AgentBlazor.Hosting/AgentBlazorRegistrationOptions.cs
@@ -29,14 +29,24 @@ public sealed class AgentBlazorRegistrationOptions
 
     public void UseOpenAI(string apiKey, string model = "gpt-4o-mini")
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(apiKey);
+        if (string.IsNullOrWhiteSpace(apiKey))
+        {
+            throw new AgentBlazorConfigurationException(
+                "OpenAI API key is not configured. Set 'OpenAI:ApiKey' in app configuration or provide 'OPENAI_API_KEY'/'OpenAI__ApiKey' before calling options.UseOpenAI(...).");
+        }
+
         ArgumentException.ThrowIfNullOrWhiteSpace(model);
         _providerRegistration = services => services.AddOpenAIProvider(model, apiKey);
     }
 
     public void UseOpenAI(string apiKey, string model, string endpoint)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(apiKey);
+        if (string.IsNullOrWhiteSpace(apiKey))
+        {
+            throw new AgentBlazorConfigurationException(
+                "OpenAI API key is not configured. Set 'OpenAI:ApiKey' in app configuration or provide 'OPENAI_API_KEY'/'OpenAI__ApiKey' before calling options.UseOpenAI(...).");
+        }
+
         ArgumentException.ThrowIfNullOrWhiteSpace(model);
         ArgumentException.ThrowIfNullOrWhiteSpace(endpoint);
         _providerRegistration = services => services.AddOpenAIProvider(model, apiKey, endpoint);

--- a/tests/AgentBlazor.IntegrationTests/ProviderAdapterIntegrationTests.cs
+++ b/tests/AgentBlazor.IntegrationTests/ProviderAdapterIntegrationTests.cs
@@ -74,6 +74,20 @@ public class ProviderAdapterIntegrationTests
     }
 
     [Fact]
+    public void AddAgentBlazor_WithUseOpenAIAndMissingApiKey_ThrowsConfigurationException()
+    {
+        var services = new ServiceCollection();
+
+        var exception = Assert.Throws<AgentBlazorConfigurationException>(() =>
+            AgentBlazorServiceExtensions.AddAgentBlazor(
+                services,
+                options => options.UseOpenAI("", DefaultOpenAiModel)));
+
+        Assert.Contains("OpenAI:ApiKey", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("OPENAI_API_KEY", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void OpenAiProvider_RegistersFrameworkChatClient()
     {
         var services = new ServiceCollection();


### PR DESCRIPTION
## Summary
- remove the duplicate public MapAgentBlazorEndpoints alias from the hosting namespace
- render AgentChatWidget alongside shell child content
- surface missing-agent guidance in chat UI and update misleading widget/panel descriptions
- throw a clearer configuration exception when UseOpenAI is called without an API key
- add a regression test for the new OpenAI configuration error

## Validation
- dotnet build demo/AgentBlazor.Demo/AgentBlazor.Demo.csproj -c Release --no-restore -nologo -p:RuntimeIdentifier=linux-x64
- dotnet test tests/AgentBlazor.IntegrationTests/AgentBlazor.IntegrationTests.csproj -c Release --no-restore --filter "ProviderAdapterIntegrationTests" -nologo -p:RuntimeIdentifier=linux-x64