### PR TITLE
Prepare 0.1.0-preview.11 release

### DIFF
--- a/.github/ISSUE_TEMPLATE/install-friction.yml
+++ b/.github/ISSUE_TEMPLATE/install-friction.yml
@@ -8,7 +8,7 @@ body:
     id: command
     attributes:
       label: Command that failed
-      placeholder: dotnet add package AgentBlazor --version 0.1.0-preview.10
+      placeholder: dotnet add package AgentBlazor --version 0.1.0-preview.11
     validations:
       required: true
   - type: input

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Local Package Smoke Test
         shell: pwsh
         run: |
-          ./scripts/smoke-test-local-package.ps1 -PackageVersion 0.1.0-preview.10
+          ./scripts/smoke-test-local-package.ps1 -PackageVersion 0.1.0-preview.11
 
       - name: Restore Demo For E2E
         run: >

--- a/.github/workflows/publish-nuget-org.yml
+++ b/.github/workflows/publish-nuget-org.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       package_version:
-        description: "Package version to publish (example: 0.1.0-preview.10 or 0.1.0)"
+        description: "Package version to publish (example: 0.1.0-preview.11 or 0.1.0)"
         required: true
         type: string
 
@@ -36,7 +36,7 @@ jobs:
         run: |
           $version = "${{ inputs.package_version }}"
           if ($version -notmatch '^\d+\.\d+\.\d+([-.].+)?$') {
-            throw "package_version must be a valid SemVer string such as 0.1.0-preview.10 or 0.1.0"
+            throw "package_version must be a valid SemVer string such as 0.1.0-preview.11 or 0.1.0"
           }
 
       - name: Validate Central Package Pinning

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
 
   <!-- Common package metadata for all AgentBlazor packages -->
   <PropertyGroup>
-    <Version>0.1.0-preview.10</Version>
+    <Version>0.1.0-preview.11</Version>
     <Authors>Ash Peterson</Authors>
     <Company>AgentBlazor</Company>
     <Copyright>Copyright (c) 2026 Ash Peterson</Copyright>
@@ -16,7 +16,7 @@
     <RepositoryType>git</RepositoryType>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <PackageIcon>icon.png</PackageIcon>
-    <PackageReleaseNotes>Private preview cut focused on one public install path, one support-inbox demo, and route-scoped workflow setup.</PackageReleaseNotes>
+    <PackageReleaseNotes>Install-path fixes: explicit workflow quickstart, clearer OpenAI configuration errors, and chat shell/widget setup corrections.</PackageReleaseNotes>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <Deterministic>true</Deterministic>

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ AgentBlazor gives a Blazor route a chat surface, explicit capabilities, approval
 ## Install
 
 ```bash
-dotnet add package AgentBlazor --version 0.1.0-preview.10
+dotnet add package AgentBlazor --version 0.1.0-preview.11
 ```
 
 The CLI is optional. Keep it out of the critical path unless you want scaffold help for an existing app.

--- a/demo/AgentBlazor.Demo/Components/Pages/Docs/CliGuide.razor
+++ b/demo/AgentBlazor.Demo/Components/Pages/Docs/CliGuide.razor
@@ -20,8 +20,8 @@
             </div>
         </div>
 
-        <pre class="docs-code"><code>dotnet tool install --global AgentBlazor.Cli --version 0.1.0-preview.10
-dotnet tool update --global AgentBlazor.Cli --version 0.1.0-preview.10</code></pre>
+        <pre class="docs-code"><code>dotnet tool install --global AgentBlazor.Cli --version 0.1.0-preview.11
+dotnet tool update --global AgentBlazor.Cli --version 0.1.0-preview.11</code></pre>
     </section>
 
     <section class="docs-section">

--- a/demo/AgentBlazor.Demo/Components/Pages/Docs/DocsHome.razor
+++ b/demo/AgentBlazor.Demo/Components/Pages/Docs/DocsHome.razor
@@ -40,7 +40,7 @@
             </div>
         </div>
 
-        <pre class="docs-code"><code>dotnet add package AgentBlazor --version 0.1.0-preview.10
+        <pre class="docs-code"><code>dotnet add package AgentBlazor --version 0.1.0-preview.11
 builder.Services.AddAgentBlazor(...)
 app.MapAgentBlazorEndpoints()
 Render one chat surface on one route

--- a/demo/AgentBlazor.Demo/Components/Pages/Docs/GettingStarted.razor
+++ b/demo/AgentBlazor.Demo/Components/Pages/Docs/GettingStarted.razor
@@ -20,7 +20,7 @@
             </div>
         </div>
 
-        <pre class="docs-code"><code>dotnet add ./src/MyBlazorApp/MyBlazorApp.csproj package AgentBlazor --version 0.1.0-preview.10</code></pre>
+        <pre class="docs-code"><code>dotnet add ./src/MyBlazorApp/MyBlazorApp.csproj package AgentBlazor --version 0.1.0-preview.11</code></pre>
     </section>
 
     <section class="docs-section">
@@ -30,7 +30,7 @@
             </div>
         </div>
 
-        <pre class="docs-code"><code>dotnet add ./src/MyBlazorApp/MyBlazorApp.csproj package AgentBlazor --version 0.1.0-preview.10
+        <pre class="docs-code"><code>dotnet add ./src/MyBlazorApp/MyBlazorApp.csproj package AgentBlazor --version 0.1.0-preview.11
 
 builder.Services.AddMudServices();
 builder.Services.AddAgentBlazor(options =&gt; { ... });
@@ -43,7 +43,7 @@ options.ConfigureBuilder(agentBuilder =&gt;
 });
 
 @@using AgentBlazor.Components
-&lt;AgentBlazorShell /&gt;</code></pre>
+&lt;AgentChatWidget @@rendermode="InteractiveServer" Title="Hello workflow" /&gt;</code></pre>
     </section>
 
     <section class="docs-section">
@@ -81,7 +81,7 @@ app.MapAgentBlazorEndpoints();</code></pre>
             </div>
         </div>
 
-        <pre class="docs-code"><code>dotnet tool install --global AgentBlazor.Cli --version 0.1.0-preview.10
+        <pre class="docs-code"><code>dotnet tool install --global AgentBlazor.Cli --version 0.1.0-preview.11
 agentblazor init ./MySolution.slnx --host MyBlazorApp
 agentblazor scaffold ./MySolution.slnx --host MyBlazorApp --provider openai --diff
 agentblazor scaffold ./MySolution.slnx --host MyBlazorApp --provider openai --approve
@@ -96,7 +96,7 @@ dotnet build ./MySolution.slnx --no-restore -nologo</code></pre>
             </div>
         </div>
 
-        <pre class="docs-code"><code>dotnet add ./src/MyBlazorApp.Client/MyBlazorApp.Client.csproj package AgentBlazor.Client --version 0.1.0-preview.10
+        <pre class="docs-code"><code>dotnet add ./src/MyBlazorApp.Client/MyBlazorApp.Client.csproj package AgentBlazor.Client --version 0.1.0-preview.11
 
 // Server
 app.MapAgentBlazorEndpoints();

--- a/demo/AgentBlazor.Demo/Components/Pages/Docs/Verification.razor
+++ b/demo/AgentBlazor.Demo/Components/Pages/Docs/Verification.razor
@@ -20,7 +20,7 @@
             </div>
         </div>
 
-        <pre class="docs-code"><code>dotnet add ./src/MyBlazorApp/MyBlazorApp.csproj package AgentBlazor --version 0.1.0-preview.10
+        <pre class="docs-code"><code>dotnet add ./src/MyBlazorApp/MyBlazorApp.csproj package AgentBlazor --version 0.1.0-preview.11
 dotnet build ./MySolution.slnx --nologo
 OpenAI__ApiKey=placeholder-key dotnet run --project ./src/MyBlazorApp/MyBlazorApp.csproj --no-launch-profile --urls http://127.0.0.1:5288
 Open the support route and submit one real prompt</code></pre>
@@ -35,7 +35,7 @@ Open the support route and submit one real prompt</code></pre>
 
         <pre class="docs-code"><code>dotnet new blazor -o FreshAgentBlazor
 cd FreshAgentBlazor
-dotnet add package AgentBlazor --version 0.1.0-preview.10
+dotnet add package AgentBlazor --version 0.1.0-preview.11
 dotnet build FreshAgentBlazor.csproj --nologo</code></pre>
     </section>
 
@@ -46,8 +46,8 @@ dotnet build FreshAgentBlazor.csproj --nologo</code></pre>
             </div>
         </div>
 
-        <pre class="docs-code"><code>dotnet add ./src/MyHostedServer/MyHostedServer.csproj package AgentBlazor --version 0.1.0-preview.10
-dotnet add ./src/MyHostedClient/MyHostedClient.csproj package AgentBlazor.Client --version 0.1.0-preview.10
+        <pre class="docs-code"><code>dotnet add ./src/MyHostedServer/MyHostedServer.csproj package AgentBlazor --version 0.1.0-preview.11
+dotnet add ./src/MyHostedClient/MyHostedClient.csproj package AgentBlazor.Client --version 0.1.0-preview.11
 
 // Server
 app.MapAgentBlazorEndpoints();

--- a/docs/advanced/cli.md
+++ b/docs/advanced/cli.md
@@ -11,7 +11,7 @@ Use it when:
 Current run order:
 
 ```bash
-dotnet tool install --global AgentBlazor.Cli --version 0.1.0-preview.10
+dotnet tool install --global AgentBlazor.Cli --version 0.1.0-preview.11
 agentblazor init ./MySolution.slnx --host MyBlazorApp
 agentblazor scaffold ./MySolution.slnx --host MyBlazorApp --provider openai --diff
 agentblazor scaffold ./MySolution.slnx --host MyBlazorApp --provider openai --approve

--- a/docs/beta-testing.md
+++ b/docs/beta-testing.md
@@ -18,7 +18,7 @@ Use a fresh app first. Do not start with an existing codebase.
 ```bash
 dotnet new blazor -o FreshAgentBlazor
 cd FreshAgentBlazor
-dotnet add package AgentBlazor --version 0.1.0-preview.10
+dotnet add package AgentBlazor --version 0.1.0-preview.11
 ```
 
 Then follow:
@@ -35,7 +35,7 @@ Use the support-inbox shape only:
 
 Please report pass or fail for each of these:
 
-1. `dotnet add package AgentBlazor --version 0.1.0-preview.10`
+1. `dotnet add package AgentBlazor --version 0.1.0-preview.11`
 2. `dotnet build`
 3. app starts with AgentBlazor assets loaded
 4. chat surface opens

--- a/docs/internal/beta-tester-runbook.md
+++ b/docs/internal/beta-tester-runbook.md
@@ -80,7 +80,7 @@ For each tester capture:
 If a tester asks what to do, answer with this exact path:
 
 1. create a fresh Blazor app
-2. run `dotnet add package AgentBlazor --version 0.1.0-preview.10`
+2. run `dotnet add package AgentBlazor --version 0.1.0-preview.11`
 3. follow `docs/quickstart.md`
 4. test the support-inbox shape only
 5. submit feedback through one of the issue forms

--- a/docs/internal/launch-content/blog-post.md
+++ b/docs/internal/launch-content/blog-post.md
@@ -37,7 +37,7 @@ What it does not try to do at launch:
 The first install path is now the normal one:
 
 ```bash
-dotnet add package AgentBlazor --version 0.1.0-preview.10
+dotnet add package AgentBlazor --version 0.1.0-preview.11
 ```
 
 Then wire `AddAgentBlazor(...)`, map `MapAgentBlazorEndpoints()`, add one capability class, and mount one chat surface.

--- a/docs/internal/launch-content/reddit-r-dotnet.md
+++ b/docs/internal/launch-content/reddit-r-dotnet.md
@@ -19,7 +19,7 @@ What it is:
 Current public package:
 
 ```bash
-dotnet add package AgentBlazor --version 0.1.0-preview.10
+dotnet add package AgentBlazor --version 0.1.0-preview.11
 ```
 
 Current public demo:

--- a/docs/internal/launch-content/social-thread.md
+++ b/docs/internal/launch-content/social-thread.md
@@ -38,7 +38,7 @@ Post 4:
 Install path:
 
 ```bash
-dotnet add package AgentBlazor --version 0.1.0-preview.10
+dotnet add package AgentBlazor --version 0.1.0-preview.11
 ```
 
 CLI exists, but it is the advanced path, not the headline.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -40,9 +40,9 @@ var app = builder.Build();
 app.UseHttpsRedirection();
 app.UseAntiforgery();
 app.MapStaticAssets();
-app.MapAgentBlazorEndpoints();
 app.MapRazorComponents<App>()
     .AddInteractiveServerRenderMode();
+app.MapAgentBlazorEndpoints();
 
 app.Run();
 ```
@@ -58,18 +58,36 @@ app.Run();
 ```razor
 <link rel="stylesheet" href="@Assets["_content/MudBlazor/MudBlazor.min.css"]" />
 <link rel="stylesheet" href="@Assets[AgentBlazorAssetPaths.Css]" />
-<script src="@Assets["_content/MudBlazor/MudBlazor.min.js"]"></script>
-<script src="@Assets[AgentBlazorAssetPaths.Js]"></script>
+...
+<HeadOutlet @rendermode="InteractiveServer" />
+</head>
+
+<body>
+    <Routes @rendermode="InteractiveServer" />
+    <script src="@Assets["_framework/blazor.web.js"]"></script>
+    <script src="@Assets["_content/MudBlazor/MudBlazor.min.js"]"></script>
+    <script src="@Assets[AgentBlazorAssetPaths.Js]"></script>
+</body>
 ```
 
 ## Components/Layout/MainLayout.razor
 
 ```razor
 @inherits LayoutComponentBase
+@using MudBlazor
 
-<AgentBlazorShell>
+<MudThemeProvider />
+<MudPopoverProvider />
+<MudDialogProvider />
+<MudSnackbarProvider />
+
+<div class="page">
     @Body
-</AgentBlazorShell>
+</div>
+
+<AgentChatWidget
+    Title="Hello workflow"
+    Placeholder="Ask the agent to say hello..." />
 ```
 
 ## Workflows/HelloWorkflow.cs
@@ -77,6 +95,8 @@ app.Run();
 ```csharp
 using AgentBlazor.App;
 using AgentBlazor.Attributes;
+
+namespace MyApp.Workflows;
 
 [AgentCapability("hello_workflow")]
 public sealed class HelloWorkflow
@@ -113,7 +133,13 @@ dotnet user-secrets set "OpenAI:ApiKey" "sk-..."
 dotnet run
 ```
 
-You should see the floating widget. Open it and ask: `Say hello`.
+You should see the floating widget in the bottom-right corner. Open it and ask: `Say hello`.
+
+## Notes
+
+- `MapAgentBlazorEndpoints()` is required or the chat UI will render without a working runtime endpoint.
+- The current public package requires an explicit workflow or agent registration before the chat can respond.
+- `AgentBlazorShell` is not the public quickstart path until the next preview release lands its child-content/widget fix.
 
 ## Next
 

--- a/samples/AgentBlazor.Starter/README.md
+++ b/samples/AgentBlazor.Starter/README.md
@@ -30,5 +30,5 @@ Inside this repo, the starter defaults to local source-project references so the
 To validate the published package path from inside the repo:
 
 ```powershell
-dotnet run --project samples/AgentBlazor.Starter/AgentBlazor.Starter.csproj -p:UseLocalAgentBlazorSource=false -p:AgentBlazorPackageVersion=0.1.0-preview.10
+dotnet run --project samples/AgentBlazor.Starter/AgentBlazor.Starter.csproj -p:UseLocalAgentBlazorSource=false -p:AgentBlazorPackageVersion=0.1.0-preview.11
 ```

--- a/scripts/video/compose-product-videos.cjs
+++ b/scripts/video/compose-product-videos.cjs
@@ -114,7 +114,7 @@ function renderTitleCard(outputPath, config) {
     `drawtext=fontfile=${fontBold}:text='${safeTitle}':x=896:y=208:fontsize=${titleSize}:line_spacing=8:fontcolor=white`,
     `drawtext=fontfile=${fontRegular}:text='${safeBody}':x=896:y=336:fontsize=${bodySize}:fontcolor=white@0.80`,
     `drawtext=fontfile=${fontBold}:text='dotnet new blazor -n FreshAgentBlazor':x=112:y=164:fontsize=22:fontcolor=white@0.82`,
-    `drawtext=fontfile=${fontRegular}:text='dotnet add package AgentBlazor --version 0.1.0-preview.10':x=112:y=208:fontsize=18:fontcolor=white@0.58`,
+    `drawtext=fontfile=${fontRegular}:text='dotnet add package AgentBlazor --version 0.1.0-preview.11':x=112:y=208:fontsize=18:fontcolor=white@0.58`,
     `drawtext=fontfile=${fontRegular}:text='Install. Mount one workflow. Watch the UI move.' :x=112:y=578:fontsize=22:fontcolor=white@0.72`,
     `fade=t=in:st=0:d=0.2,fade=t=out:st=${Math.max(0.1, config.duration - 0.25).toFixed(2)}:d=0.2`
   ].join(",");

--- a/scripts/video/record-cli-install-demo.sh
+++ b/scripts/video/record-cli-install-demo.sh
@@ -51,11 +51,11 @@ run_step "dotnet new blazor -n FreshAgentBlazor" \
 
 cd FreshAgentBlazor
 
-run_step "dotnet add package AgentBlazor --version 0.1.0-preview.10" \
-    dotnet add package AgentBlazor --version 0.1.0-preview.10
+run_step "dotnet add package AgentBlazor --version 0.1.0-preview.11" \
+    dotnet add package AgentBlazor --version 0.1.0-preview.11
 
-run_step "dotnet tool install AgentBlazor.Cli --tool-path ./.tools --version 0.1.0-preview.10" \
-    dotnet tool install AgentBlazor.Cli --tool-path ./.tools --version 0.1.0-preview.10
+run_step "dotnet tool install AgentBlazor.Cli --tool-path ./.tools --version 0.1.0-preview.11" \
+    dotnet tool install AgentBlazor.Cli --tool-path ./.tools --version 0.1.0-preview.11
 
 run_step "./.tools/agentblazor init ./FreshAgentBlazor.csproj --host FreshAgentBlazor" \
     ./.tools/agentblazor init ./FreshAgentBlazor.csproj --host FreshAgentBlazor

--- a/src/AgentBlazor.Cli.Analysis/ExistingAppScaffoldApplier.cs
+++ b/src/AgentBlazor.Cli.Analysis/ExistingAppScaffoldApplier.cs
@@ -301,7 +301,7 @@ public sealed class ExistingAppScaffoldApplier
             .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
             ?.InformationalVersion
             ?? typeof(ExistingAppScaffoldApplier).Assembly.GetName().Version?.ToString()
-            ?? "0.1.0-preview.10";
+            ?? "0.1.0-preview.11";
 
         return version.Split('+', 2)[0];
     }

--- a/src/AgentBlazor.Cli/PACKAGE_README.md
+++ b/src/AgentBlazor.Cli/PACKAGE_README.md
@@ -11,7 +11,7 @@ dotnet tool install --global AgentBlazor.Cli --prerelease
 If you want the exact current preview:
 
 ```bash
-dotnet tool install --global AgentBlazor.Cli --version 0.1.0-preview.10
+dotnet tool install --global AgentBlazor.Cli --version 0.1.0-preview.11
 ```
 
 Example:

--- a/src/AgentBlazor.Cli/Program.cs
+++ b/src/AgentBlazor.Cli/Program.cs
@@ -7,7 +7,7 @@ var version = typeof(ScaffoldCommand).Assembly
     .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
     ?.InformationalVersion
     ?? typeof(ScaffoldCommand).Assembly.GetName().Version?.ToString()
-    ?? "0.1.0-preview.10";
+    ?? "0.1.0-preview.11";
 version = version.Split('+', 2)[0];
 
 app.Configure(config =>

--- a/src/AgentBlazor.Client/PACKAGE_README.md
+++ b/src/AgentBlazor.Client/PACKAGE_README.md
@@ -11,7 +11,7 @@ dotnet add package AgentBlazor.Client --prerelease
 If you want the exact current preview:
 
 ```bash
-dotnet add package AgentBlazor.Client --version 0.1.0-preview.10
+dotnet add package AgentBlazor.Client --version 0.1.0-preview.11
 ```
 
 Server project:

--- a/src/AgentBlazor.Components/PACKAGE_README.md
+++ b/src/AgentBlazor.Components/PACKAGE_README.md
@@ -11,7 +11,7 @@ dotnet add package AgentBlazor --prerelease
 Current public releases are prerelease builds. If you prefer a pinned install, use:
 
 ```bash
-dotnet add package AgentBlazor --version 0.1.0-preview.10
+dotnet add package AgentBlazor --version 0.1.0-preview.11
 ```
 
 If `dotnet` still probes an old custom package source on your machine, remove or disable that source before testing the public NuGet install path.
@@ -47,6 +47,8 @@ app.MapAgentBlazorEndpoints();
 ```
 
 `AddAgentBlazor(...)` alone does not create a responding agent. Register at least one workflow or agent inside `options.ConfigureBuilder(...)`.
+
+For the current public preview, mount `AgentChatWidget` directly in an interactive layout or page. The `AgentBlazorShell` child-content/widget fix lands in the next preview.
 
 ```csharp
 [AgentCapability("support_inbox")]

--- a/tests/AgentBlazor.Cli.Analysis.Tests/ExistingAppScaffoldPlannerTests.cs
+++ b/tests/AgentBlazor.Cli.Analysis.Tests/ExistingAppScaffoldPlannerTests.cs
@@ -151,7 +151,7 @@ public sealed class ExistingAppScaffoldPlannerTests : IDisposable
                     <ImplicitUsings>enable</ImplicitUsings>
                   </PropertyGroup>
                   <ItemGroup>
-                    <PackageReference Include="AgentBlazor" Version="0.1.0-preview.10" />
+                    <PackageReference Include="AgentBlazor" Version="0.1.0-preview.11" />
                   </ItemGroup>
                 </Project>
                 """,
@@ -186,7 +186,7 @@ public sealed class ExistingAppScaffoldPlannerTests : IDisposable
         var report = await new InstallReadinessAnalyzer().AnalyzeAsync(projectPath, hostProjectName: null);
 
         Assert.Contains(plan.Items, item => item.Id == "package-references" && item.Action == ScaffoldPlanAction.Update);
-        Assert.Contains("""<PackageReference Include="AgentBlazor" Version="0.1.0-preview.10" />""", projectText, StringComparison.Ordinal);
+        Assert.Contains("""<PackageReference Include="AgentBlazor" Version="0.1.0-preview.11" />""", projectText, StringComparison.Ordinal);
         Assert.Contains("""<PackageReference Include="MudBlazor" Version="9.0.0" />""", projectText, StringComparison.Ordinal);
         Assert.Contains(report.Checks, check => check.Id == "package-references" && check.Status == InstallReadinessStatus.Pass);
     }
@@ -250,7 +250,7 @@ public sealed class ExistingAppScaffoldPlannerTests : IDisposable
         Assert.Contains("""<PackageReference Include="MudBlazor" />""", projectText, StringComparison.Ordinal);
         Assert.DoesNotContain("PackageReference Include=\"AgentBlazor\" Version=", projectText, StringComparison.Ordinal);
         Assert.DoesNotContain("PackageReference Include=\"MudBlazor\" Version=", projectText, StringComparison.Ordinal);
-        Assert.Contains("""<PackageVersion Include="AgentBlazor" Version="0.1.0-preview.10" />""", centralPackagesText, StringComparison.Ordinal);
+        Assert.Contains("""<PackageVersion Include="AgentBlazor" Version="0.1.0-preview.11" />""", centralPackagesText, StringComparison.Ordinal);
         Assert.Contains("""<PackageVersion Include="MudBlazor" Version="9.0.0" />""", centralPackagesText, StringComparison.Ordinal);
     }
 

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -39,7 +39,7 @@ The external chat surface runner now verifies scaffold idempotency, submitted pr
 
 For external apps that require authentication before the main layout is reachable, set `AGENTBLAZOR_EXTERNAL_LOGIN_PATH`, `AGENTBLAZOR_EXTERNAL_LOGIN_USERNAME`, and `AGENTBLAZOR_EXTERNAL_LOGIN_PASSWORD`. The runner signs in before opening the installed floating widget and before visiting the injected surface harness. Set `AGENTBLAZOR_EXTERNAL_EXPECTED_TEXT` to require a protected-page marker before chat assertions begin; the matrix uses this for the CleanArchitecture `/identity/users` authenticated route.
 
-Current release context: `0.1.0-preview.10` is the current public prerelease. Local e2e runs still require a configured OpenAI, Azure OpenAI, or Ollama provider.
+Current release context: `0.1.0-preview.11` is the current public prerelease. Local e2e runs still require a configured OpenAI, Azure OpenAI, or Ollama provider.
 
 The real-usability runner requires an explicit live provider from environment variables. It intentionally does not treat demo `appsettings.json` sample values as proof that CI can reach a provider, because empty GitHub secrets or missing Ollama services otherwise produce misleading no-provider transcripts instead of a clear preflight failure.
 


### PR DESCRIPTION
## Summary
- bump repo/package/docs/scripts to 0.1.0-preview.11
- bring the quickstart and package docs in line with the current public package behavior
- keep explicit workflow registration in the public install path
- update release metadata and validation docs for the next preview

## Validation
- dotnet test tests/AgentBlazor.Components.Tests/AgentBlazor.Components.Tests.csproj -c Release --no-restore --filter "AgentChatWidgetTests" -nologo -p:RuntimeIdentifier=linux-x64
- dotnet test tests/AgentBlazor.IntegrationTests/AgentBlazor.IntegrationTests.csproj -c Release --no-restore --filter "ProviderAdapterIntegrationTests" -nologo -p:RuntimeIdentifier=linux-x64
- dotnet test tests/AgentBlazor.Cli.Analysis.Tests/AgentBlazor.Cli.Analysis.Tests.csproj -c Release --no-restore -nologo
- dotnet build demo/AgentBlazor.Demo/AgentBlazor.Demo.csproj -c Release --no-restore -nologo -p:RuntimeIdentifier=linux-x64