### PR TITLE
Allow support inbox drafts by ticket id

### DIFF
--- a/demo/AgentBlazor.Demo/Services/SupportInboxWorkflowService.cs
+++ b/demo/AgentBlazor.Demo/Services/SupportInboxWorkflowService.cs
@@ -45,9 +45,16 @@ internal sealed class SupportInboxCapabilities(SupportInboxWorkflowService workf
         });
     }
 
-    [AgentAction("Draft a reply for the highlighted tickets", ActionId = "draft_ticket_reply", RequiresApproval = true)]
-    public Task<CapabilityResult> DraftReplyAsync()
+    [AgentAction("Draft a reply for a ticket or the highlighted tickets", ActionId = "draft_ticket_reply", RequiresApproval = true)]
+    public Task<CapabilityResult> DraftReplyAsync(
+        [AgentParam("Optional ticket id to draft a reply for, for example TCK-1042", Required = false)] string? ticketId = null)
     {
+        if (!string.IsNullOrWhiteSpace(ticketId) && !workflow.FocusTicket(ticketId))
+        {
+            return Task.FromResult(CapabilityResult.NeedsClarification(
+                $"I could not find ticket {ticketId}. Ask me to show open tickets first or choose a visible ticket id."));
+        }
+
         if (!workflow.HighlightedTicketIds.Any())
         {
             return Task.FromResult(CapabilityResult.NeedsClarification(
@@ -161,6 +168,27 @@ internal sealed class SupportInboxWorkflowService
         return _highlightedTicketIds.Count == 0
             ? $"No tickets in the last {CurrentReviewWindowDays} days still need a reply."
             : $"Highlighted {_highlightedTicketIds.Count} tickets from the last {CurrentReviewWindowDays} days that still need a reply.";
+    }
+
+    public bool FocusTicket(string ticketId)
+    {
+        var ticket = _tickets.FirstOrDefault(ticket => string.Equals(ticket.Id, ticketId, StringComparison.OrdinalIgnoreCase));
+        if (ticket is null)
+        {
+            LatestInsight = $"Ticket {ticketId} was not found in the support queue.";
+            NotifyChanged();
+            return false;
+        }
+
+        ShowOnlyHighlighted = true;
+        _highlightedTicketIds.Clear();
+        _highlightedTicketIds.Add(ticket.Id);
+        _latestDraftBlockers.Clear();
+        CurrentDraft = null;
+        IsDraftDialogOpen = false;
+        LatestInsight = BuildInsightSummary(_highlightedTicketIds);
+        NotifyChanged();
+        return true;
     }
 
     public string ExplainFocusedTickets()

--- a/tests/AgentBlazor.IntegrationTests/SupportInboxWorkflowIntegrationTests.cs
+++ b/tests/AgentBlazor.IntegrationTests/SupportInboxWorkflowIntegrationTests.cs
@@ -36,4 +36,35 @@ public class SupportInboxWorkflowIntegrationTests
         Assert.Empty(workflow.LatestDraftBlockers);
         Assert.Contains("TCK-1055", workflow.EscalatedTicketIds, StringComparer.OrdinalIgnoreCase);
     }
+
+    [Fact]
+    public async Task DraftReplyAsync_TargetsRequestedTicketWithoutPriorHighlight()
+    {
+        var workflow = new SupportInboxWorkflowService();
+        var capabilities = new SupportInboxCapabilities(workflow);
+
+        var result = await capabilities.DraftReplyAsync("TCK-1042");
+
+        Assert.True(result.Succeeded);
+        Assert.Contains("Prepared a reply draft", result.Summary, StringComparison.OrdinalIgnoreCase);
+        Assert.NotNull(workflow.CurrentDraft);
+        Assert.True(workflow.IsDraftDialogOpen);
+        Assert.Contains("TCK-1042", workflow.HighlightedTicketIds, StringComparer.OrdinalIgnoreCase);
+        Assert.Contains("TCK-1042", workflow.CurrentDraft.TicketIds, StringComparer.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task DraftReplyAsync_ReturnsClarificationForUnknownTicket()
+    {
+        var workflow = new SupportInboxWorkflowService();
+        var capabilities = new SupportInboxCapabilities(workflow);
+
+        var result = await capabilities.DraftReplyAsync("TCK-9999");
+
+        Assert.False(result.Succeeded);
+        Assert.True(result.RequiresClarification);
+        Assert.Contains("could not find ticket TCK-9999", result.ClarificationQuestion, StringComparison.OrdinalIgnoreCase);
+        Assert.Null(workflow.CurrentDraft);
+        Assert.Empty(workflow.HighlightedTicketIds);
+    }
 }


### PR DESCRIPTION
## Summary
- let the support inbox draft action accept an optional ticket id
- focus the requested ticket before drafting so prompts like `Draft a reply for ticket TCK-1042` work without a prior highlight step
- add regression coverage for known and unknown ticket ids

## Validation
- `dotnet test tests/AgentBlazor.IntegrationTests/AgentBlazor.IntegrationTests.csproj -c Release --no-restore --filter SupportInboxWorkflowIntegrationTests -nologo -p:RuntimeIdentifier=linux-x64`
- `dotnet build demo/AgentBlazor.Demo/AgentBlazor.Demo.csproj -c Release --no-restore -nologo -p:RuntimeIdentifier=linux-x64`
