### PR TITLE
Preserve approval arguments across continuation

### DIFF
--- a/demo/AgentBlazor.Demo/Services/SupportInboxWorkflowService.cs
+++ b/demo/AgentBlazor.Demo/Services/SupportInboxWorkflowService.cs
@@ -45,28 +45,39 @@ internal sealed class SupportInboxCapabilities(SupportInboxWorkflowService workf
         });
     }
 
-    [AgentAction("Draft a reply for a ticket or the highlighted tickets", ActionId = "draft_ticket_reply", RequiresApproval = true)]
-    public Task<CapabilityResult> DraftReplyAsync(
-        [AgentParam("Optional ticket id to draft a reply for, for example TCK-1042", Required = false)] string? ticketId = null)
+    [AgentAction("Draft a reply for a specific ticket", ActionId = "draft_ticket_reply_for_ticket", RequiresApproval = true)]
+    public Task<CapabilityResult> DraftReplyForTicketAsync(
+        [AgentParam("Ticket id to draft a reply for, for example TCK-1042", Required = true)] string ticketId)
     {
-        if (!string.IsNullOrWhiteSpace(ticketId) && !workflow.FocusTicket(ticketId))
+        if (!workflow.FocusTicket(ticketId))
         {
             return Task.FromResult(CapabilityResult.NeedsClarification(
                 $"I could not find ticket {ticketId}. Ask me to show open tickets first or choose a visible ticket id."));
         }
 
+        return Task.FromResult(BuildDraftResult(workflow));
+    }
+
+    [AgentAction("Draft a reply for the highlighted tickets", ActionId = "draft_ticket_reply", RequiresApproval = true)]
+    public Task<CapabilityResult> DraftReplyAsync()
+    {
         if (!workflow.HighlightedTicketIds.Any())
         {
             return Task.FromResult(CapabilityResult.NeedsClarification(
                 "No tickets are highlighted yet. Ask me to show open tickets first or tell me which ticket needs a reply."));
         }
 
+        return Task.FromResult(BuildDraftResult(workflow));
+    }
+
+    private static CapabilityResult BuildDraftResult(SupportInboxWorkflowService workflow)
+    {
         var summary = workflow.PrepareReplyDraft();
         var resultFactory = workflow.LatestDraftBlockers.Count > 0
             ? CapabilityResult.Blocked(summary)
             : CapabilityResult.Success(summary);
 
-        return Task.FromResult(resultFactory with
+        return resultFactory with
         {
             Outputs = new Dictionary<string, object?>
             {
@@ -85,7 +96,7 @@ internal sealed class SupportInboxCapabilities(SupportInboxWorkflowService workf
                     "Review the draft reply",
                     "Approve the reply draft"
                 ]
-        });
+        };
     }
 
     [AgentAction("Escalate the blocked tickets", ActionId = "escalate_blocked_tickets")]

--- a/src/AgentBlazor.Components/Chat/AgentChatSurface.razor
+++ b/src/AgentBlazor.Components/Chat/AgentChatSurface.razor
@@ -14,6 +14,7 @@
 @using AgentBlazor.Core.Runtime.Interfaces
 @using AgentBlazor.Execution
 @using AgentBlazor.Runtime
+@using System.Text.Json
 @using Microsoft.Extensions.Options
 @using Microsoft.JSInterop
 @inject IAgentRegistry AgentRegistry
@@ -991,6 +992,11 @@
         {
             ["agentblazor.approvals"] = string.Join(",", approvalKeys)
         };
+        foreach (var approval in _pendingApprovals)
+        {
+            var approvalKey = $"{approval.ComponentId}.{approval.ActionId}";
+            approvalContext[$"agentblazor.approvalArgs.{approvalKey}"] = JsonSerializer.Serialize(approval.Parameters);
+        }
         
         _timeline.Add(ChatTimelineItem.User("Approved"));
         _pendingApprovals.Clear();

--- a/src/AgentBlazor.Core/Runtime/Adapters/ChatClientRuntimeAdapter.cs
+++ b/src/AgentBlazor.Core/Runtime/Adapters/ChatClientRuntimeAdapter.cs
@@ -563,9 +563,11 @@ public sealed class ChatClientRuntimeAdapter(
 
         foreach (var capability in capabilities)
         {
+            var approvalKey = BuildApprovalKey(capability.CapabilityId, capability.LocalActionId);
+            var approvalArguments = ResolveApprovedActionArguments(request.Context, approvalKey);
             await InvokeCapabilityAsync(
                     capability,
-                    new AIFunctionArguments(new Dictionary<string, object?>()),
+                    new AIFunctionArguments(approvalArguments),
                     turnState,
                     cancellationToken)
                 .ConfigureAwait(false);
@@ -602,6 +604,29 @@ public sealed class ChatClientRuntimeAdapter(
 
     private static string BuildApprovalKey(string componentId, string actionId)
         => $"{componentId}.{actionId}";
+
+    private static IDictionary<string, object?> ResolveApprovedActionArguments(
+        IDictionary<string, string>? context,
+        string approvalKey)
+    {
+        if (context is null ||
+            string.IsNullOrWhiteSpace(approvalKey) ||
+            !context.TryGetValue($"agentblazor.approvalArgs.{approvalKey}", out var rawArguments) ||
+            string.IsNullOrWhiteSpace(rawArguments))
+        {
+            return new Dictionary<string, object?>();
+        }
+
+        try
+        {
+            return JsonSerializer.Deserialize<Dictionary<string, object?>>(rawArguments) ??
+                new Dictionary<string, object?>();
+        }
+        catch (JsonException)
+        {
+            return new Dictionary<string, object?>();
+        }
+    }
 
     private static bool IsGlobalApprovalValue(string value)
         => value.Equals("1", StringComparison.OrdinalIgnoreCase) ||

--- a/tests/AgentBlazor.IntegrationTests/CapabilityAuditIntegrationTests.cs
+++ b/tests/AgentBlazor.IntegrationTests/CapabilityAuditIntegrationTests.cs
@@ -12,6 +12,46 @@ namespace AgentBlazor.IntegrationTests;
 public class CapabilityAuditIntegrationTests
 {
     [Fact]
+    public async Task CapabilityApprovalContinuation_PreservesApprovedArguments()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<ApprovalCapabilityChatClient>();
+        services.AddSingleton<IChatClient>(static sp => sp.GetRequiredService<ApprovalCapabilityChatClient>());
+        services.AddAgentBlazorServices()
+            .UseChatClientRuntimeAdapter()
+            .AddCapability<ApprovalCapabilities>()
+            .AddAgent("approval-agent", agent =>
+            {
+                agent.WithAllowedActions("approval_workflow.create_change_request");
+            });
+
+        await using var provider = services.BuildServiceProvider();
+        var runtime = provider.GetRequiredService<IAgentRuntimeAdapter>();
+
+        var approvalResponse = await runtime.RunTurnAsync(new AgentTurnRequest(
+            "Create the change request",
+            AgentName: "approval-agent",
+            SessionId: "integration-approval-args"));
+
+        var approval = Assert.Single(approvalResponse.PendingApprovals);
+        Assert.Equal("CAB-99", approval.Parameters["name"]?.ToString());
+
+        var approvedResponse = await runtime.RunTurnAsync(new AgentTurnRequest(
+            "Approved. Continue by invoking the approved action(s): approval_workflow.create_change_request.",
+            AgentName: "approval-agent",
+            SessionId: "integration-approval-args",
+            Context: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["agentblazor.approvals"] = "approval_workflow.create_change_request",
+                ["agentblazor.approvalArgs.approval_workflow.create_change_request"] = """{"name":"CAB-99"}"""
+            }));
+
+        var executionStep = Assert.Single(approvedResponse.ExecutionPlan?.Steps ?? []);
+        Assert.Equal("Created 'CAB-99'.", executionStep.Message);
+        Assert.False(approvedResponse.RequiresApproval);
+    }
+
+    [Fact]
     public async Task CapabilityExecution_WithAuditLog_DoesNotRequireHttpContextAccessor()
     {
         var services = new ServiceCollection();

--- a/tests/AgentBlazor.IntegrationTests/SupportInboxWorkflowIntegrationTests.cs
+++ b/tests/AgentBlazor.IntegrationTests/SupportInboxWorkflowIntegrationTests.cs
@@ -38,12 +38,12 @@ public class SupportInboxWorkflowIntegrationTests
     }
 
     [Fact]
-    public async Task DraftReplyAsync_TargetsRequestedTicketWithoutPriorHighlight()
+    public async Task DraftReplyForTicketAsync_TargetsRequestedTicketWithoutPriorHighlight()
     {
         var workflow = new SupportInboxWorkflowService();
         var capabilities = new SupportInboxCapabilities(workflow);
 
-        var result = await capabilities.DraftReplyAsync("TCK-1042");
+        var result = await capabilities.DraftReplyForTicketAsync("TCK-1042");
 
         Assert.True(result.Succeeded);
         Assert.Contains("Prepared a reply draft", result.Summary, StringComparison.OrdinalIgnoreCase);
@@ -54,12 +54,12 @@ public class SupportInboxWorkflowIntegrationTests
     }
 
     [Fact]
-    public async Task DraftReplyAsync_ReturnsClarificationForUnknownTicket()
+    public async Task DraftReplyForTicketAsync_ReturnsClarificationForUnknownTicket()
     {
         var workflow = new SupportInboxWorkflowService();
         var capabilities = new SupportInboxCapabilities(workflow);
 
-        var result = await capabilities.DraftReplyAsync("TCK-9999");
+        var result = await capabilities.DraftReplyForTicketAsync("TCK-9999");
 
         Assert.False(result.Succeeded);
         Assert.True(result.RequiresClarification);


### PR DESCRIPTION
## Summary
- preserve pending approval parameters in the chat approval context
- reuse preserved parameters when approved capabilities are executed on continuation
- split support inbox drafting into explicit ticket-specific and highlighted-ticket actions
- add regression coverage for approval argument preservation and direct support ticket drafting

## Validation
- dotnet test tests/AgentBlazor.IntegrationTests/AgentBlazor.IntegrationTests.csproj -c Release --no-restore --filter "SupportInboxWorkflowIntegrationTests|CapabilityApprovalContinuation_PreservesApprovedArguments" -nologo -p:RuntimeIdentifier=linux-x64
- dotnet build demo/AgentBlazor.Demo/AgentBlazor.Demo.csproj -c Release --no-restore -nologo -p:RuntimeIdentifier=linux-x64
- git diff --check