### PR TITLE
Harden approval continuation argument handling

### DIFF
--- a/src/AgentBlazor.Core/Runtime/Adapters/ChatClientRuntimeAdapter.cs
+++ b/src/AgentBlazor.Core/Runtime/Adapters/ChatClientRuntimeAdapter.cs
@@ -585,9 +585,14 @@ public sealed class ChatClientRuntimeAdapter(
         var keys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         if (context is null ||
             !context.TryGetValue("agentblazor.approvals", out var approvals) ||
-            string.IsNullOrWhiteSpace(approvals) ||
-            IsGlobalApprovalValue(approvals))
+            string.IsNullOrWhiteSpace(approvals))
         {
+            return keys;
+        }
+
+        if (IsGlobalApprovalValue(approvals))
+        {
+            AddApprovalArgumentKeys(context, keys);
             return keys;
         }
 
@@ -600,6 +605,26 @@ public sealed class ChatClientRuntimeAdapter(
         }
 
         return keys;
+    }
+
+    private static void AddApprovalArgumentKeys(
+        IDictionary<string, string> context,
+        ISet<string> keys)
+    {
+        const string prefix = "agentblazor.approvalArgs.";
+        foreach (var key in context.Keys)
+        {
+            if (!key.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            var approvalKey = key[prefix.Length..];
+            if (approvalKey.Contains('.', StringComparison.Ordinal))
+            {
+                keys.Add(approvalKey);
+            }
+        }
     }
 
     private static string BuildApprovalKey(string componentId, string actionId)

--- a/src/AgentBlazor.Hosting/DeterministicAgUiHostedAgent.cs
+++ b/src/AgentBlazor.Hosting/DeterministicAgUiHostedAgent.cs
@@ -917,21 +917,7 @@ internal sealed class DeterministicAgUiHostedAgent(
         IReadOnlyList<PendingApproval> pendingApprovals)
     {
         var approvals = pendingApprovals
-            .Select(static pending => (object?)new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
-            {
-                ["componentId"] = pending.ComponentId,
-                ["actionId"] = pending.ActionId,
-                ["description"] = pending.Description,
-                ["policyDecision"] = pending.PolicyDecision is null
-                    ? null
-                    : new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
-                    {
-                        ["allowed"] = pending.PolicyDecision.Allowed,
-                        ["riskClass"] = pending.PolicyDecision.RiskClass.ToString(),
-                        ["approvalMode"] = pending.PolicyDecision.ApprovalMode.ToString(),
-                        ["reason"] = pending.PolicyDecision.Reason
-                    }
-            })
+            .Select(static pending => (object?)CreatePendingApprovalPayload(pending))
             .ToArray();
 
         return new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
@@ -940,6 +926,24 @@ internal sealed class DeterministicAgUiHostedAgent(
             ["pendingApprovals"] = approvals
         };
     }
+
+    private static Dictionary<string, object?> CreatePendingApprovalPayload(PendingApproval pending)
+        => new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["componentId"] = pending.ComponentId,
+            ["actionId"] = pending.ActionId,
+            ["description"] = pending.Description,
+            ["parameters"] = pending.Parameters,
+            ["policyDecision"] = pending.PolicyDecision is null
+                ? null
+                : new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["allowed"] = pending.PolicyDecision.Allowed,
+                    ["riskClass"] = pending.PolicyDecision.RiskClass.ToString(),
+                    ["approvalMode"] = pending.PolicyDecision.ApprovalMode.ToString(),
+                    ["reason"] = pending.PolicyDecision.Reason
+                }
+        };
 
     private static PlannedComponentAction? ToPlannedAction(AgentExecutionStep step)
     {
@@ -1218,21 +1222,7 @@ internal sealed class DeterministicAgUiHostedAgent(
             case AgentTurnStreamEventKind.ApprovalRequired:
             {
                 var pendingApprovals = streamEvent.PendingApprovals?
-                    .Select(static pending => (object?)new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
-                    {
-                        ["componentId"] = pending.ComponentId,
-                        ["actionId"] = pending.ActionId,
-                        ["description"] = pending.Description,
-                        ["policyDecision"] = pending.PolicyDecision is null
-                            ? null
-                            : new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
-                            {
-                                ["allowed"] = pending.PolicyDecision.Allowed,
-                                ["riskClass"] = pending.PolicyDecision.RiskClass.ToString(),
-                                ["approvalMode"] = pending.PolicyDecision.ApprovalMode.ToString(),
-                                ["reason"] = pending.PolicyDecision.Reason
-                            }
-                    })
+                    .Select(static pending => (object?)CreatePendingApprovalPayload(pending))
                     .ToArray() ?? [];
                 var payload = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
                 {

--- a/tests/AgentBlazor.Components.Tests/AgentChatSurfaceTests.cs
+++ b/tests/AgentBlazor.Components.Tests/AgentChatSurfaceTests.cs
@@ -10,6 +10,7 @@ using AgentBlazor.Execution;
 using AgentBlazor.Services;
 using Bunit;
 using Microsoft.Extensions.DependencyInjection;
+using System.Text.Json;
 
 namespace AgentBlazor.Components.Tests;
 
@@ -323,6 +324,16 @@ public sealed class AgentChatSurfaceTests : TestContext
 
         public async Task<AgentTurnResponse> RunTurnAsync(AgentTurnRequest request, CancellationToken cancellationToken = default)
         {
+            if (IsApprovalMessage(request.UserMessage))
+            {
+                Assert.NotNull(request.Context);
+                Assert.True(
+                    request.Context.TryGetValue("agentblazor.approvalArgs.runtime_probe.run_approval_probe", out var rawArguments),
+                    "Approval continuation should include the original pending approval parameters.");
+                using var document = JsonDocument.Parse(rawArguments);
+                Assert.Equal("TCK-1042", document.RootElement.GetProperty("ticketId").GetString());
+            }
+
             var response = IsApprovalMessage(request.UserMessage)
                 ? CreateApprovedResponse(request.GetEffectiveSessionId())
                 : CreateApprovalRequiredResponse(request.GetEffectiveSessionId());
@@ -404,7 +415,10 @@ public sealed class AgentChatSurfaceTests : TestContext
                         "runtime_probe",
                         "run_approval_probe",
                         "Run the runtime approval probe",
-                        new Dictionary<string, object?>(),
+                        new Dictionary<string, object?>
+                        {
+                            ["ticketId"] = "TCK-1042"
+                        },
                         new AgentPolicyDecision(true, AgentRiskClass.SensitiveMutation, AgentApprovalMode.StepApproval))
                 ],
                 ExecutionPlan = executionPlan

--- a/tests/AgentBlazor.IntegrationTests/AgUiHostingIntegrationTests.cs
+++ b/tests/AgentBlazor.IntegrationTests/AgUiHostingIntegrationTests.cs
@@ -40,6 +40,8 @@ public class AgUiHostingIntegrationTests
             Assert.Contains("TEXT_MESSAGE_CONTENT", body, StringComparison.Ordinal);
             Assert.Contains("STATE_SNAPSHOT", body, StringComparison.Ordinal);
             Assert.Contains("approval_required", body, StringComparison.Ordinal);
+            Assert.Contains("parameters", body, StringComparison.Ordinal);
+            Assert.Contains("agentblazor.session_id", body, StringComparison.Ordinal);
             Assert.Equal(0, executor.CallCount);
         }
         finally

--- a/tests/AgentBlazor.IntegrationTests/CapabilityAuditIntegrationTests.cs
+++ b/tests/AgentBlazor.IntegrationTests/CapabilityAuditIntegrationTests.cs
@@ -52,6 +52,46 @@ public class CapabilityAuditIntegrationTests
     }
 
     [Fact]
+    public async Task CapabilityApprovalContinuation_GlobalApprovalUsesPreservedArgumentKeys()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<ApprovalCapabilityChatClient>();
+        services.AddSingleton<IChatClient>(static sp => sp.GetRequiredService<ApprovalCapabilityChatClient>());
+        services.AddAgentBlazorServices()
+            .UseChatClientRuntimeAdapter()
+            .AddCapability<ApprovalCapabilities>()
+            .AddAgent("approval-agent", agent =>
+            {
+                agent.WithAllowedActions(
+                    "approval_workflow.create_complex_change_request",
+                    "approval_workflow.notify_owner");
+            });
+
+        await using var provider = services.BuildServiceProvider();
+        var runtime = provider.GetRequiredService<IAgentRuntimeAdapter>();
+
+        var approvedResponse = await runtime.RunTurnAsync(new AgentTurnRequest(
+            "Approved. Continue by invoking the approved action(s).",
+            AgentName: "approval-agent",
+            SessionId: "integration-approval-all-args",
+            Context: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["agentblazor.approvals"] = "all",
+                ["agentblazor.approvalArgs.approval_workflow.create_complex_change_request"] =
+                    """{"request":{"name":"CAB-100","priority":3,"tags":["database","hotfix"]}}""",
+                ["agentblazor.approvalArgs.approval_workflow.notify_owner"] =
+                    """{"owner":"ops","ticketCount":2}"""
+            }));
+
+        var messages = approvedResponse.ExecutionPlan?.Steps
+            .Select(static step => step.Message)
+            .ToArray() ?? [];
+        Assert.Contains("Created 'CAB-100' priority 3 tags database|hotfix.", messages);
+        Assert.Contains("Notified ops about 2 ticket(s).", messages);
+        Assert.False(approvedResponse.RequiresApproval);
+    }
+
+    [Fact]
     public async Task CapabilityExecution_WithAuditLog_DoesNotRequireHttpContextAccessor()
     {
         var services = new ServiceCollection();
@@ -94,7 +134,18 @@ public class CapabilityAuditIntegrationTests
         [AgentAction("Create a change request", ActionId = "create_change_request", RequiresApproval = true)]
         public CapabilityResult CreateChangeRequest(string name = "Default")
             => CapabilityResult.Success($"Created '{name}'.");
+
+        [AgentAction("Create a complex change request", ActionId = "create_complex_change_request", RequiresApproval = true)]
+        public CapabilityResult CreateComplexChangeRequest(ChangeRequest request)
+            => CapabilityResult.Success(
+                $"Created '{request.Name}' priority {request.Priority} tags {string.Join("|", request.Tags)}.");
+
+        [AgentAction("Notify owner", ActionId = "notify_owner", RequiresApproval = true)]
+        public CapabilityResult NotifyOwner(string owner, int ticketCount)
+            => CapabilityResult.Success($"Notified {owner} about {ticketCount} ticket(s).");
     }
+
+    private sealed record ChangeRequest(string Name, int Priority, string[] Tags);
 
     private sealed class ApprovalCapabilityChatClient : IChatClient
     {


### PR DESCRIPTION
## Summary
- derive exact approved action keys from preserved argument payloads when approval context uses a global approval value
- include pending approval parameters in AG-UI approval-required state snapshots for both non-streaming and streaming paths
- assert the chat surface carries pending approval parameters into the approval continuation context
- add regression coverage for multi-action approval continuation and complex argument payloads

## Validation
- dotnet test tests/AgentBlazor.IntegrationTests/AgentBlazor.IntegrationTests.csproj -c Release --no-restore --filter "CapabilityApprovalContinuation|AgUiRun_ApprovalRequiredAction_SkipsExecution_WhenApprovalMissing" -nologo -p:RuntimeIdentifier=linux-x64
- dotnet test tests/AgentBlazor.Components.Tests/AgentBlazor.Components.Tests.csproj -c Release --no-restore --filter "ApprovalOutcome_ReplacesPersistedPlaceholderResponse_ForFreshRender" -nologo -p:RuntimeIdentifier=linux-x64
- dotnet build AgentBlazor.slnx -c Release --no-restore -nologo
- git diff --check