### PR TITLE
Replace demo video with quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Render one chat surface:
 
 ## What To Open
 
-- Home video: `/`
+- Home quickstart: `/`
 - Docs: `/docs`
 - Live demo: `/demo/workflows/support-inbox`
 - Starter sample: `samples/AgentBlazor.Starter`

--- a/demo/AgentBlazor.Demo/Components/Pages/Demo/DemoHome.razor
+++ b/demo/AgentBlazor.Demo/Components/Pages/Demo/DemoHome.razor
@@ -10,18 +10,24 @@
             <MudChip T="string" Color="Color.Primary" Variant="Variant.Filled" Size="Size.Small">Live demo</MudChip>
             <MudText Typo="Typo.h4" Class="mt-4 mb-2">One normal app screen. One support queue.</MudText>
             <MudText Typo="Typo.body2" Color="Color.Secondary">
-                Start with the reel, then open the route and run the same ticket flow live: find open tickets, explain the queue, draft a reply, and escalate blockers.
+                Open the support queue and run a concrete ticket flow live: find open tickets, explain the queue, draft a reply, and cross the approval boundary.
             </MudText>
         </div>
 
         <div class="launchpad__feature-grid">
             <article class="launchpad__feature-card">
-                <div class="launchpad__feature-frame">
-                    <video controls preload="metadata" playsinline poster="/videos/agentblazor-capability-reel-poster.jpg" src="/videos/agentblazor-capability-reel.mp4"></video>
+                <div class="launchpad__quickstart-card" aria-label="AgentBlazor quickstart">
+                    <span class="launchpad__eyebrow">Minimal setup</span>
+                    <h2>NuGet package, one workflow, one widget.</h2>
+                    <ol>
+                        <li><code>dotnet add package AgentBlazor --prerelease</code></li>
+                        <li><code>AddAgentBlazor(...).AddWorkflow&lt;HelloWorkflow&gt;("hello-workflow")</code></li>
+                        <li><code>&lt;AgentChatWidget Title="Assistant" /&gt;</code></li>
+                    </ol>
                 </div>
                 <div class="launchpad__feature-copy">
-                    <strong>AgentBlazor in one reel</strong>
-                    <p>CLI install, support-queue workflow code, then a live reply draft and approval boundary on a real Blazor page.</p>
+                    <strong>What to look for in the live route</strong>
+                    <p>The agent reads the current support queue, plans an action, requests approval for the reply draft, then updates the page after approval.</p>
                 </div>
             </article>
 

--- a/demo/AgentBlazor.Demo/Components/Pages/Demo/DemoHome.razor.css
+++ b/demo/AgentBlazor.Demo/Components/Pages/Demo/DemoHome.razor.css
@@ -45,19 +45,48 @@
         rgba(7, 14, 24, 0.76);
 }
 
-.launchpad__feature-frame {
-    overflow: hidden;
+.launchpad__quickstart-card {
+    display: grid;
+    gap: 0.8rem;
+    padding: 1rem;
     border-radius: 0.95rem;
-    background: #030914;
+    background:
+        radial-gradient(circle at top left, rgba(255, 106, 61, 0.16), transparent 34%),
+        #030914;
     border: 1px solid rgba(255, 255, 255, 0.08);
-    aspect-ratio: 16 / 9;
 }
 
-.launchpad__feature-frame video {
+.launchpad__quickstart-card h2 {
+    max-width: 32rem;
+    margin: 0;
+    color: #f1f7ff;
+    font-size: clamp(1.45rem, 2.5vw, 2.15rem);
+    line-height: 1.05;
+}
+
+.launchpad__quickstart-card ol {
+    display: grid;
+    gap: 0.55rem;
+    padding: 0;
+    margin: 0;
+    list-style: none;
+}
+
+.launchpad__quickstart-card li {
+    min-width: 0;
+    padding: 0.68rem 0.78rem;
+    border-radius: 0.78rem;
+    background: rgba(255, 255, 255, 0.045);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.launchpad__quickstart-card code {
     display: block;
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
+    overflow: hidden;
+    color: #d8eaff;
+    font-size: 0.84rem;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .launchpad__feature-copy {

--- a/demo/AgentBlazor.Demo/Components/Pages/Home.razor
+++ b/demo/AgentBlazor.Demo/Components/Pages/Home.razor
@@ -10,14 +10,30 @@
     <section class="landing-page__stage">
         <LandingHero />
 
-        <article class="landing-page__hero-player">
-            <div class="landing-page__hero-frame">
-                <video autoplay muted loop preload="auto" playsinline poster="/videos/agentblazor-capability-reel-poster.jpg" src="/videos/agentblazor-capability-reel.mp4"></video>
+        <article class="landing-page__quickstart" aria-label="AgentBlazor quickstart">
+            <div class="landing-page__quickstart-header">
+                <span class="landing-page__quickstart-eyebrow">Quickstart</span>
+                <h2>Add a chat-controlled Blazor workflow</h2>
+                <p>Install the package, register one workflow, then mount the widget in an interactive layout.</p>
             </div>
-            <div class="landing-page__hero-meta" aria-label="Demo sequence">
-                <span>CLI install</span>
-                <span>Support workflow code</span>
-                <span>Reply draft with approval</span>
+            <ol class="landing-page__quickstart-steps">
+                <li>
+                    <span>1</span>
+                    <code>dotnet add package AgentBlazor --prerelease</code>
+                </li>
+                <li>
+                    <span>2</span>
+                    <code>builder.Services.AddAgentBlazor(...).AddWorkflow&lt;HelloWorkflow&gt;("hello-workflow")</code>
+                </li>
+                <li>
+                    <span>3</span>
+                    <code>&lt;AgentChatWidget Title="Assistant" /&gt;</code>
+                </li>
+            </ol>
+            <div class="landing-page__hero-meta" aria-label="Quickstart links">
+                <a href="/docs/quickstart">Read quickstart</a>
+                <a href="/demo/workflows/support-inbox">Try live demo</a>
+                <a href="https://github.com/ashpeterson/AgentBlazor">GitHub</a>
             </div>
         </article>
     </section>

--- a/demo/AgentBlazor.Demo/Components/Pages/Home.razor.css
+++ b/demo/AgentBlazor.Demo/Components/Pages/Home.razor.css
@@ -12,7 +12,7 @@
     min-height: calc(100svh - 10rem);
 }
 
-.landing-page__hero-player {
+.landing-page__quickstart {
     display: grid;
     gap: 0.9rem;
     padding: 1.1rem;
@@ -25,20 +25,71 @@
     box-shadow: 0 42px 110px rgba(0, 0, 0, 0.3);
 }
 
-.landing-page__hero-frame {
-    overflow: hidden;
-    border-radius: 1.35rem;
-    background: #020610;
-    border: 1px solid rgba(255, 255, 255, 0.08);
-    aspect-ratio: 16 / 9;
+.landing-page__quickstart-header {
+    display: grid;
+    gap: 0.5rem;
+    padding: 0.3rem 0.2rem;
 }
 
-.landing-page__hero-frame video {
-    display: block;
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-    background: #020610;
+.landing-page__quickstart-eyebrow {
+    color: #8fc5ff;
+    font-size: 0.74rem;
+    font-weight: 900;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+}
+
+.landing-page__quickstart-header h2 {
+    margin: 0;
+    color: #f1f7ff;
+    font-size: clamp(1.6rem, 3vw, 2.35rem);
+    line-height: 1.02;
+}
+
+.landing-page__quickstart-header p {
+    max-width: 35rem;
+    margin: 0;
+    color: rgba(224, 236, 252, 0.75);
+    line-height: 1.55;
+}
+
+.landing-page__quickstart-steps {
+    display: grid;
+    gap: 0.7rem;
+    padding: 0;
+    margin: 0;
+    list-style: none;
+}
+
+.landing-page__quickstart-steps li {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    gap: 0.75rem;
+    align-items: center;
+    padding: 0.8rem;
+    border-radius: 1rem;
+    background: rgba(2, 7, 16, 0.62);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.landing-page__quickstart-steps li span {
+    display: inline-grid;
+    place-items: center;
+    width: 1.8rem;
+    height: 1.8rem;
+    border-radius: 999px;
+    background: rgba(255, 106, 61, 0.18);
+    color: #ffb097;
+    font-size: 0.82rem;
+    font-weight: 900;
+}
+
+.landing-page__quickstart-steps code {
+    overflow: hidden;
+    color: #d8eaff;
+    font-size: 0.86rem;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .landing-page__hero-meta {
@@ -59,6 +110,26 @@
     font-size: 0.8rem;
     font-weight: 700;
     letter-spacing: 0.025em;
+}
+
+.landing-page__hero-meta a {
+    display: inline-flex;
+    align-items: center;
+    min-height: 2rem;
+    padding: 0.35rem 0.75rem;
+    border-radius: 999px;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    background: rgba(255, 255, 255, 0.04);
+    color: rgba(234, 242, 252, 0.88);
+    font-size: 0.8rem;
+    font-weight: 800;
+    letter-spacing: 0.025em;
+    text-decoration: none;
+}
+
+.landing-page__hero-meta a:hover {
+    border-color: rgba(143, 197, 255, 0.42);
+    color: #ffffff;
 }
 
 @media (max-width: 700px) {

--- a/tests/e2e/specs/home.spec.cjs
+++ b/tests/e2e/specs/home.spec.cjs
@@ -9,10 +9,12 @@ test.describe("Landing page", () => {
     await expect(page.getByRole("navigation", { name: "Primary" }).getByRole("link", { name: "Live Demo", exact: true })).toBeVisible();
     await expect(page.locator("#hero").getByRole("link", { name: "Docs" })).toBeVisible();
     await expect(page.locator("#hero").getByRole("link", { name: "Live demo" })).toBeVisible();
-    await expect(page.locator(".landing-page__hero-meta")).toContainText("CLI install");
-    await expect(page.locator(".landing-page__hero-meta")).toContainText("Support workflow code");
-    await expect(page.locator(".landing-page__hero-meta")).toContainText("Reply draft with approval");
-    await expect(page.locator(".landing-page__hero-frame video")).toHaveAttribute("src", "/videos/agentblazor-capability-reel.mp4");
+    await expect(page.locator(".landing-page__quickstart")).toContainText("Quickstart");
+    await expect(page.locator(".landing-page__quickstart")).toContainText("dotnet add package AgentBlazor --prerelease");
+    await expect(page.locator(".landing-page__quickstart")).toContainText("AgentChatWidget");
+    await expect(page.locator(".landing-page__hero-meta").getByRole("link", { name: "Read quickstart" })).toBeVisible();
+    await expect(page.locator(".landing-page__hero-meta").getByRole("link", { name: "Try live demo" })).toBeVisible();
+    await expect(page.locator(".landing-page__quickstart video")).toHaveCount(0);
     await expect(page.locator(".landing-page__support-strip")).toHaveCount(0);
 
     await page.locator("#hero").getByRole("link", { name: "Docs" }).click();


### PR DESCRIPTION
## Summary
- replace the landing page video reel with a concise quickstart panel
- replace the demo launchpad video card with minimal setup steps
- update README wording from home video to home quickstart

## Validation
- dotnet build demo/AgentBlazor.Demo/AgentBlazor.Demo.csproj -c Release --no-restore -nologo -p:RuntimeIdentifier=linux-x64
- git diff --check
- rg "<video|agentblazor-capability-reel|Home video|hero-player|feature-frame video" -n README.md demo/AgentBlazor.Demo/Components/Pages demo/AgentBlazor.Demo/wwwroot