### PR TITLE
Unify approval UI contract

### DIFF
--- a/demo/AgentBlazor.Demo/Components/Pages/Demo/SupportInboxWorkflow.razor
+++ b/demo/AgentBlazor.Demo/Components/Pages/Demo/SupportInboxWorkflow.razor
@@ -128,7 +128,7 @@
             @if (Workflow.CurrentDraft is { } draft)
             {
                 <MudText Typo="Typo.body2" Class="mb-2">
-                    This is the approval boundary before the drafted reply is handed back to the queue owner.
+                    The runtime approval is complete. This panel summarizes the prepared draft before it leaves the queue.
                 </MudText>
                 <MudText Typo="Typo.caption" Class="d-block mb-3">
                     Tickets: @string.Join(", ", draft.TicketIds)
@@ -224,7 +224,7 @@
     {
         if (Workflow.CurrentDraft is not null)
         {
-            return "Review the drafted reply and decide whether to approve it.";
+            return "Review the prepared draft in the reply panel.";
         }
 
         if (Workflow.LatestDraftBlockers.Count > 0)
@@ -272,7 +272,7 @@
     {
         if (Workflow.CurrentDraft is not null)
         {
-            return ["Review the reply draft", "Approve the reply draft"];
+            return ["Review the prepared draft", "Send through the normal support workflow"];
         }
 
         if (Workflow.LatestDraftBlockers.Count > 0)

--- a/demo/AgentBlazor.Demo/Services/SupportInboxWorkflowService.cs
+++ b/demo/AgentBlazor.Demo/Services/SupportInboxWorkflowService.cs
@@ -93,8 +93,8 @@ internal sealed class SupportInboxCapabilities(SupportInboxWorkflowService workf
                     "Draft the reply again once the blockers are cleared"
                 ]
                 : [
-                    "Review the draft reply",
-                    "Approve the reply draft"
+                    "Review the prepared draft",
+                    "Send the reply through the normal support workflow"
                 ]
         };
     }
@@ -241,7 +241,7 @@ internal sealed class SupportInboxWorkflowService
             "Draft customer reply",
             targetedTickets.Select(static ticket => ticket.Id).ToArray(),
             targetedTickets.SelectMany(BuildReplyChecklist).ToArray());
-        IsDraftDialogOpen = true;
+        IsDraftDialogOpen = false;
         LatestInsight = $"Prepared a reply draft for {targetedTickets.Length} highlighted tickets.";
         NotifyChanged();
         return LatestInsight;

--- a/src/AgentBlazor.Core/Runtime/Adapters/ChatClientRuntimeAdapter.cs
+++ b/src/AgentBlazor.Core/Runtime/Adapters/ChatClientRuntimeAdapter.cs
@@ -1986,14 +1986,22 @@ public sealed class ChatClientRuntimeAdapter(
         var clarificationQuestion = executionPlan.Steps
             .FirstOrDefault(static step => step.Status is AgentExecutionStepStatus.NeedsClarification)?
             .Message;
+        var pendingApprovals = turnState.GetPendingApprovals();
+        var effectiveResponseText = pendingApprovals.Count > 0
+            ? RuntimePlanApprovals.BuildApprovalRequiredResponseText(pendingApprovals)
+            : RuntimePlanResponses.BuildExecutionResponseText(responseText, executionResults);
+        var generatedUi = pendingApprovals.Count > 0
+            ? null
+            : BuildGeneratedUi(turnState);
+
         return RuntimeTurnResponses.Build(
             agentName,
-            RuntimePlanResponses.BuildExecutionResponseText(responseText, executionResults),
+            effectiveResponseText,
             executionPlan.Steps.Count > 0 ? [] : turnState.GetPlannedActions(),
             responseExecutionResults,
-            generatedUi: BuildGeneratedUi(turnState),
+            generatedUi: generatedUi,
             clarificationQuestion: clarificationQuestion,
-            pendingApprovals: turnState.GetPendingApprovals(),
+            pendingApprovals: pendingApprovals,
             requiresApproval: turnState.RequiresApproval,
             executionPlan: executionPlan);
     }

--- a/tests/AgentBlazor.Core.Tests/ServiceRegistrationTests.cs
+++ b/tests/AgentBlazor.Core.Tests/ServiceRegistrationTests.cs
@@ -721,6 +721,43 @@ public class ServiceRegistrationTests
     }
 
     [Fact]
+    public async Task ChatClientRuntimeAdapter_SuppressesGeneratedUi_WhenRuntimeApprovalIsPending()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<GeneratedUiAndApprovalToolInvokingChatClient>();
+        services.AddSingleton<IChatClient>(static sp => sp.GetRequiredService<GeneratedUiAndApprovalToolInvokingChatClient>());
+        services.AddAgentBlazorServices()
+            .UseChatClientRuntimeAdapter()
+            .AddCapability<ApprovalUiContractCapabilities>()
+            .AddAgent("approval-ui-agent", agent =>
+            {
+                agent.WithAllowedActions("approval_ui_contract.draft_reply");
+            });
+
+        await using var provider = services.BuildServiceProvider();
+
+        var adapter = provider.GetRequiredService<IAgentRuntimeAdapter>();
+
+        var response = await adapter.RunTurnAsync(new AgentTurnRequest(
+            "Draft a reply for ticket TCK-1042",
+            AgentName: "approval-ui-agent",
+            SessionId: "approval-ui-contract",
+            Context: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                [AgentGenerativeUiSpec.GenerateUiContextKey] = bool.TrueString
+            }));
+
+        Assert.True(response.RequiresApproval);
+        Assert.Null(response.GeneratedUi);
+        Assert.Equal("Approval required for approval_ui_contract.draft_reply.", response.ResponseText);
+
+        var approval = Assert.Single(response.PendingApprovals);
+        Assert.Equal("approval_ui_contract", approval.ComponentId);
+        Assert.Equal("draft_reply", approval.ActionId);
+        Assert.Equal("TCK-1042", approval.Parameters["ticketId"]?.ToString());
+    }
+
+    [Fact]
     public async Task ChatClientRuntimeAdapter_BlocksImplicitFormSubmitFromGeneratedUiAction()
     {
         var services = new ServiceCollection();
@@ -2162,6 +2199,17 @@ public class ServiceRegistrationTests
             => global::AgentBlazor.App.CapabilityResult.Success("prepared");
     }
 
+    [global::AgentBlazor.App.AgentCapability("approval_ui_contract", Name = "Approval UI Contract")]
+    private sealed class ApprovalUiContractCapabilities
+    {
+        [global::AgentBlazor.Attributes.AgentAction(
+            "Draft a support reply",
+            ActionId = "draft_reply",
+            RequiresApproval = true)]
+        public global::AgentBlazor.App.CapabilityResult DraftReply(string ticketId)
+            => global::AgentBlazor.App.CapabilityResult.Success($"Prepared draft for {ticketId}.");
+    }
+
     private sealed class RecordingChatClient : IChatClient
     {
         private int _callCount;
@@ -2550,6 +2598,60 @@ public class ServiceRegistrationTests
             }), cancellationToken);
 
             return new ChatResponse(new ChatMessage(ChatRole.Assistant, "generated-ui-ready"));
+        }
+
+        public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IEnumerable<ChatMessage> messages,
+            ChatOptions? options = null,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            var response = await GetResponseAsync(messages, options, cancellationToken);
+            yield return new ChatResponseUpdate(ChatRole.Assistant, response.Text);
+        }
+
+        public object? GetService(Type serviceType, object? serviceKey = null)
+        {
+            _ = serviceType;
+            _ = serviceKey;
+            return null;
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class GeneratedUiAndApprovalToolInvokingChatClient : IChatClient
+    {
+        public async Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> messages,
+            ChatOptions? options = null,
+            CancellationToken cancellationToken = default)
+        {
+            _ = messages;
+            var generatedUiTool = Assert.Single(
+                options?.Tools?.OfType<AIFunction>().Where(static function =>
+                    function.Name.Contains("generated_ui_summary_card", StringComparison.OrdinalIgnoreCase)) ??
+                []);
+            await generatedUiTool.InvokeAsync(new AIFunctionArguments(new Dictionary<string, object?>
+            {
+                ["blockId"] = "approval-confirmation",
+                ["title"] = "Approve Draft Reply",
+                ["description"] = "Do you want to approve the draft reply for ticket TCK-1042?"
+            }), cancellationToken);
+
+            var approvalTool = Assert.Single(
+                options?.Tools?.OfType<AIFunction>().Where(static function =>
+                    function.Name.Contains("capability_approval_ui_contract_draft_reply", StringComparison.OrdinalIgnoreCase)) ??
+                []);
+            await approvalTool.InvokeAsync(new AIFunctionArguments(new Dictionary<string, object?>
+            {
+                ["ticketId"] = "TCK-1042"
+            }), cancellationToken);
+
+            return new ChatResponse(new ChatMessage(
+                ChatRole.Assistant,
+                "I can draft the reply, but here is another generated approval request."));
         }
 
         public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(

--- a/tests/AgentBlazor.IntegrationTests/SupportInboxWorkflowIntegrationTests.cs
+++ b/tests/AgentBlazor.IntegrationTests/SupportInboxWorkflowIntegrationTests.cs
@@ -32,7 +32,7 @@ public class SupportInboxWorkflowIntegrationTests
         Assert.Contains("Escalated", escalationSummary, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("Prepared a reply draft", draftSummary, StringComparison.OrdinalIgnoreCase);
         Assert.NotNull(workflow.CurrentDraft);
-        Assert.True(workflow.IsDraftDialogOpen);
+        Assert.False(workflow.IsDraftDialogOpen);
         Assert.Empty(workflow.LatestDraftBlockers);
         Assert.Contains("TCK-1055", workflow.EscalatedTicketIds, StringComparer.OrdinalIgnoreCase);
     }
@@ -48,7 +48,7 @@ public class SupportInboxWorkflowIntegrationTests
         Assert.True(result.Succeeded);
         Assert.Contains("Prepared a reply draft", result.Summary, StringComparison.OrdinalIgnoreCase);
         Assert.NotNull(workflow.CurrentDraft);
-        Assert.True(workflow.IsDraftDialogOpen);
+        Assert.False(workflow.IsDraftDialogOpen);
         Assert.Contains("TCK-1042", workflow.HighlightedTicketIds, StringComparer.OrdinalIgnoreCase);
         Assert.Contains("TCK-1042", workflow.CurrentDraft.TicketIds, StringComparer.OrdinalIgnoreCase);
     }


### PR DESCRIPTION
## Summary
- suppress generated UI documents whenever a runtime approval is pending
- replace model-authored confirmation copy with deterministic runtime approval text for pending approvals
- add a regression test where a model attempts to emit generated UI and an approval-gated capability in the same turn
- stop auto-opening the support inbox draft dialog after the runtime-approved draft completes
- update support inbox next-step copy so it does not imply a second approval step

## Validation
- dotnet test tests/AgentBlazor.Core.Tests/AgentBlazor.Core.Tests.csproj -c Release --no-restore --filter "ChatClientRuntimeAdapter_SuppressesGeneratedUi_WhenRuntimeApprovalIsPending|ChatClientRuntimeAdapter_AttachesGeneratedUiDocumentFromProjectedUiTool" -nologo -p:RuntimeIdentifier=linux-x64
- dotnet test tests/AgentBlazor.IntegrationTests/AgentBlazor.IntegrationTests.csproj -c Release --no-restore --filter "SupportInboxWorkflowIntegrationTests" -nologo -p:RuntimeIdentifier=linux-x64
- dotnet build demo/AgentBlazor.Demo/AgentBlazor.Demo.csproj -c Release --no-restore -nologo -p:RuntimeIdentifier=linux-x64
- npm run test:e2e -- --grep "support inbox"
- git diff --check