### PR TITLE
Add demo container deployment path

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.git
+.github
+.tmp
+.vs
+.vscode
+artifacts
+test-results
+**/bin
+**/obj
+**/TestResults
+**/*.user
+**/*.suo
+**/*.nupkg
+**/*.snupkg
+**/.DS_Store

--- a/.github/workflows/demo-container.yml
+++ b/.github/workflows/demo-container.yml
@@ -2,6 +2,21 @@ name: Demo Container
 
 on:
   workflow_dispatch:
+  pull_request:
+    paths:
+      - Dockerfile
+      - .dockerignore
+      - demo/AgentBlazor.Demo/**
+      - src/AgentBlazor.Core/**
+      - src/AgentBlazor.Hosting/**
+      - src/AgentBlazor.Components/**
+      - src/AgentBlazor.ProviderAdapters/**
+      - src/AgentBlazor.Licensing/**
+      - Directory.Build.props
+      - Directory.Packages.props
+      - NuGet.Config
+      - global.json
+      - .github/workflows/demo-container.yml
   push:
     branches:
       - master
@@ -50,7 +65,7 @@ jobs:
         with:
           context: .
           file: Dockerfile
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: |
             ${{ steps.image.outputs.name }}:${{ github.sha }}
             ${{ steps.image.outputs.name }}:latest

--- a/.github/workflows/demo-container.yml
+++ b/.github/workflows/demo-container.yml
@@ -1,0 +1,56 @@
+name: Demo Container
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+    paths:
+      - Dockerfile
+      - .dockerignore
+      - demo/AgentBlazor.Demo/**
+      - src/AgentBlazor.Core/**
+      - src/AgentBlazor.Hosting/**
+      - src/AgentBlazor.Components/**
+      - src/AgentBlazor.ProviderAdapters/**
+      - src/AgentBlazor.Licensing/**
+      - Directory.Build.props
+      - Directory.Packages.props
+      - NuGet.Config
+      - global.json
+      - .github/workflows/demo-container.yml
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set image name
+        id: image
+        shell: bash
+        run: |
+          owner="$(echo "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')"
+          echo "name=ghcr.io/${owner}/agentblazor-demo" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: |
+            ${{ steps.image.outputs.name }}:${{ github.sha }}
+            ${{ steps.image.outputs.name }}:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+# syntax=docker/dockerfile:1
+
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /src
+
+COPY global.json Directory.Build.props Directory.Packages.props NuGet.Config ./
+COPY src/AgentBlazor.Core/ src/AgentBlazor.Core/
+COPY src/AgentBlazor.ProviderAdapters/ src/AgentBlazor.ProviderAdapters/
+COPY src/AgentBlazor.Licensing/ src/AgentBlazor.Licensing/
+COPY src/AgentBlazor.Hosting/ src/AgentBlazor.Hosting/
+COPY src/AgentBlazor.Components/ src/AgentBlazor.Components/
+COPY demo/AgentBlazor.Demo/ demo/AgentBlazor.Demo/
+
+RUN dotnet restore demo/AgentBlazor.Demo/AgentBlazor.Demo.csproj
+RUN dotnet publish demo/AgentBlazor.Demo/AgentBlazor.Demo.csproj \
+    --configuration Release \
+    --no-restore \
+    --output /app/publish \
+    /p:UseAppHost=false
+
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
+WORKDIR /app
+
+ENV ASPNETCORE_ENVIRONMENT=Production \
+    ASPNETCORE_URLS=http://+:8080 \
+    DOTNET_EnableDiagnostics=0
+
+EXPOSE 8080
+
+COPY --from=build /app/publish .
+
+ENTRYPOINT ["dotnet", "AgentBlazor.Demo.dll"]

--- a/docs/deployment/demo-container-apps.md
+++ b/docs/deployment/demo-container-apps.md
@@ -1,0 +1,92 @@
+# Deploy The Demo
+
+Recommended low-cost host: Azure Container Apps Consumption, using a public GHCR image. This keeps the demo on a scale-to-zero container platform, avoids an Azure Container Registry monthly charge, supports WebSockets for Blazor Server, and supports managed TLS for a custom subdomain.
+
+Use `demo.agentblazor.com` for the live demo. Keep `agentblazor.com` free for the landing page.
+
+## 1. Build The Image
+
+Run the `Demo Container` GitHub Actions workflow. It publishes:
+
+```text
+ghcr.io/ashpeterson/agentblazor-demo:latest
+ghcr.io/ashpeterson/agentblazor-demo:<commit-sha>
+```
+
+If the package is private after the first run, make it public in GitHub Packages before deploying to Azure Container Apps.
+
+## 2. Deploy To Azure
+
+Prerequisites:
+
+```bash
+az login
+az account set --subscription "<subscription-id-or-name>"
+```
+
+Deploy:
+
+```bash
+export OPENAI_API_KEY="<live-demo-openai-key>"
+export AGENTBLAZOR_DEMO_IMAGE="ghcr.io/ashpeterson/agentblazor-demo:latest"
+
+./scripts/deploy/azure-container-apps-demo.sh
+```
+
+The script creates or updates:
+
+```text
+Resource group: agentblazor-demo-rg
+Container Apps environment: agentblazor-demo-env
+Container app: agentblazor-demo
+Ingress: external, target port 8080
+Scale: 0-2 replicas
+Secret: openai-api-key
+Rate limit: 20 agent requests per client IP per minute
+```
+
+The script prints the generated Azure hostname. Smoke test it before adding DNS:
+
+```bash
+curl -I "https://<generated-hostname>"
+```
+
+## 3. Add The Domain
+
+Start with `demo.agentblazor.com`, not the apex domain.
+
+In the Azure portal:
+
+1. Open `agentblazor-demo`.
+2. Go to `Settings` -> `Custom domains`.
+3. Add `demo.agentblazor.com`.
+4. Choose `Managed certificate`.
+5. Add the DNS records Azure gives you at your domain registrar.
+
+For a subdomain, Azure Container Apps expects a direct CNAME to the generated Container Apps hostname. If the domain is on Cloudflare, set the record to DNS-only while Azure issues the managed certificate.
+
+## 4. Production Settings
+
+Keep these enabled for the public demo:
+
+```text
+ASPNETCORE_ENVIRONMENT=Production
+OPENAI_API_KEY=secretref:openai-api-key
+OpenAI__Model=gpt-4o-mini
+DemoSecurity__TrustForwardedHeaders=true
+DemoSecurity__RateLimiting__PermitLimit=20
+DemoSecurity__RateLimiting__WindowSeconds=60
+```
+
+Do not set `AgentBlazor:LicenseKey` for the public v1 demo unless you intentionally want Pro surfaces visible.
+
+## Rollback
+
+Redeploy a known-good image tag:
+
+```bash
+export OPENAI_API_KEY="<live-demo-openai-key>"
+export AGENTBLAZOR_DEMO_IMAGE="ghcr.io/ashpeterson/agentblazor-demo:<commit-sha>"
+
+./scripts/deploy/azure-container-apps-demo.sh
+```

--- a/scripts/deploy/azure-container-apps-demo.sh
+++ b/scripts/deploy/azure-container-apps-demo.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${OPENAI_API_KEY:?Set OPENAI_API_KEY before deploying.}"
+: "${AGENTBLAZOR_DEMO_IMAGE:?Set AGENTBLAZOR_DEMO_IMAGE, for example ghcr.io/ashpeterson/agentblazor-demo:latest.}"
+
+RESOURCE_GROUP="${RESOURCE_GROUP:-agentblazor-demo-rg}"
+LOCATION="${LOCATION:-uksouth}"
+ENVIRONMENT_NAME="${ENVIRONMENT_NAME:-agentblazor-demo-env}"
+CONTAINER_APP_NAME="${CONTAINER_APP_NAME:-agentblazor-demo}"
+OPENAI_MODEL="${OPENAI_MODEL:-gpt-4o-mini}"
+RATE_LIMIT_PER_MINUTE="${RATE_LIMIT_PER_MINUTE:-20}"
+
+az extension add --name containerapp --upgrade >/dev/null
+
+az group create \
+  --name "$RESOURCE_GROUP" \
+  --location "$LOCATION" \
+  --output none
+
+if ! az containerapp env show --name "$ENVIRONMENT_NAME" --resource-group "$RESOURCE_GROUP" >/dev/null 2>&1; then
+  az containerapp env create \
+    --name "$ENVIRONMENT_NAME" \
+    --resource-group "$RESOURCE_GROUP" \
+    --location "$LOCATION" \
+    --output none
+fi
+
+if az containerapp show --name "$CONTAINER_APP_NAME" --resource-group "$RESOURCE_GROUP" >/dev/null 2>&1; then
+  az containerapp secret set \
+    --name "$CONTAINER_APP_NAME" \
+    --resource-group "$RESOURCE_GROUP" \
+    --secrets openai-api-key="$OPENAI_API_KEY" \
+    --output none
+
+  az containerapp update \
+    --name "$CONTAINER_APP_NAME" \
+    --resource-group "$RESOURCE_GROUP" \
+    --image "$AGENTBLAZOR_DEMO_IMAGE" \
+    --set-env-vars \
+      ASPNETCORE_ENVIRONMENT=Production \
+      OPENAI_API_KEY=secretref:openai-api-key \
+      OpenAI__Model="$OPENAI_MODEL" \
+      DemoSecurity__TrustForwardedHeaders=true \
+      DemoSecurity__RateLimiting__PermitLimit="$RATE_LIMIT_PER_MINUTE" \
+      DemoSecurity__RateLimiting__WindowSeconds=60 \
+    --output none
+else
+  az containerapp create \
+    --name "$CONTAINER_APP_NAME" \
+    --resource-group "$RESOURCE_GROUP" \
+    --environment "$ENVIRONMENT_NAME" \
+    --image "$AGENTBLAZOR_DEMO_IMAGE" \
+    --ingress external \
+    --target-port 8080 \
+    --min-replicas 0 \
+    --max-replicas 2 \
+    --cpu 0.5 \
+    --memory 1Gi \
+    --secrets openai-api-key="$OPENAI_API_KEY" \
+    --env-vars \
+      ASPNETCORE_ENVIRONMENT=Production \
+      OPENAI_API_KEY=secretref:openai-api-key \
+      OpenAI__Model="$OPENAI_MODEL" \
+      DemoSecurity__TrustForwardedHeaders=true \
+      DemoSecurity__RateLimiting__PermitLimit="$RATE_LIMIT_PER_MINUTE" \
+      DemoSecurity__RateLimiting__WindowSeconds=60 \
+    --output none
+fi
+
+az containerapp show \
+  --name "$CONTAINER_APP_NAME" \
+  --resource-group "$RESOURCE_GROUP" \
+  --query "properties.configuration.ingress.fqdn" \
+  --output tsv


### PR DESCRIPTION
## Summary
- add a production Dockerfile for the AgentBlazor demo
- add a GHCR image publishing workflow for the demo container
- document and script the Azure Container Apps deployment path for demo.agentblazor.com

## Validation
- dotnet publish demo/AgentBlazor.Demo/AgentBlazor.Demo.csproj -c Release -o /tmp/agentblazor-demo-publish /p:UseAppHost=false
- bash -n scripts/deploy/azure-container-apps-demo.sh
- git diff --check

Docker is not installed in this environment, so the container build itself needs to run in GitHub Actions.