### PR TITLE
Harden approval continuation handling

### DIFF
--- a/src/AgentBlazor.Components/Chat/AgentChatBar.razor
+++ b/src/AgentBlazor.Components/Chat/AgentChatBar.razor
@@ -522,7 +522,7 @@
             {
                 var result = streamEvent.ExecutionResult;
                 var key = BuildActivityKey(result.ComponentId, result.ActionId);
-                var status = result.Succeeded ? ActionStatus.Complete : ActionStatus.Failed;
+                var status = MapExecutionResultStatus(result);
                 AddStreamingActivityMessage(
                     new ActivityMessage(
                         key,
@@ -815,6 +815,14 @@
             : $"Failed {executionResult.ComponentId}.{executionResult.ActionId}.";
     }
 
+    private static ActionStatus MapExecutionResultStatus(ComponentActionExecutionResult executionResult)
+        => executionResult.Outcome switch
+        {
+            ActionOutcome.Applied => ActionStatus.Complete,
+            ActionOutcome.Queued => ActionStatus.InProgress,
+            _ => ActionStatus.Failed
+        };
+
     private IDictionary<string, string>? CreateRequestContext()
     {
         var context = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
@@ -979,7 +987,7 @@
         {
             var key = BuildActivityKey(result.ComponentId, result.ActionId);
             var text = FormatToolCallResultMessage(result);
-            var status = result.Succeeded ? ActionStatus.Complete : ActionStatus.Failed;
+            var status = MapExecutionResultStatus(result);
             messages.Add(new ActivityMessage(
                 key,
                 text,

--- a/src/AgentBlazor.Components/Chat/AgentChatSurface.razor
+++ b/src/AgentBlazor.Components/Chat/AgentChatSurface.razor
@@ -168,6 +168,7 @@
                             <AgentGenerativeSurface Document="@item.GeneratedUi"
                                                     AgentName="@item.RoleLabel"
                                                     SessionId="@EffectiveSessionId"
+                                                    BaseContext="@CreateRequestContext()"
                                                     ForwardActionsToRuntime="true"
                                                     ShowRuntimeResponses="false"
                                                     OnActionInvoked="HandleGeneratedActionInvokedAsync"
@@ -984,18 +985,20 @@
         if (_isBusy || _pendingApprovals.Count == 0)
             return;
 
-        var approvalKeys = _pendingApprovals
-            .Select(static approval => $"{approval.ComponentId}.{approval.ActionId}")
+        var approvalIds = _pendingApprovals
+            .Select(static approval => approval.ApprovalId)
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToArray();
         var approvalContext = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
-            ["agentblazor.approvals"] = string.Join(",", approvalKeys)
+            ["agentblazor.approvals"] = string.Join(",", approvalIds)
         };
         foreach (var approval in _pendingApprovals)
         {
-            var approvalKey = $"{approval.ComponentId}.{approval.ActionId}";
-            approvalContext[$"agentblazor.approvalArgs.{approvalKey}"] = JsonSerializer.Serialize(approval.Parameters);
+            var approvalTarget = PendingApprovalIds.BuildTargetKey(approval.ComponentId, approval.ActionId);
+            approvalContext[$"agentblazor.approval.{approval.ComponentId}.{approval.ActionId}"] = bool.TrueString;
+            approvalContext[$"agentblazor.approvalTarget.{approval.ApprovalId}"] = approvalTarget;
+            approvalContext[$"agentblazor.approvalArgs.{approval.ApprovalId}"] = JsonSerializer.Serialize(approval.Parameters);
         }
         
         _timeline.Add(ChatTimelineItem.User("Approved"));
@@ -1015,14 +1018,15 @@
         try
         {
             var approvalMessage =
-                $"Approved. Continue by invoking the approved action(s): {string.Join(", ", approvalKeys)}. " +
+                $"Approved. Continue by invoking the approved action(s): {string.Join(", ", approvalIds)}. " +
                 "Do not request approval again for these action(s); execute the approved tool call(s) now and summarize the result.";
             var conversationTurnCountBefore = await GetConversationTurnCountAsync();
             var turnOutcome = await RunTurnWithOptionalStreamingAsync(new AgentTurnRequest(
                 approvalMessage,
                 _selectedAgent,
                 SessionId: EffectiveSessionId,
-                Context: CreateRequestContext(approvalContext)));
+                Context: CreateRequestContext(approvalContext),
+                ApprovalContinuation: new AgentApprovalContinuation(approvalIds)));
             turnOutcome = EnrichApprovalOutcome(turnOutcome);
             await ApplyTurnOutcomeAsync(approvalMessage, turnOutcome, conversationTurnCountBefore);
             _scrollRequested = true;
@@ -1200,7 +1204,7 @@
                     streamEvent.ExecutionResult is not null)
                 {
                     var resultKey = BuildActivityKey(streamEvent.ExecutionResult.ComponentId, streamEvent.ExecutionResult.ActionId);
-                    var resultStatus = streamEvent.ExecutionResult.Succeeded ? ActionStatus.Complete : ActionStatus.Failed;
+                    var resultStatus = MapExecutionResultStatus(streamEvent.ExecutionResult);
                     AddStreamingActivityMessage(
                         new ActivityMessage(
                             resultKey,
@@ -1515,6 +1519,7 @@
                 approval.ActionId);
 
             return new PendingApprovalInfo(
+                PendingApprovalIds.Resolve(approval),
                 approval.ComponentId,
                 approval.ActionId,
                 approval.Description,
@@ -1739,7 +1744,7 @@
         ChatTimelineItem item,
         ComponentActionExecutionResult result)
     {
-        var status = result.Succeeded ? ActionStatus.Complete : ActionStatus.Failed;
+        var status = MapExecutionResultStatus(result);
         var args = FindActionArguments(item.LegacyPlannedActions, result.ComponentId, result.ActionId);
         return new ActionRenderContext(
             result.ComponentId,
@@ -1810,6 +1815,14 @@
             ? $"Completed {executionResult.ComponentId}.{executionResult.ActionId}."
             : $"Failed {executionResult.ComponentId}.{executionResult.ActionId}.";
     }
+
+    private static ActionStatus MapExecutionResultStatus(ComponentActionExecutionResult executionResult)
+        => executionResult.Outcome switch
+        {
+            ActionOutcome.Applied => ActionStatus.Complete,
+            ActionOutcome.Queued => ActionStatus.InProgress,
+            _ => ActionStatus.Failed
+        };
 
     private static string FormatExecutionStepActivity(AgentExecutionStep step)
     {
@@ -2880,6 +2893,7 @@
     private sealed record PendingHandoffRequest(string FromAgent, string ToAgent, string? TargetRoute);
     private sealed record PendingClarificationInfo(string Question, string OriginalMessage);
     private sealed record PendingApprovalInfo(
+        string ApprovalId,
         string ComponentId,
         string ActionId,
         string Description,

--- a/src/AgentBlazor.Components/GenerativeUI/AgentGenerativeSurface.razor
+++ b/src/AgentBlazor.Components/GenerativeUI/AgentGenerativeSurface.razor
@@ -81,7 +81,13 @@
     public string? SessionId { get; set; }
 
     [Parameter]
+    public IDictionary<string, string>? BaseContext { get; set; }
+
+    [Parameter]
     public bool ForwardActionsToRuntime { get; set; }
+
+    [Parameter]
+    public bool AllowApprovalRequestsFromForwardedActions { get; set; }
 
     [Parameter]
     public bool ShowRuntimeResponses { get; set; } = true;
@@ -230,12 +236,12 @@
         try
         {
             _isBusy = true;
-            var runtimeContext = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-            {
-                [AgentGenerativeUiSpec.GenerateUiContextKey] = bool.TrueString,
-                [AgentGenerativeUiSpec.BlockIdContextKey] = blockId,
-                [AgentGenerativeUiSpec.ActionIdContextKey] = action.Id
-            };
+            var runtimeContext = BaseContext is null
+                ? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                : new Dictionary<string, string>(BaseContext, StringComparer.OrdinalIgnoreCase);
+            runtimeContext[AgentGenerativeUiSpec.GenerateUiContextKey] = bool.TrueString;
+            runtimeContext[AgentGenerativeUiSpec.BlockIdContextKey] = blockId;
+            runtimeContext[AgentGenerativeUiSpec.ActionIdContextKey] = action.Id;
             var generatedUiAction = new GeneratedUiActionInvocation(
                 BlockId: blockId,
                 ActionId: action.Id,
@@ -248,6 +254,17 @@
                 SessionId: EffectiveSessionId,
                 Context: runtimeContext,
                 GeneratedUiAction: generatedUiAction));
+            if (response.RequiresApproval && !AllowApprovalRequestsFromForwardedActions)
+            {
+                response = new AgentTurnResponse(
+                    response.AgentName,
+                    "Generated UI action was blocked because it requested approval-gated actions. Ask for the action in chat to review and approve it.",
+                    [],
+                    [])
+                {
+                    ExecutionPlan = response.ExecutionPlan
+                };
+            }
 
             if (ShowRuntimeResponses)
             {

--- a/src/AgentBlazor.Core/Runtime/Adapters/ChatClientRuntimeAdapter.cs
+++ b/src/AgentBlazor.Core/Runtime/Adapters/ChatClientRuntimeAdapter.cs
@@ -537,12 +537,7 @@ public sealed class ChatClientRuntimeAdapter(
             return false;
         }
 
-        var approvedKeys = ResolveApprovedActionKeys(request.Context);
-        if (approvedKeys.Count == 0)
-        {
-            return false;
-        }
-
+        var approvedActions = ResolveApprovedActionContinuations(request.Context);
         var executionServiceProvider = ResolveExecutionServiceProvider();
         if (executionServiceProvider is null)
         {
@@ -553,63 +548,85 @@ public sealed class ChatClientRuntimeAdapter(
             .GetActions(executionServiceProvider)
             .Where(capability =>
                 capability.RequiresApproval &&
-                IsCapabilityToolAllowed(registration, capability.ActionId) &&
-                approvedKeys.Contains(BuildApprovalKey(capability.CapabilityId, capability.LocalActionId)))
-            .ToArray();
-        if (capabilities.Length == 0)
+                IsCapabilityToolAllowed(registration, capability.ActionId))
+            .ToDictionary(
+                capability => BuildApprovalKey(capability.CapabilityId, capability.LocalActionId),
+                StringComparer.OrdinalIgnoreCase);
+        if (capabilities.Count == 0)
         {
             return false;
         }
 
-        foreach (var capability in capabilities)
+        if (approvedActions.Count == 0 && IsGlobalApprovalContinuation(request.Context))
         {
-            var approvalKey = BuildApprovalKey(capability.CapabilityId, capability.LocalActionId);
-            var approvalArguments = ResolveApprovedActionArguments(request.Context, approvalKey);
+            approvedActions = capabilities.Keys
+                .Select(static targetKey => new ApprovedActionContinuation(
+                    targetKey,
+                    targetKey,
+                    new Dictionary<string, object?>()))
+                .ToArray();
+        }
+
+        if (approvedActions.Count == 0)
+        {
+            return false;
+        }
+
+        var executed = false;
+        foreach (var approvedAction in approvedActions)
+        {
+            if (!capabilities.TryGetValue(approvedAction.TargetKey, out var capability))
+            {
+                continue;
+            }
+
             await InvokeCapabilityAsync(
                     capability,
-                    new AIFunctionArguments(approvalArguments),
+                    new AIFunctionArguments(approvedAction.Arguments),
                     turnState,
                     cancellationToken)
                 .ConfigureAwait(false);
+            executed = true;
         }
 
-        return true;
+        return executed;
     }
 
     private static bool IsApprovalContinuationRequest(AgentTurnRequest request)
-        => request.Context is not null &&
+        => request.ApprovalContinuation is not null ||
+           request.Context is not null &&
            request.UserMessage.StartsWith("Approved.", StringComparison.OrdinalIgnoreCase);
 
-    private static HashSet<string> ResolveApprovedActionKeys(IDictionary<string, string>? context)
+    private static IReadOnlyList<ApprovedActionContinuation> ResolveApprovedActionContinuations(
+        IDictionary<string, string>? context)
     {
-        var keys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var actions = new List<ApprovedActionContinuation>();
         if (context is null ||
             !context.TryGetValue("agentblazor.approvals", out var approvals) ||
             string.IsNullOrWhiteSpace(approvals))
         {
-            return keys;
+            return actions;
         }
 
         if (IsGlobalApprovalValue(approvals))
         {
-            AddApprovalArgumentKeys(context, keys);
-            return keys;
+            foreach (var approvalId in EnumerateApprovalArgumentIds(context))
+            {
+                actions.Add(BuildApprovedActionContinuation(context, approvalId));
+            }
+
+            return DeduplicateApprovedActions(actions);
         }
 
         foreach (var entry in approvals.Split([',', ';'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
         {
-            if (entry.Contains('.', StringComparison.Ordinal))
-            {
-                keys.Add(entry);
-            }
+            actions.Add(BuildApprovedActionContinuation(context, entry));
         }
 
-        return keys;
+        return DeduplicateApprovedActions(actions);
     }
 
-    private static void AddApprovalArgumentKeys(
-        IDictionary<string, string> context,
-        ISet<string> keys)
+    private static IEnumerable<string> EnumerateApprovalArgumentIds(IDictionary<string, string> context)
     {
         const string prefix = "agentblazor.approvalArgs.";
         foreach (var key in context.Keys)
@@ -622,22 +639,58 @@ public sealed class ChatClientRuntimeAdapter(
             var approvalKey = key[prefix.Length..];
             if (approvalKey.Contains('.', StringComparison.Ordinal))
             {
-                keys.Add(approvalKey);
+                yield return approvalKey;
             }
         }
     }
+
+    private static ApprovedActionContinuation BuildApprovedActionContinuation(
+        IDictionary<string, string> context,
+        string approvalId)
+    {
+        var targetKey = context.TryGetValue($"agentblazor.approvalTarget.{approvalId}", out var mappedTarget) &&
+                        !string.IsNullOrWhiteSpace(mappedTarget)
+            ? mappedTarget
+            : approvalId.Split('#', 2)[0];
+        return new ApprovedActionContinuation(
+            approvalId,
+            targetKey,
+            ResolveApprovedActionArguments(context, approvalId, targetKey));
+    }
+
+    private static IReadOnlyList<ApprovedActionContinuation> DeduplicateApprovedActions(
+        IReadOnlyList<ApprovedActionContinuation> actions)
+        => actions
+            .Where(static action => action.TargetKey.Contains('.', StringComparison.Ordinal))
+            .GroupBy(static action => action.ApprovalId, StringComparer.OrdinalIgnoreCase)
+            .Select(static group => group.First())
+            .ToArray();
 
     private static string BuildApprovalKey(string componentId, string actionId)
         => $"{componentId}.{actionId}";
 
     private static IDictionary<string, object?> ResolveApprovedActionArguments(
         IDictionary<string, string>? context,
-        string approvalKey)
+        string approvalId,
+        string? legacyApprovalKey = null)
     {
-        if (context is null ||
-            string.IsNullOrWhiteSpace(approvalKey) ||
-            !context.TryGetValue($"agentblazor.approvalArgs.{approvalKey}", out var rawArguments) ||
+        if (context is null || string.IsNullOrWhiteSpace(approvalId))
+        {
+            return new Dictionary<string, object?>();
+        }
+
+        if (!context.TryGetValue($"agentblazor.approvalArgs.{approvalId}", out var rawArguments) ||
             string.IsNullOrWhiteSpace(rawArguments))
+        {
+            if (string.IsNullOrWhiteSpace(legacyApprovalKey) ||
+                !context.TryGetValue($"agentblazor.approvalArgs.{legacyApprovalKey}", out rawArguments) ||
+                string.IsNullOrWhiteSpace(rawArguments))
+            {
+                return new Dictionary<string, object?>();
+            }
+        }
+
+        if (rawArguments is null)
         {
             return new Dictionary<string, object?>();
         }
@@ -660,6 +713,16 @@ public sealed class ChatClientRuntimeAdapter(
            value.Equals("allow", StringComparison.OrdinalIgnoreCase) ||
            value.Equals("approved", StringComparison.OrdinalIgnoreCase) ||
            value.Equals("all", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsGlobalApprovalContinuation(IDictionary<string, string>? context)
+        => context is not null &&
+           context.TryGetValue("agentblazor.approvals", out var approvals) &&
+           IsGlobalApprovalValue(approvals);
+
+    private sealed record ApprovedActionContinuation(
+        string ApprovalId,
+        string TargetKey,
+        IDictionary<string, object?> Arguments);
 
     private static async Task EmitDrainedTurnEventsAsync(
         TurnExecutionState turnState,
@@ -1254,7 +1317,8 @@ public sealed class ChatClientRuntimeAdapter(
                 capability.ActionId,
                 capability.Description,
                 invocationArguments,
-                policyDecision);
+                policyDecision,
+                PendingApprovalIds.Create(componentId, capability.ActionId, invocationArguments));
             turnState?.AddPendingApproval(approval);
             if (stepIndex is int approvalStepIndex && turnState is not null)
             {
@@ -1434,7 +1498,8 @@ public sealed class ChatClientRuntimeAdapter(
                 capability.LocalActionId,
                 capability.Description,
                 invocationArguments,
-                policyDecision);
+                policyDecision,
+                PendingApprovalIds.Create(capability.CapabilityId, capability.LocalActionId, invocationArguments));
             turnState?.AddPendingApproval(approval);
             if (stepIndex is int approvalStepIndex && turnState is not null)
             {
@@ -3112,6 +3177,13 @@ public sealed class ChatClientRuntimeAdapter(
         {
             lock (_gate)
             {
+                var approvalId = PendingApprovalIds.Resolve(approval);
+                if (_pendingApprovals.Any(existing =>
+                    string.Equals(PendingApprovalIds.Resolve(existing), approvalId, StringComparison.OrdinalIgnoreCase)))
+                {
+                    return;
+                }
+
                 _pendingApprovals.Add(approval);
             }
         }

--- a/src/AgentBlazor.Core/Runtime/Agents/AgentTurnRequest.cs
+++ b/src/AgentBlazor.Core/Runtime/Agents/AgentTurnRequest.cs
@@ -9,13 +9,15 @@ namespace AgentBlazor.Core.Runtime.Agents;
 /// <param name="UserId">Optional user identifier for cross-session preferences.</param>
 /// <param name="Context">Optional context dictionary.</param>
 /// <param name="GeneratedUiAction">Optional typed generated-UI action invocation metadata.</param>
+/// <param name="ApprovalContinuation">Optional typed approval continuation metadata.</param>
 public sealed record AgentTurnRequest(
     string UserMessage,
     string? AgentName = null,
     string? SessionId = null,
     string? UserId = null,
     IDictionary<string, string>? Context = null,
-    GeneratedUiActionInvocation? GeneratedUiAction = null)
+    GeneratedUiActionInvocation? GeneratedUiAction = null,
+    AgentApprovalContinuation? ApprovalContinuation = null)
 {
     /// <summary>
     /// Gets the effective session ID, using the context value if SessionId is not set.
@@ -66,3 +68,9 @@ public sealed record GeneratedUiActionInvocation(
     string ActionId,
     string? Prompt,
     IReadOnlyDictionary<string, object?> Payload);
+
+/// <summary>
+/// Typed approval continuation metadata forwarded by first-party AgentBlazor UI.
+/// </summary>
+public sealed record AgentApprovalContinuation(
+    IReadOnlyList<string> ApprovalIds);

--- a/src/AgentBlazor.Core/Runtime/Agents/AgentTurnResponse.cs
+++ b/src/AgentBlazor.Core/Runtime/Agents/AgentTurnResponse.cs
@@ -33,4 +33,5 @@ public sealed record PendingApproval(
     string ActionId,
     string Description,
     IReadOnlyDictionary<string, object?> Parameters,
-    AgentPolicyDecision? PolicyDecision = null);
+    AgentPolicyDecision? PolicyDecision = null,
+    string? ApprovalId = null);

--- a/src/AgentBlazor.Core/Runtime/Agents/PendingApprovalIds.cs
+++ b/src/AgentBlazor.Core/Runtime/Agents/PendingApprovalIds.cs
@@ -1,0 +1,39 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+
+namespace AgentBlazor.Core.Runtime.Agents;
+
+public static class PendingApprovalIds
+{
+    public static string Resolve(PendingApproval approval)
+        => !string.IsNullOrWhiteSpace(approval.ApprovalId)
+            ? approval.ApprovalId
+            : Create(approval.ComponentId, approval.ActionId, approval.Parameters);
+
+    public static string Create(
+        string componentId,
+        string actionId,
+        IReadOnlyDictionary<string, object?> parameters)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(componentId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(actionId);
+
+        var canonicalParameters = parameters
+            .OrderBy(static pair => pair.Key, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(
+                static pair => pair.Key,
+                static pair => pair.Value,
+                StringComparer.OrdinalIgnoreCase);
+        var serialized = JsonSerializer.Serialize(canonicalParameters);
+        var hash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(serialized)))[..16].ToLowerInvariant();
+        return $"{componentId}.{actionId}#{hash}";
+    }
+
+    public static string BuildTargetKey(string componentId, string actionId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(componentId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(actionId);
+        return $"{componentId}.{actionId}";
+    }
+}

--- a/src/AgentBlazor.Core/Runtime/ExecutionPlans/RuntimePlanApprovals.cs
+++ b/src/AgentBlazor.Core/Runtime/ExecutionPlans/RuntimePlanApprovals.cs
@@ -57,7 +57,8 @@ internal static class RuntimePlanApprovals
                 step.ActionId,
                 action.Description,
                 step.Arguments.ToDictionary(kv => kv.Key, kv => kv.Value, StringComparer.OrdinalIgnoreCase),
-                RuntimeTrustDecisions.BuildPolicyDecision(step.ComponentId, step.ActionId, requiresApproval: true)));
+                RuntimeTrustDecisions.BuildPolicyDecision(step.ComponentId, step.ActionId, requiresApproval: true),
+                PendingApprovalIds.Create(step.ComponentId, step.ActionId, step.Arguments)));
         }
 
         return pending;

--- a/tests/AgentBlazor.Components.Tests/AgentChatSurfaceTests.cs
+++ b/tests/AgentBlazor.Components.Tests/AgentChatSurfaceTests.cs
@@ -327,8 +327,12 @@ public sealed class AgentChatSurfaceTests : TestContext
             if (IsApprovalMessage(request.UserMessage))
             {
                 Assert.NotNull(request.Context);
-                Assert.True(
-                    request.Context.TryGetValue("agentblazor.approvalArgs.runtime_probe.run_approval_probe", out var rawArguments),
+                var rawArguments = request.Context
+                    .Where(static pair => pair.Key.StartsWith("agentblazor.approvalArgs.", StringComparison.OrdinalIgnoreCase))
+                    .Select(static pair => pair.Value)
+                    .SingleOrDefault();
+                Assert.False(
+                    string.IsNullOrWhiteSpace(rawArguments),
                     "Approval continuation should include the original pending approval parameters.");
                 using var document = JsonDocument.Parse(rawArguments);
                 Assert.Equal("TCK-1042", document.RootElement.GetProperty("ticketId").GetString());

--- a/tests/AgentBlazor.Core.Tests/RuntimeAdapterCapabilityProjectionTests.cs
+++ b/tests/AgentBlazor.Core.Tests/RuntimeAdapterCapabilityProjectionTests.cs
@@ -404,6 +404,73 @@ public class RuntimeAdapterCapabilityProjectionTests
     }
 
     [Fact]
+    public async Task ChatClientRuntimeAdapter_ApprovalContinuation_PreservesMultipleApprovalArgumentsForSameAction()
+    {
+        var services = new ServiceCollection();
+        var chatClient = new ThrowingChatClient();
+        services.AddSingleton<IChatClient>(chatClient);
+        services.AddAgentBlazorServices()
+            .UseChatClientRuntimeAdapter()
+            .AddCapability<ApprovalCapabilities>()
+            .AddAgent("approval-agent", agent =>
+            {
+                agent.WithAllowedActions("approval_workflow.create_change_request");
+            });
+
+        await using var provider = services.BuildServiceProvider();
+
+        var adapter = provider.GetRequiredService<IAgentRuntimeAdapter>();
+        var response = await adapter.RunTurnAsync(new AgentTurnRequest(
+            "Approved.",
+            AgentName: "approval-agent",
+            SessionId: "approval-direct-multiple",
+            Context: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["agentblazor.approvals"] =
+                    "approval_workflow.create_change_request#a,approval_workflow.create_change_request#b",
+                ["agentblazor.approval.approval_workflow.create_change_request"] = "true",
+                ["agentblazor.approvalTarget.approval_workflow.create_change_request#a"] =
+                    "approval_workflow.create_change_request",
+                ["agentblazor.approvalTarget.approval_workflow.create_change_request#b"] =
+                    "approval_workflow.create_change_request",
+                ["agentblazor.approvalArgs.approval_workflow.create_change_request#a"] =
+                    """{"name":"CAB-1"}""",
+                ["agentblazor.approvalArgs.approval_workflow.create_change_request#b"] =
+                    """{"name":"CAB-2"}"""
+            },
+            ApprovalContinuation: new AgentApprovalContinuation(
+            [
+                "approval_workflow.create_change_request#a",
+                "approval_workflow.create_change_request#b"
+            ])));
+
+        Assert.Equal(0, chatClient.CallCount);
+        Assert.False(response.RequiresApproval);
+        Assert.Equal(2, response.ExecutionPlan!.Steps.Count);
+        Assert.Contains(response.ExecutionPlan.Steps, static step =>
+            step.Message?.Contains("CAB-1", StringComparison.Ordinal) == true);
+        Assert.Contains(response.ExecutionPlan.Steps, static step =>
+            step.Message?.Contains("CAB-2", StringComparison.Ordinal) == true);
+    }
+
+    [Fact]
+    public void PendingApprovalIds_CreateDistinctIdsForSameActionWithDifferentArguments()
+    {
+        var first = PendingApprovalIds.Create(
+            "support_inbox",
+            "draft_ticket_reply_for_ticket",
+            new Dictionary<string, object?> { ["ticketId"] = "TCK-1042" });
+        var second = PendingApprovalIds.Create(
+            "support_inbox",
+            "draft_ticket_reply_for_ticket",
+            new Dictionary<string, object?> { ["ticketId"] = "TCK-1048" });
+
+        Assert.StartsWith("support_inbox.draft_ticket_reply_for_ticket#", first, StringComparison.Ordinal);
+        Assert.StartsWith("support_inbox.draft_ticket_reply_for_ticket#", second, StringComparison.Ordinal);
+        Assert.NotEqual(first, second);
+    }
+
+    [Fact]
     public async Task ChatClientRuntimeAdapter_StreamingApprovalContinuation_EmitsApprovedCapabilityEventsWithoutModelRoundTrip()
     {
         var services = new ServiceCollection();


### PR DESCRIPTION
## Summary
- add stable approval IDs so multiple approvals for the same action preserve separate arguments
- execute approval continuations by approval ID/target mapping while keeping legacy approval context support
- dedupe pending approvals by approval ID
- prevent generated UI forwarded actions from introducing approval chains by default
- preserve chat route/context when generated UI actions call back into the runtime
- keep queued UI actions visually pending instead of complete in chat surfaces

## Validation
- dotnet build AgentBlazor.slnx --no-restore
- dotnet test tests/AgentBlazor.Core.Tests/AgentBlazor.Core.Tests.csproj --filter "RuntimeAdapterCapabilityProjectionTests|RuntimePlanApprovalsTests"
- dotnet test tests/AgentBlazor.Components.Tests/AgentBlazor.Components.Tests.csproj --filter "AgentChatSurfaceTests"
- env -u OPENAI_API_KEY -u OpenAI__ApiKey dotnet test AgentBlazor.slnx --no-build

## Notes
- With a live OPENAI_API_KEY in the shell, the existing live OpenAI recovery integration test still failed once with an approval-required response. CI normally runs without that key, so the suite passes with live provider tests skipped.