### PR TITLE
Add scalable demo scenario launchpad

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Render one chat surface:
 
 - Home quickstart: `/`
 - Docs: `/docs`
-- Live demo: `/demo/workflows/support-inbox`
+- Live demo: `/demo`
 - Starter sample: `samples/AgentBlazor.Starter`
 - Starter sample route: `/ops-review`
 

--- a/demo/AgentBlazor.Demo/Components/Layout/DemoLayout.razor
+++ b/demo/AgentBlazor.Demo/Components/Layout/DemoLayout.razor
@@ -1,6 +1,7 @@
 @inherits LayoutComponentBase
 @using AgentBlazor.Components
 @using AgentBlazor.Components.Chat
+@using AgentBlazor.Demo.Services
 @using Microsoft.JSInterop
 @using MudBlazor
 @implements IDisposable
@@ -138,22 +139,14 @@
     private const int MaxAssistantClientIdLoadAttempts = 8;
 
     private string CurrentRoutePath => new Uri(NavigationManager.Uri).AbsolutePath;
+    private DemoScenario? CurrentScenario => DemoScenarioCatalog.FindByPath(CurrentRoutePath);
     private string AssistantSessionId => $"demo:{_assistantClientId}:{CurrentRoutePath.TrimEnd('/').ToLowerInvariant()}";
 
-    private bool IsWorkflowHubRoute => string.Equals(CurrentRoutePath.TrimEnd('/'), "/demo", StringComparison.OrdinalIgnoreCase);
     private bool IsComponentsRoute => CurrentRoutePath.StartsWith("/demo/components", StringComparison.OrdinalIgnoreCase);
     private bool IsWorkflowRoute => CurrentRoutePath.StartsWith("/demo/workflows", StringComparison.OrdinalIgnoreCase);
     private bool IsSupportInboxRoute => CurrentRoutePath.StartsWith("/demo/workflows/support-inbox", StringComparison.OrdinalIgnoreCase);
-    private bool IsDashboardRoute => CurrentRoutePath.StartsWith("/demo/dashboard", StringComparison.OrdinalIgnoreCase);
-    private bool IsSupplierWorkflowRoute => CurrentRoutePath.StartsWith("/demo/workflows/supplier-compliance", StringComparison.OrdinalIgnoreCase);
-    private bool IsFileWorkflowRoute => CurrentRoutePath.StartsWith("/demo/workflows/file-audit-bundle", StringComparison.OrdinalIgnoreCase);
-    private bool IsRecipeWorkflowRoute => CurrentRoutePath.StartsWith("/demo/workflows/recipe-release", StringComparison.OrdinalIgnoreCase);
-    private bool IsIncidentWorkflowRoute => CurrentRoutePath.StartsWith("/demo/workflows/incident-escalation", StringComparison.OrdinalIgnoreCase);
-    private bool IsResponseOrchestrationRoute => CurrentRoutePath.StartsWith("/demo/workflows/response-orchestration", StringComparison.OrdinalIgnoreCase);
-    private bool IsReleaseDossierRoute => CurrentRoutePath.StartsWith("/demo/workflows/release-dossier", StringComparison.OrdinalIgnoreCase);
-    private bool IsRuntimeProbeRoute => CurrentRoutePath.StartsWith("/demo/workflows/runtime-probe", StringComparison.OrdinalIgnoreCase);
 
-    private bool ShowAssistantPane => IsWorkflowRoute && !IsComponentsRoute && !IsSupportInboxRoute;
+    private bool ShowAssistantPane => CurrentScenario is not null && IsWorkflowRoute && !IsComponentsRoute && !IsSupportInboxRoute;
     private bool ShowAssistantWidget => !ShowAssistantPane;
 
     private string AssistantWidgetWidth =>
@@ -169,89 +162,13 @@
     private string AssistantWidgetRight => "0.85rem";
     private string AssistantWidgetBottom => "0.85rem";
 
-    private string AssistantTitle =>
-        IsWorkflowHubRoute
-            ? "Demo assistant"
-            : IsSupportInboxRoute
-            ? "Support assistant"
-            : IsResponseOrchestrationRoute
-            ? "Response assistant"
-            : IsReleaseDossierRoute
-                ? "Release assistant"
-                : IsSupplierWorkflowRoute
-                    ? "Supplier assistant"
-                    : IsFileWorkflowRoute
-                        ? "Evidence assistant"
-                        : IsRecipeWorkflowRoute
-                            ? "Recipe assistant"
-                            : IsIncidentWorkflowRoute
-                                ? "Incident assistant"
-                                : IsRuntimeProbeRoute
-                                    ? "Runtime probe assistant"
-                                : "Workflow assistant";
+    private string AssistantTitle => CurrentScenario?.AssistantTitle ?? "Workflow assistant";
 
-    private string AssistantDescription =>
-        IsWorkflowHubRoute
-            ? "Open the main flow first."
-            : IsSupportInboxRoute
-            ? "Find tickets, explain the queue, draft a reply."
-            : IsResponseOrchestrationRoute
-            ? "Assess, advance, recover, prepare."
-            : IsReleaseDossierRoute
-                ? "Assess, advance, recover, prepare."
-                : IsSupplierWorkflowRoute
-                    ? "Review risk, clear blockers, prepare."
-                    : IsFileWorkflowRoute
-                        ? "Prepare, recover, retry."
-                        : IsRecipeWorkflowRoute
-                            ? "Assess, recover, stage."
-                            : IsIncidentWorkflowRoute
-                                ? "Triage, recover, hand off."
-                                : IsRuntimeProbeRoute
-                                    ? "Run the cancellation probe, then stop it."
-                                : "Ask for the next step.";
+    private string AssistantDescription => CurrentScenario?.AssistantDescription ?? "Ask for the next step.";
 
-    private string AssistantPlaceholder =>
-        IsWorkflowHubRoute
-            ? "Open the response flow or the release flow."
-            : IsSupportInboxRoute
-            ? "Show open tickets. Explain the queue. Draft a reply."
-            : IsResponseOrchestrationRoute
-            ? "Assess readiness. Advance next stage. Prepare packet."
-            : IsReleaseDossierRoute
-                ? "Assess readiness. Advance next stage. Prepare dossier."
-                : IsSupplierWorkflowRoute
-                    ? "Explain risk. Recover. Prepare."
-                    : IsFileWorkflowRoute
-                        ? "Explain blockers. Recover. Prepare."
-                        : IsRecipeWorkflowRoute
-                            ? "Assess readiness. Recover. Prepare."
-                            : IsIncidentWorkflowRoute
-                                ? "Summarize triage. Recover. Submit."
-                                : IsRuntimeProbeRoute
-                                    ? "Run the runtime cancellation probe, then stop."
-                                : "What should happen next?";
+    private string AssistantPlaceholder => CurrentScenario?.AssistantPlaceholder ?? "What should happen next?";
 
-    private string? DefaultAssistantAgent =>
-        IsWorkflowHubRoute
-            ? "Workflow Hub Agent"
-            : IsSupportInboxRoute
-            ? "Support Inbox Agent"
-            : IsResponseOrchestrationRoute
-            ? "Response Orchestration Agent"
-            : IsReleaseDossierRoute
-                ? "Release Dossier Agent"
-                : IsSupplierWorkflowRoute
-                    ? "Supplier Compliance Agent"
-                    : IsFileWorkflowRoute
-                        ? "File Workflow Agent"
-                        : IsRecipeWorkflowRoute
-                            ? "Recipe Release Agent"
-                            : IsIncidentWorkflowRoute
-                                ? "Incident Escalation Agent"
-                                : IsRuntimeProbeRoute
-                                    ? "Runtime Probe Agent"
-                                : null;
+    private string? DefaultAssistantAgent => CurrentScenario?.AgentName;
 
     protected override void OnInitialized()
     {

--- a/demo/AgentBlazor.Demo/Components/Layout/DocsLayout.razor
+++ b/demo/AgentBlazor.Demo/Components/Layout/DocsLayout.razor
@@ -27,7 +27,7 @@
         </nav>
 
         <div class="docs-shell__actions">
-            <a href="/demo/workflows/support-inbox" class="docs-shell__demo-link">Live Demo</a>
+            <a href="/demo" class="docs-shell__demo-link">Live Demo</a>
         </div>
     </header>
 

--- a/demo/AgentBlazor.Demo/Components/Layout/LandingLayout.razor
+++ b/demo/AgentBlazor.Demo/Components/Layout/LandingLayout.razor
@@ -18,7 +18,7 @@
 
         <nav class="lp__nav" aria-label="Primary">
             <a href="/docs">Docs</a>
-            <a href="/demo/workflows/support-inbox">Live Demo</a>
+            <a href="/demo">Live Demo</a>
         </nav>
     </header>
 

--- a/demo/AgentBlazor.Demo/Components/Pages/Demo/DemoHome.razor
+++ b/demo/AgentBlazor.Demo/Components/Pages/Demo/DemoHome.razor
@@ -1,5 +1,6 @@
 @page "/demo"
 @layout DemoLayout
+@using AgentBlazor.Demo.Services
 @using MudBlazor
 
 <PageTitle>Demo — AgentBlazor</PageTitle>
@@ -8,45 +9,88 @@
     <MudPaper Elevation="0" Class="launchpad__hero">
         <div class="launchpad__hero-copy">
             <MudChip T="string" Color="Color.Primary" Variant="Variant.Filled" Size="Size.Small">Live demo</MudChip>
-            <MudText Typo="Typo.h4" Class="mt-4 mb-2">One normal app screen. One support queue.</MudText>
+            <MudText Typo="Typo.h4" Class="mt-4 mb-2">Pick the workflow size you want to see.</MudText>
             <MudText Typo="Typo.body2" Color="Color.Secondary">
-                Open the support queue and run a concrete ticket flow live: find open tickets, explain the queue, draft a reply, and cross the approval boundary.
+                Start small with one support reply, scale the same route into blockers and handoff, or open the advanced multi-surface flows.
             </MudText>
         </div>
 
-        <div class="launchpad__feature-grid">
-            <article class="launchpad__feature-card">
-                <div class="launchpad__quickstart-card" aria-label="AgentBlazor quickstart">
-                    <span class="launchpad__eyebrow">Minimal setup</span>
-                    <h2>NuGet package, one workflow, one widget.</h2>
-                    <ol>
-                        <li><code>dotnet add package AgentBlazor --prerelease</code></li>
-                        <li><code>AddAgentBlazor(...).AddWorkflow&lt;HelloWorkflow&gt;("hello-workflow")</code></li>
-                        <li><code>&lt;AgentChatWidget Title="Assistant" /&gt;</code></li>
-                    </ol>
-                </div>
-                <div class="launchpad__feature-copy">
-                    <strong>What to look for in the live route</strong>
-                    <p>The agent reads the current support queue, plans an action, requests approval for the reply draft, then updates the page after approval.</p>
-                </div>
-            </article>
-
-            <aside class="launchpad__guide-card">
-                <span class="launchpad__eyebrow">Try these prompts</span>
-                <div class="launchpad__guide-list">
-                    <span><strong>Show open tickets from this week.</strong> Focus the queue on tickets that still need a reply.</span>
-                    <span><strong>Explain why they need attention.</strong> Summarize the visible blockers before you draft anything.</span>
-                    <span><strong>Draft a reply for ticket TCK-1042.</strong> Hit the approval boundary and see the draft appear on screen.</span>
-                </div>
-                <div class="launchpad__hero-actions">
-                    <MudButton Variant="Variant.Filled" Color="Color.Primary" Href="/demo/workflows/support-inbox">
-                        Open live support queue
-                    </MudButton>
-                    <MudButton Variant="Variant.Outlined" Color="Color.Secondary" Href="/docs/cli">
-                        Advanced CLI
-                    </MudButton>
-                </div>
-            </aside>
+        <div class="launchpad__quickstart">
+            <span class="launchpad__eyebrow">Fast path</span>
+            <ol>
+                <li>Open the quick support queue.</li>
+                <li>Ask the three visible prompts in order.</li>
+                <li>Approve the draft and watch the page render structured output.</li>
+            </ol>
+            <MudButton Variant="Variant.Filled"
+                       Color="Color.Primary"
+                       Href="@DemoScenarioCatalog.LaunchpadScenarios[0].Route">
+                Start with quick demo
+            </MudButton>
         </div>
     </MudPaper>
+
+    <section class="launchpad__scenario-section">
+        <div class="launchpad__section-head">
+            <span class="launchpad__eyebrow">Scale up or down</span>
+            <MudText Typo="Typo.h5">Same runtime, different workflow sizes</MudText>
+        </div>
+
+        <div class="launchpad__scenario-grid">
+            @foreach (var scenario in DemoScenarioCatalog.LaunchpadScenarios)
+            {
+                <article class="launchpad__scenario-card launchpad__scenario-card--@GetScaleClass(scenario.Scale)">
+                    <div class="launchpad__scenario-topline">
+                        <span>@GetScaleLabel(scenario.Scale)</span>
+                        <small>@scenario.AgentName</small>
+                    </div>
+
+                    <div class="launchpad__scenario-copy">
+                        <h2>@scenario.Title</h2>
+                        <p>@scenario.Summary</p>
+                    </div>
+
+                    <div class="launchpad__prompt-list" aria-label="@($"{scenario.Title} prompts")">
+                        @foreach (var prompt in scenario.Prompts)
+                        {
+                            <span>@prompt</span>
+                        }
+                    </div>
+
+                    <div class="launchpad__proof-list">
+                        @foreach (var proofPoint in scenario.ProofPoints)
+                        {
+                            <span>@proofPoint</span>
+                        }
+                    </div>
+
+                    <MudButton Variant="@(scenario.Scale == DemoScenarioScale.Quick ? Variant.Filled : Variant.Outlined)"
+                               Color="@(scenario.Scale == DemoScenarioScale.Advanced ? Color.Secondary : Color.Primary)"
+                               Href="@scenario.Route">
+                        @scenario.CtaLabel
+                    </MudButton>
+                </article>
+            }
+        </div>
+    </section>
 </div>
+
+@code {
+    private static string GetScaleLabel(DemoScenarioScale scale)
+        => scale switch
+        {
+            DemoScenarioScale.Quick => "Quick",
+            DemoScenarioScale.Full => "Full",
+            DemoScenarioScale.Advanced => "Advanced",
+            _ => scale.ToString()
+        };
+
+    private static string GetScaleClass(DemoScenarioScale scale)
+        => scale switch
+        {
+            DemoScenarioScale.Quick => "quick",
+            DemoScenarioScale.Full => "full",
+            DemoScenarioScale.Advanced => "advanced",
+            _ => "default"
+        };
+}

--- a/demo/AgentBlazor.Demo/Components/Pages/Demo/DemoHome.razor.css
+++ b/demo/AgentBlazor.Demo/Components/Pages/Demo/DemoHome.razor.css
@@ -1,108 +1,47 @@
 .launchpad {
-    max-width: 72rem;
+    max-width: 78rem;
     margin: 0 auto;
+    display: grid;
+    gap: 1.1rem;
 }
 
 .launchpad__hero {
     display: grid;
+    grid-template-columns: minmax(0, 1.15fr) minmax(18rem, 0.85fr);
     gap: 1rem;
-    padding: 1.2rem;
+    padding: 1.25rem;
     border-radius: 1.25rem;
     border: 1px solid rgba(255, 255, 255, 0.08);
     background:
-        radial-gradient(circle at top right, rgba(255, 106, 61, 0.14), transparent 30%),
+        radial-gradient(circle at top right, rgba(255, 106, 61, 0.16), transparent 32%),
         radial-gradient(circle at bottom left, rgba(110, 168, 254, 0.16), transparent 34%),
         linear-gradient(150deg, rgba(14, 25, 39, 0.94), rgba(8, 16, 26, 0.98));
 }
 
 .launchpad__hero-copy {
-    max-width: 40rem;
+    max-width: 42rem;
 }
 
-.launchpad__feature-grid {
+.launchpad__quickstart {
     display: grid;
-    grid-template-columns: minmax(0, 1.55fr) minmax(18rem, 0.85fr);
-    gap: 1rem;
-}
-
-.launchpad__feature-card,
-.launchpad__guide-card {
-    display: grid;
-    gap: 0.9rem;
+    align-content: start;
+    gap: 0.85rem;
     padding: 1rem;
     border-radius: 1.05rem;
-    border: 1px solid rgba(255, 255, 255, 0.08);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    background: rgba(7, 14, 24, 0.72);
 }
 
-.launchpad__feature-card {
-    background: rgba(7, 14, 24, 0.76);
-}
-
-.launchpad__guide-card {
-    align-content: start;
-    background:
-        radial-gradient(circle at top right, rgba(110, 168, 254, 0.14), transparent 32%),
-        rgba(7, 14, 24, 0.76);
-}
-
-.launchpad__quickstart-card {
+.launchpad__quickstart ol {
     display: grid;
-    gap: 0.8rem;
-    padding: 1rem;
-    border-radius: 0.95rem;
-    background:
-        radial-gradient(circle at top left, rgba(255, 106, 61, 0.16), transparent 34%),
-        #030914;
-    border: 1px solid rgba(255, 255, 255, 0.08);
-}
-
-.launchpad__quickstart-card h2 {
-    max-width: 32rem;
+    gap: 0.5rem;
     margin: 0;
-    color: #f1f7ff;
-    font-size: clamp(1.45rem, 2.5vw, 2.15rem);
-    line-height: 1.05;
+    padding-left: 1.15rem;
+    color: rgba(214, 228, 247, 0.78);
 }
 
-.launchpad__quickstart-card ol {
-    display: grid;
-    gap: 0.55rem;
-    padding: 0;
-    margin: 0;
-    list-style: none;
-}
-
-.launchpad__quickstart-card li {
-    min-width: 0;
-    padding: 0.68rem 0.78rem;
-    border-radius: 0.78rem;
-    background: rgba(255, 255, 255, 0.045);
-    border: 1px solid rgba(255, 255, 255, 0.08);
-}
-
-.launchpad__quickstart-card code {
-    display: block;
-    overflow: hidden;
-    color: #d8eaff;
-    font-size: 0.84rem;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-}
-
-.launchpad__feature-copy {
-    display: grid;
-    gap: 0.45rem;
-}
-
-.launchpad__feature-copy strong {
-    color: #eef6ff;
-    font-size: 1.05rem;
-}
-
-.launchpad__feature-copy p {
-    margin: 0;
-    color: rgba(214, 228, 247, 0.74);
-    line-height: 1.5;
+.launchpad__quickstart li {
+    line-height: 1.45;
 }
 
 .launchpad__eyebrow {
@@ -113,35 +52,143 @@
     text-transform: uppercase;
 }
 
-.launchpad__guide-list {
+.launchpad__scenario-section {
     display: grid;
-    gap: 0.65rem;
+    gap: 0.85rem;
 }
 
-.launchpad__guide-list span {
-    color: rgba(214, 228, 247, 0.76);
+.launchpad__section-head {
+    display: grid;
+    gap: 0.25rem;
+}
+
+.launchpad__scenario-grid {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 0.9rem;
+}
+
+.launchpad__scenario-card {
+    position: relative;
+    overflow: hidden;
+    display: grid;
+    align-content: start;
+    gap: 0.95rem;
+    min-height: 26rem;
+    padding: 1rem;
+    border-radius: 1.05rem;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    background:
+        radial-gradient(circle at top right, rgba(110, 168, 254, 0.12), transparent 35%),
+        rgba(7, 14, 24, 0.78);
+}
+
+.launchpad__scenario-card::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    border-top: 3px solid rgba(110, 168, 254, 0.6);
+}
+
+.launchpad__scenario-card--quick::before {
+    border-top-color: #40c89b;
+}
+
+.launchpad__scenario-card--full::before {
+    border-top-color: #ff6a3d;
+}
+
+.launchpad__scenario-card--advanced::before {
+    border-top-color: #6ea8fe;
+}
+
+.launchpad__scenario-topline {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 0.75rem;
+}
+
+.launchpad__scenario-topline span {
+    padding: 0.32rem 0.58rem;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.08);
+    color: #eef6ff;
+    font-size: 0.72rem;
+    font-weight: 800;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
+
+.launchpad__scenario-topline small {
+    color: rgba(214, 228, 247, 0.58);
+    font-size: 0.72rem;
+    line-height: 1.35;
+    text-align: right;
+}
+
+.launchpad__scenario-copy {
+    display: grid;
+    gap: 0.45rem;
+}
+
+.launchpad__scenario-copy h2 {
+    margin: 0;
+    color: #eef6ff;
+    font-size: 1.14rem;
+    line-height: 1.18;
+}
+
+.launchpad__scenario-copy p {
+    margin: 0;
+    color: rgba(214, 228, 247, 0.74);
     line-height: 1.5;
 }
 
-.launchpad__guide-list strong {
-    color: #eef6ff;
+.launchpad__prompt-list,
+.launchpad__proof-list {
+    display: grid;
+    gap: 0.48rem;
 }
 
-.launchpad__hero-actions {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.8rem;
+.launchpad__prompt-list span {
+    padding: 0.58rem 0.68rem;
+    border-radius: 0.75rem;
+    background: rgba(255, 255, 255, 0.055);
+    color: rgba(236, 244, 255, 0.86);
+    font-size: 0.82rem;
+    line-height: 1.35;
 }
 
-@media (max-width: 920px) {
-    .launchpad__feature-grid {
+.launchpad__proof-list {
+    margin-top: auto;
+}
+
+.launchpad__proof-list span {
+    color: rgba(123, 224, 191, 0.86);
+    font-size: 0.8rem;
+    line-height: 1.35;
+}
+
+.launchpad__proof-list span::before {
+    content: "✓ ";
+}
+
+@media (max-width: 1180px) {
+    .launchpad__scenario-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+}
+
+@media (max-width: 820px) {
+    .launchpad__hero {
         grid-template-columns: 1fr;
     }
 }
 
 @media (max-width: 640px) {
-    .launchpad__hero-actions {
-        flex-direction: column;
-        align-items: stretch;
+    .launchpad__scenario-grid {
+        grid-template-columns: 1fr;
     }
 }

--- a/demo/AgentBlazor.Demo/Components/Pages/Docs/DocsHome.razor
+++ b/demo/AgentBlazor.Demo/Components/Pages/Docs/DocsHome.razor
@@ -14,7 +14,7 @@
 
         <div class="docs-actions">
             <MudButton Variant="Variant.Filled" Color="Color.Primary" Href="/docs/getting-started">Start setup</MudButton>
-            <MudButton Variant="Variant.Outlined" Color="Color.Secondary" Href="/demo/workflows/support-inbox">Open demo</MudButton>
+            <MudButton Variant="Variant.Outlined" Color="Color.Secondary" Href="/demo">Open demo</MudButton>
         </div>
 
         <div class="docs-kpi-grid">

--- a/demo/AgentBlazor.Demo/Components/Pages/Home.razor
+++ b/demo/AgentBlazor.Demo/Components/Pages/Home.razor
@@ -32,7 +32,7 @@
             </ol>
             <div class="landing-page__hero-meta" aria-label="Quickstart links">
                 <a href="/docs/quickstart">Read quickstart</a>
-                <a href="/demo/workflows/support-inbox">Try live demo</a>
+                <a href="/demo">Try live demo</a>
                 <a href="https://github.com/ashpeterson/AgentBlazor">GitHub</a>
             </div>
         </article>

--- a/demo/AgentBlazor.Demo/Components/Shared/LandingHero.razor
+++ b/demo/AgentBlazor.Demo/Components/Shared/LandingHero.razor
@@ -17,7 +17,7 @@
                    EndIcon="@Icons.Material.Filled.MenuBook">
             Docs
         </MudButton>
-        <MudButton Href="/demo/workflows/support-inbox"
+        <MudButton Href="/demo"
                    Variant="Variant.Outlined"
                    Size="Size.Large">
             Live demo

--- a/demo/AgentBlazor.Demo/Services/DemoScenarioCatalog.cs
+++ b/demo/AgentBlazor.Demo/Services/DemoScenarioCatalog.cs
@@ -1,0 +1,257 @@
+namespace AgentBlazor.Demo.Services;
+
+internal enum DemoScenarioScale
+{
+    Quick,
+    Full,
+    Advanced
+}
+
+internal sealed record DemoScenario(
+    string Id,
+    DemoScenarioScale Scale,
+    string Title,
+    string Summary,
+    string Route,
+    string CtaLabel,
+    string AssistantTitle,
+    string AssistantDescription,
+    string AssistantPlaceholder,
+    string AgentName,
+    IReadOnlyList<string> Prompts,
+    IReadOnlyList<string> ProofPoints)
+{
+    public bool ShowOnLaunchpad { get; init; } = true;
+}
+
+internal static class DemoScenarioCatalog
+{
+    public static IReadOnlyList<DemoScenario> Scenarios { get; } =
+    [
+        new(
+            "support-quick",
+            DemoScenarioScale.Quick,
+            "Quick: draft one safe reply",
+            "A one-page support queue flow that shows discovery, explanation, approval, and a structured customer reply.",
+            "/demo/workflows/support-inbox",
+            "Open quick demo",
+            "Support assistant",
+            "Find tickets, explain the queue, draft a reply.",
+            "Show open tickets. Explain the queue. Draft a reply.",
+            "Support Inbox Agent",
+            [
+                "Show open tickets from this week",
+                "Explain why they need attention",
+                "Draft a reply for ticket TCK-1042"
+            ],
+            [
+                "One Blazor route",
+                "One approval boundary",
+                "Structured draft appears in the page"
+            ]),
+        new(
+            "support-full",
+            DemoScenarioScale.Full,
+            "Full: handle blockers and handoff",
+            "The same support queue scales up to multiple tickets, an evidence blocker, escalation, and a safe reply handoff.",
+            "/demo/workflows/support-inbox?mode=full",
+            "Open full support flow",
+            "Support assistant",
+            "Find tickets, explain blockers, draft replies, escalate blocked cases.",
+            "Show open tickets. Explain blockers. Draft replies. Escalate if blocked.",
+            "Support Inbox Agent",
+            [
+                "Show open tickets from this week",
+                "Draft a reply for the highlighted tickets",
+                "Escalate the blocked tickets"
+            ],
+            [
+                "Same route, larger workflow",
+                "Blocked ticket recovery",
+                "Approval-safe customer response"
+            ]),
+        new(
+            "response-orchestration",
+            DemoScenarioScale.Advanced,
+            "Advanced: response orchestration",
+            "A multi-surface flow that coordinates supplier, file, and incident work into one response packet.",
+            "/demo/workflows/response-orchestration?reset=true",
+            "Open response flow",
+            "Response assistant",
+            "Assess, advance, recover, prepare.",
+            "Assess readiness. Advance next stage. Prepare packet.",
+            "Response Orchestration Agent",
+            [
+                "Assess cross-system response readiness",
+                "Advance the next guided subsystem stage",
+                "Prepare the response packet"
+            ],
+            [
+                "Multiple workflow surfaces",
+                "Guided recovery",
+                "Cross-page packet preparation"
+            ]),
+        new(
+            "release-dossier",
+            DemoScenarioScale.Advanced,
+            "Advanced: release dossier",
+            "A second multi-surface flow that pulls recipe and evidence checks into a release approval package.",
+            "/demo/workflows/release-dossier?reset=true",
+            "Open release flow",
+            "Release assistant",
+            "Assess, advance, recover, prepare.",
+            "Assess readiness. Advance next stage. Prepare dossier.",
+            "Release Dossier Agent",
+            [
+                "Assess release readiness",
+                "Advance the next guided stage",
+                "Prepare the release dossier"
+            ],
+            [
+                "Recipe readiness",
+                "Evidence bundle checks",
+                "Release approval package"
+            ]),
+        new(
+            "supplier-compliance",
+            DemoScenarioScale.Advanced,
+            "Supplier compliance",
+            "A focused supplier-risk workflow used by the larger response orchestration flow.",
+            "/demo/workflows/supplier-compliance",
+            "Open supplier flow",
+            "Supplier assistant",
+            "Review risk, clear blockers, prepare.",
+            "Explain risk. Recover. Prepare.",
+            "Supplier Compliance Agent",
+            [
+                "Explain why the current suppliers are at risk",
+                "Recover the blocked suppliers",
+                "Prepare the remediation draft"
+            ],
+            [
+                "Component-level focus",
+                "Risk blockers",
+                "Draft remediation"
+            ])
+        {
+            ShowOnLaunchpad = false
+        },
+        new(
+            "file-audit-bundle",
+            DemoScenarioScale.Advanced,
+            "File audit bundle",
+            "A focused evidence workflow used by the larger orchestration flows.",
+            "/demo/workflows/file-audit-bundle",
+            "Open evidence flow",
+            "Evidence assistant",
+            "Prepare, recover, retry.",
+            "Explain blockers. Recover. Prepare.",
+            "File Workflow Agent",
+            [
+                "Explain the evidence blockers",
+                "Recover the missing file",
+                "Prepare the audit bundle"
+            ],
+            [
+                "File workflow",
+                "Recoverable blockers",
+                "Audit-ready output"
+            ])
+        {
+            ShowOnLaunchpad = false
+        },
+        new(
+            "recipe-release",
+            DemoScenarioScale.Advanced,
+            "Recipe release",
+            "A focused recipe readiness workflow used by the release dossier flow.",
+            "/demo/workflows/recipe-release",
+            "Open recipe flow",
+            "Recipe assistant",
+            "Assess, recover, stage.",
+            "Assess readiness. Recover. Prepare.",
+            "Recipe Release Agent",
+            [
+                "Assess recipe readiness",
+                "Recover missing evidence",
+                "Prepare the release draft"
+            ],
+            [
+                "Recipe readiness",
+                "Recovery",
+                "Release staging"
+            ])
+        {
+            ShowOnLaunchpad = false
+        },
+        new(
+            "incident-escalation",
+            DemoScenarioScale.Advanced,
+            "Incident escalation",
+            "A focused incident workflow used by the response orchestration flow.",
+            "/demo/workflows/incident-escalation",
+            "Open incident flow",
+            "Incident assistant",
+            "Triage, recover, hand off.",
+            "Summarize triage. Recover. Submit.",
+            "Incident Escalation Agent",
+            [
+                "Summarize incident triage",
+                "Recover missing evidence",
+                "Submit the handoff"
+            ],
+            [
+                "Incident triage",
+                "Evidence recovery",
+                "Safe handoff"
+            ])
+        {
+            ShowOnLaunchpad = false
+        },
+        new(
+            "runtime-probe",
+            DemoScenarioScale.Advanced,
+            "Runtime probe",
+            "A narrow runtime behavior probe for cancellation and long-running action handling.",
+            "/demo/workflows/runtime-probe",
+            "Open runtime probe",
+            "Runtime probe assistant",
+            "Run the cancellation probe, then stop it.",
+            "Run the runtime cancellation probe, then stop.",
+            "Runtime Probe Agent",
+            [
+                "Run the runtime cancellation probe",
+                "Stop the probe"
+            ],
+            [
+                "Runtime behavior",
+                "Cancellation",
+                "Long-running action visibility"
+            ])
+        {
+            ShowOnLaunchpad = false
+        }
+    ];
+
+    public static IReadOnlyList<DemoScenario> LaunchpadScenarios { get; }
+        = Scenarios.Where(static scenario => scenario.ShowOnLaunchpad).ToArray();
+
+    public static IEnumerable<DemoScenario> ForScale(DemoScenarioScale scale)
+        => Scenarios.Where(scenario => scenario.Scale == scale);
+
+    public static DemoScenario? FindByPath(string path)
+    {
+        var normalizedPath = NormalizePath(path);
+
+        return Scenarios
+            .Where(scenario => NormalizePath(scenario.Route) == normalizedPath)
+            .OrderBy(static scenario => scenario.Scale)
+            .FirstOrDefault();
+    }
+
+    private static string NormalizePath(string route)
+    {
+        var path = route.Split('?', 2, StringSplitOptions.TrimEntries)[0].TrimEnd('/');
+        return string.IsNullOrWhiteSpace(path) ? "/" : path.ToLowerInvariant();
+    }
+}

--- a/tests/e2e/specs/home.spec.cjs
+++ b/tests/e2e/specs/home.spec.cjs
@@ -23,6 +23,11 @@ test.describe("Landing page", () => {
 
     await page.goto("/", { waitUntil: "networkidle" });
     await page.locator("#hero").getByRole("link", { name: "Live demo" }).click();
+    await expect(page).toHaveURL(/\/demo$/);
+    await expect(page.getByRole("heading", { name: /pick the workflow size you want to see/i }).first()).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Quick: draft one safe reply" })).toBeVisible();
+
+    await page.getByRole("link", { name: "Start with quick demo" }).click();
     await expect(page).toHaveURL(/\/demo\/workflows\/support-inbox/);
   });
 });


### PR DESCRIPTION
## Summary
- Add a shared DemoScenarioCatalog for workflow scale, prompts, assistant copy, and route metadata
- Replace the video-led /demo page with Quick / Full / Advanced scenario choices
- Drive DemoLayout assistant title/description/agent selection from scenario metadata instead of route-specific conditionals
- Send public Live Demo links to /demo so visitors choose the right workflow size first

## Validation
- dotnet build demo/AgentBlazor.Demo/AgentBlazor.Demo.csproj -p:UseAppHost=false
- dotnet build AgentBlazor.slnx -p:UseAppHost=false
- env -u OPENAI_API_KEY -u OpenAI__ApiKey dotnet test AgentBlazor.slnx -p:UseAppHost=false --no-build
- local HTTP smoke: /demo and /demo/workflows/support-inbox returned 200

Note: UseAppHost=false is required in this Ubuntu 24.04 dev environment because the SDK attempts to restore Microsoft.NETCore.App.Host.ubuntu.24.04-x64, which is not available from nuget.org.