### PR TITLE
Harden runtime queued and generated UI approval semantics

### DIFF
--- a/src/AgentBlazor.Components/Chat/AgentChatBar.razor
+++ b/src/AgentBlazor.Components/Chat/AgentChatBar.razor
@@ -527,7 +527,7 @@
                     new ActivityMessage(
                         key,
                         FormatToolCallResultMessage(result),
-                        result.Succeeded,
+                        result.Outcome is ActionOutcome.Applied,
                         result.ComponentId,
                         result.ActionId,
                         status,
@@ -810,9 +810,12 @@
             return executionResult.Message;
         }
 
-        return executionResult.Succeeded
-            ? $"Completed {executionResult.ComponentId}.{executionResult.ActionId}."
-            : $"Failed {executionResult.ComponentId}.{executionResult.ActionId}.";
+        return executionResult.Outcome switch
+        {
+            ActionOutcome.Applied => $"Completed {executionResult.ComponentId}.{executionResult.ActionId}.",
+            ActionOutcome.Queued => $"Queued {executionResult.ComponentId}.{executionResult.ActionId}.",
+            _ => $"Failed {executionResult.ComponentId}.{executionResult.ActionId}."
+        };
     }
 
     private static ActionStatus MapExecutionResultStatus(ComponentActionExecutionResult executionResult)
@@ -991,7 +994,7 @@
             messages.Add(new ActivityMessage(
                 key,
                 text,
-                result.Succeeded,
+                result.Outcome is ActionOutcome.Applied,
                 result.ComponentId,
                 result.ActionId,
                 status,
@@ -1006,6 +1009,7 @@
         status switch
         {
             AgentExecutionStepStatus.Pending => ActionStatus.InProgress,
+            AgentExecutionStepStatus.Queued => ActionStatus.InProgress,
             AgentExecutionStepStatus.ApprovalRequired => ActionStatus.Executing,
             AgentExecutionStepStatus.NeedsClarification => ActionStatus.Failed,
             AgentExecutionStepStatus.Blocked => ActionStatus.Failed,

--- a/src/AgentBlazor.Components/Chat/AgentChatSurface.razor
+++ b/src/AgentBlazor.Components/Chat/AgentChatSurface.razor
@@ -1209,7 +1209,7 @@
                         new ActivityMessage(
                             resultKey,
                             FormatToolCallResultMessage(streamEvent.ExecutionResult),
-                            streamEvent.ExecutionResult.Succeeded,
+                            streamEvent.ExecutionResult.Outcome is ActionOutcome.Applied,
                             streamEvent.ExecutionResult.ComponentId,
                             streamEvent.ExecutionResult.ActionId,
                             resultStatus,
@@ -1811,9 +1811,12 @@
             return executionResult.Message;
         }
 
-        return executionResult.Succeeded
-            ? $"Completed {executionResult.ComponentId}.{executionResult.ActionId}."
-            : $"Failed {executionResult.ComponentId}.{executionResult.ActionId}.";
+        return executionResult.Outcome switch
+        {
+            ActionOutcome.Applied => $"Completed {executionResult.ComponentId}.{executionResult.ActionId}.",
+            ActionOutcome.Queued => $"Queued {executionResult.ComponentId}.{executionResult.ActionId}.",
+            _ => $"Failed {executionResult.ComponentId}.{executionResult.ActionId}."
+        };
     }
 
     private static ActionStatus MapExecutionResultStatus(ComponentActionExecutionResult executionResult)
@@ -1843,6 +1846,7 @@
         status switch
         {
             AgentExecutionStepStatus.Completed => ActionStatus.Complete,
+            AgentExecutionStepStatus.Queued => ActionStatus.InProgress,
             AgentExecutionStepStatus.Failed => ActionStatus.Failed,
             AgentExecutionStepStatus.Blocked => ActionStatus.Failed,
             AgentExecutionStepStatus.NeedsClarification => ActionStatus.Failed,
@@ -2234,11 +2238,11 @@
         {
             var key = BuildActivityKey(result.ComponentId, result.ActionId);
             var text = FormatToolCallResultMessage(result);
-            var status = result.Succeeded ? ActionStatus.Complete : ActionStatus.Failed;
+            var status = MapExecutionResultStatus(result);
             messages.Add(new ActivityMessage(
                 key,
                 text,
-                result.Succeeded,
+                result.Outcome is ActionOutcome.Applied,
                 result.ComponentId,
                 result.ActionId,
                 status,

--- a/src/AgentBlazor.Components/Chat/ExecutionPlanNarrativeFormatter.cs
+++ b/src/AgentBlazor.Components/Chat/ExecutionPlanNarrativeFormatter.cs
@@ -195,6 +195,7 @@ internal static class ExecutionPlanNarrativeFormatter
         {
             AgentExecutionStepStatus.ApprovalRequired => "awaiting approval",
             AgentExecutionStepStatus.Completed => "done",
+            AgentExecutionStepStatus.Queued => "queued",
             AgentExecutionStepStatus.NeedsClarification => "needs clarification",
             AgentExecutionStepStatus.Blocked => "blocked",
             AgentExecutionStepStatus.Failed => "failed",

--- a/src/AgentBlazor.Components/Chat/ExecutionStepNarrativeFormatter.cs
+++ b/src/AgentBlazor.Components/Chat/ExecutionStepNarrativeFormatter.cs
@@ -19,6 +19,9 @@ internal static class ExecutionStepNarrativeFormatter
                 case AgentExecutionStepStatus.ApprovalRequired:
                     lines.Add("Awaiting approval before execution.");
                     break;
+                case AgentExecutionStepStatus.Queued:
+                    lines.Add("Execution was queued and is waiting for a matching UI component.");
+                    break;
                 case AgentExecutionStepStatus.Blocked:
                     lines.Add("Execution was blocked.");
                     break;

--- a/src/AgentBlazor.Core/Execution/AgentExecutionContracts.cs
+++ b/src/AgentBlazor.Core/Execution/AgentExecutionContracts.cs
@@ -16,7 +16,8 @@ public enum AgentExecutionStepStatus
     ApprovalRequired = 2,
     NeedsClarification = 3,
     Blocked = 4,
-    Failed = 5
+    Failed = 5,
+    Queued = 6
 }
 
 public sealed record AgentExecutionContext(

--- a/src/AgentBlazor.Core/Runtime/ActionResult.cs
+++ b/src/AgentBlazor.Core/Runtime/ActionResult.cs
@@ -6,7 +6,7 @@ public sealed record ActionResult(
     ActionOutcome Outcome,
     string Message)
 {
-    public bool Succeeded => Outcome is ActionOutcome.Applied or ActionOutcome.Queued;
+    public bool Succeeded => Outcome is ActionOutcome.Applied;
 
     public static ActionResult Applied(string message) => new(ActionOutcome.Applied, message);
 

--- a/src/AgentBlazor.Core/Runtime/Adapters/ChatClientRuntimeAdapter.cs
+++ b/src/AgentBlazor.Core/Runtime/Adapters/ChatClientRuntimeAdapter.cs
@@ -1303,6 +1303,21 @@ public sealed class ChatClientRuntimeAdapter(
         });
 
         if (capability.RequiresApproval &&
+            ShouldBlockGeneratedUiApprovalRequest(turnState) &&
+            !ComponentActionApprovalPolicy.IsApprovalGranted(
+                componentId,
+                capability.ActionId,
+                turnState?.RuntimeContext))
+        {
+            return RecordBlockedGeneratedUiApprovalRequest(
+                turnState,
+                stepIndex,
+                plannedAction,
+                componentId,
+                capability.ActionId);
+        }
+
+        if (capability.RequiresApproval &&
             !ComponentActionApprovalPolicy.IsApprovalGranted(
                 componentId,
                 capability.ActionId,
@@ -1482,6 +1497,21 @@ public sealed class ChatClientRuntimeAdapter(
             StepIndex = stepIndex,
             ToolArguments = invocationArguments
         });
+
+        if (capability.RequiresApproval &&
+            ShouldBlockGeneratedUiApprovalRequest(turnState) &&
+            !ComponentActionApprovalPolicy.IsApprovalGranted(
+                capability.CapabilityId,
+                capability.LocalActionId,
+                turnState?.RuntimeContext))
+        {
+            return RecordBlockedGeneratedUiApprovalRequest(
+                turnState,
+                stepIndex,
+                plannedAction,
+                capability.CapabilityId,
+                capability.LocalActionId);
+        }
 
         if (capability.RequiresApproval &&
             !ComponentActionApprovalPolicy.IsApprovalGranted(
@@ -1856,7 +1886,8 @@ public sealed class ChatClientRuntimeAdapter(
     private static AgentExecutionStepStatus MapOutcomeToStepStatus(ActionOutcome outcome) =>
         outcome switch
         {
-            ActionOutcome.Applied or ActionOutcome.Queued => AgentExecutionStepStatus.Completed,
+            ActionOutcome.Applied => AgentExecutionStepStatus.Completed,
+            ActionOutcome.Queued => AgentExecutionStepStatus.Queued,
             ActionOutcome.NeedsClarification => AgentExecutionStepStatus.NeedsClarification,
             ActionOutcome.Blocked => AgentExecutionStepStatus.Blocked,
             ActionOutcome.Failed => AgentExecutionStepStatus.Failed,
@@ -2105,6 +2136,59 @@ public sealed class ChatClientRuntimeAdapter(
 
         return !IsExplicitSubmitIntent(turnState.UserMessage) &&
                !IsExplicitSubmitIntent(turnState.GeneratedUiAction.ActionId);
+    }
+
+    private static bool ShouldBlockGeneratedUiApprovalRequest(TurnExecutionState? turnState)
+        => turnState?.GeneratedUiAction is not null;
+
+    private static string RecordBlockedGeneratedUiApprovalRequest(
+        TurnExecutionState? turnState,
+        int? stepIndex,
+        PlannedComponentAction plannedAction,
+        string componentId,
+        string actionId)
+    {
+        var message =
+            $"Generated UI actions cannot request approval-gated action '{componentId}.{actionId}'. Ask for the action in chat to review and approve it.";
+        var result = new ComponentActionExecutionResult(
+            componentId,
+            actionId,
+            ActionOutcome.Blocked,
+            message);
+        turnState?.AddExecutionResult(result);
+        if (stepIndex is int blockedStepIndex && turnState is not null)
+        {
+            turnState.UpdateExecutionStep(
+                blockedStepIndex,
+                AgentExecutionStepStatus.Blocked,
+                message,
+                requiresApproval: false,
+                policyDecision: RuntimeTrustDecisions.BuildPolicyDecision(componentId, actionId, requiresApproval: true));
+        }
+
+        turnState?.AddStreamEvent(new AgentTurnStreamEvent
+        {
+            Kind = AgentTurnStreamEventKind.ToolCallResult,
+            PlannedAction = plannedAction,
+            StepIndex = stepIndex,
+            ExecutionResult = result
+        });
+        turnState?.AddStreamEvent(new AgentTurnStreamEvent
+        {
+            Kind = AgentTurnStreamEventKind.ToolCallEnd,
+            PlannedAction = plannedAction,
+            StepIndex = stepIndex,
+            ExecutionResult = result
+        });
+        turnState?.AddStreamEvent(new AgentTurnStreamEvent
+        {
+            Kind = AgentTurnStreamEventKind.StepFinished,
+            PlannedAction = plannedAction,
+            StepIndex = stepIndex,
+            StepSucceeded = false,
+            ExecutionResult = result
+        });
+        return message;
     }
 
     private static bool IsExplicitSubmitIntent(string? text)

--- a/src/AgentBlazor.Core/Runtime/Components/ComponentActionExecutionResult.cs
+++ b/src/AgentBlazor.Core/Runtime/Components/ComponentActionExecutionResult.cs
@@ -19,5 +19,5 @@ public sealed record ComponentActionExecutionResult(
     {
     }
 
-    public bool Succeeded => Outcome is ActionOutcome.Applied or ActionOutcome.Queued;
+    public bool Succeeded => Outcome is ActionOutcome.Applied;
 }

--- a/src/AgentBlazor.Core/Runtime/ExecutionPlans/PlanExecutionModels.cs
+++ b/src/AgentBlazor.Core/Runtime/ExecutionPlans/PlanExecutionModels.cs
@@ -34,7 +34,7 @@ public sealed record PlanExecutionResult
     public required bool Succeeded { get; init; }
     public TimeSpan Duration { get; init; }
 
-    public int SuccessCount => StepResults.Count(r => r.Outcome is ActionOutcome.Applied or ActionOutcome.Queued);
+    public int SuccessCount => StepResults.Count(r => r.Outcome is ActionOutcome.Applied);
     public int FailureCount => StepResults.Count(r =>
         r.Outcome is ActionOutcome.Failed or ActionOutcome.Blocked or ActionOutcome.NeedsClarification);
     public int AppliedCount => StepResults.Count(r => r.Outcome is ActionOutcome.Applied);
@@ -53,5 +53,5 @@ public sealed record StepExecutionResult
     public required string Message { get; init; }
     public TimeSpan Duration { get; init; }
 
-    public bool Succeeded => Outcome is ActionOutcome.Applied or ActionOutcome.Queued;
+    public bool Succeeded => Outcome is ActionOutcome.Applied;
 }

--- a/src/AgentBlazor.Core/Runtime/RuntimeExecutionPlans.cs
+++ b/src/AgentBlazor.Core/Runtime/RuntimeExecutionPlans.cs
@@ -110,7 +110,8 @@ internal static class RuntimeExecutionPlans
 
         return result.Outcome switch
         {
-            ActionOutcome.Applied or ActionOutcome.Queued => AgentExecutionStepStatus.Completed,
+            ActionOutcome.Applied => AgentExecutionStepStatus.Completed,
+            ActionOutcome.Queued => AgentExecutionStepStatus.Queued,
             ActionOutcome.NeedsClarification => AgentExecutionStepStatus.NeedsClarification,
             ActionOutcome.Blocked => AgentExecutionStepStatus.Blocked,
             ActionOutcome.Failed => AgentExecutionStepStatus.Failed,

--- a/src/AgentBlazor.Core/Runtime/RuntimePersistenceRecords.cs
+++ b/src/AgentBlazor.Core/Runtime/RuntimePersistenceRecords.cs
@@ -58,7 +58,7 @@ internal static class RuntimePersistenceRecords
             {
                 allEvents.Add(new InspectorEvent(
                     DateTimeOffset.UtcNow,
-                    result.Succeeded ? "ToolCallResult" : "ToolCallFailed",
+                    MapExecutionResultEventKind(result.Outcome),
                     result.ComponentId,
                     result.ActionId,
                     result.Message));
@@ -83,10 +83,19 @@ internal static class RuntimePersistenceRecords
         => status switch
         {
             AgentExecutionStepStatus.Completed => "StepCompleted",
+            AgentExecutionStepStatus.Queued => "StepQueued",
             AgentExecutionStepStatus.Failed => "StepFailed",
             AgentExecutionStepStatus.Blocked => "StepBlocked",
             AgentExecutionStepStatus.ApprovalRequired => "StepApprovalRequired",
             AgentExecutionStepStatus.NeedsClarification => "StepClarificationRequired",
             _ => "StepPending"
+        };
+
+    private static string MapExecutionResultEventKind(ActionOutcome outcome)
+        => outcome switch
+        {
+            ActionOutcome.Applied => "ToolCallResult",
+            ActionOutcome.Queued => "ToolCallQueued",
+            _ => "ToolCallFailed"
         };
 }

--- a/src/AgentBlazor.Core/Runtime/Tracing/PromptTraceBuilder.cs
+++ b/src/AgentBlazor.Core/Runtime/Tracing/PromptTraceBuilder.cs
@@ -254,8 +254,8 @@ internal sealed class PromptTraceBuilder
         {
             Results = tracedResults,
             TotalDuration = _stageStopwatch.Elapsed,
-            SuccessCount = results.Count(r => r.Succeeded),
-            FailureCount = results.Count(r => !r.Succeeded)
+            SuccessCount = results.Count(static result => result.Outcome is ActionOutcome.Applied),
+            FailureCount = results.Count(static result => result.Outcome is not ActionOutcome.Applied and not ActionOutcome.Queued)
         };
 
         return this;
@@ -283,7 +283,8 @@ internal sealed class PromptTraceBuilder
             Results = tracedResults,
             TotalDuration = _stageStopwatch.Elapsed,
             SuccessCount = tracedResults.Count(static result => result.Succeeded),
-            FailureCount = tracedResults.Count(static result => !result.Succeeded)
+            FailureCount = tracedResults.Count(static result =>
+                result.Outcome is not ActionOutcome.Applied and not ActionOutcome.Queued)
         };
 
         return this;
@@ -396,6 +397,7 @@ internal sealed class PromptTraceBuilder
         => status switch
         {
             AgentExecutionStepStatus.Completed => ActionOutcome.Applied,
+            AgentExecutionStepStatus.Queued => ActionOutcome.Queued,
             AgentExecutionStepStatus.ApprovalRequired => ActionOutcome.Blocked,
             AgentExecutionStepStatus.NeedsClarification => ActionOutcome.NeedsClarification,
             AgentExecutionStepStatus.Blocked => ActionOutcome.Blocked,

--- a/src/AgentBlazor.Hosting/DeterministicAgUiHostedAgent.cs
+++ b/src/AgentBlazor.Hosting/DeterministicAgUiHostedAgent.cs
@@ -969,6 +969,7 @@ internal sealed class DeterministicAgUiHostedAgent(
         var outcome = step.Status switch
         {
             AgentExecutionStepStatus.Completed => ActionOutcome.Applied,
+            AgentExecutionStepStatus.Queued => ActionOutcome.Queued,
             AgentExecutionStepStatus.ApprovalRequired => ActionOutcome.Failed,
             AgentExecutionStepStatus.NeedsClarification => ActionOutcome.Failed,
             AgentExecutionStepStatus.Blocked => ActionOutcome.Failed,

--- a/tests/AgentBlazor.Components.Tests/ExecutionPlanNarrativeFormatterTests.cs
+++ b/tests/AgentBlazor.Components.Tests/ExecutionPlanNarrativeFormatterTests.cs
@@ -88,6 +88,29 @@ public sealed class ExecutionPlanNarrativeFormatterTests
     }
 
     [Fact]
+    public void BuildStepLabels_LabelsQueuedSteps()
+    {
+        var plan = new AgentExecutionPlan(
+            "RiskAgent",
+            new AgentExecutionContext("session-1", "run-1"),
+            [
+                new AgentExecutionStep(
+                    "step-1",
+                    0,
+                    AgentExecutionStepKind.UiAction,
+                    "AgentDialog",
+                    "open",
+                    AgentExecutionStepStatus.Queued,
+                    false,
+                    new AgentPolicyDecision(true, AgentRiskClass.ReadOnly, AgentApprovalMode.None))
+            ]);
+
+        var labels = ExecutionPlanNarrativeFormatter.BuildStepLabels(plan, []);
+
+        Assert.Equal(["UI: AgentDialog.open (queued)"], labels);
+    }
+
+    [Fact]
     public void ApprovalHelpers_BuildSharedSummaryTitleAndPolicyNarrative()
     {
         var summary = ExecutionPlanNarrativeFormatter.BuildApprovalSummary(

--- a/tests/AgentBlazor.Core.Tests/ComponentMockingReportTests.cs
+++ b/tests/AgentBlazor.Core.Tests/ComponentMockingReportTests.cs
@@ -162,9 +162,9 @@ public class ComponentMockingReportTests
         var report = GenerateReport(results, mockDataGrid, mockDialog, mockForm, mockNavMenu, mockTabs);
         _output.WriteLine(report);
 
-        // Verify most scenarios succeeded (some edge cases may fail due to parameter normalization)
-        var successCount = results.Count(static r => r.HasSuccessfulExecution);
-        Assert.True(successCount >= 10, $"Expected at least 10 successful scenarios, got {successCount}");
+        // Queued actions are accepted by the runtime but not completed until the matching component mounts.
+        var acceptedCount = results.Count(static r => r.HasAcceptedExecution);
+        Assert.True(acceptedCount >= 10, $"Expected at least 10 accepted scenarios, got {acceptedCount}");
         Assert.All(results, static r => Assert.True(
             r.HasPlannedSteps,
             "Expected normalized plan steps or legacy planned actions."));
@@ -186,7 +186,7 @@ public class ComponentMockingReportTests
         sb.AppendLine();
         sb.AppendLine($"Generated: {DateTime.UtcNow:yyyy-MM-dd HH:mm:ss} UTC");
         sb.AppendLine($"Total Scenarios: {results.Count}");
-        sb.AppendLine($"Successful: {results.Count(static r => r.HasSuccessfulExecution)}");
+        sb.AppendLine($"Accepted: {results.Count(static r => r.HasAcceptedExecution)}");
         sb.AppendLine();
 
         sb.AppendLine("───────────────────────────────────────────────────────────────────────────────");
@@ -197,8 +197,8 @@ public class ComponentMockingReportTests
         int scenarioNum = 1;
         foreach (var result in results)
         {
-            var outcome = result.HasSuccessfulExecution ? "SUCCESS" : "FAILED";
-            var outcomeIcon = outcome == "SUCCESS" ? "[OK]" : "[FAIL]";
+            var outcome = result.HasAcceptedExecution ? "ACCEPTED" : "FAILED";
+            var outcomeIcon = outcome == "ACCEPTED" ? "[OK]" : "[FAIL]";
 
             sb.AppendLine($"┌─ Scenario {scenarioNum}: {outcomeIcon}");
             sb.AppendLine($"│");
@@ -305,7 +305,7 @@ public class ComponentMockingReportTests
             var promptTrunc = result.Prompt.Length > 44 ? result.Prompt[..41] + "..." : result.Prompt.PadRight(44);
             var component = result.GetPrimaryTargetId();
             var action = result.GetPrimaryActionId();
-            var status = result.HasSuccessfulExecution ? "SUCCESS" : "FAILED";
+            var status = result.HasAcceptedExecution ? "ACCEPTED" : "FAILED";
 
             sb.AppendLine($"| {scenarioNum,1} | {promptTrunc} | {component,-11} | {action,-13} | {status,-7} |");
             scenarioNum++;
@@ -340,9 +340,11 @@ public class ComponentMockingReportTests
         public bool HasPlannedSteps =>
             ExecutionPlan?.Steps.Count > 0 || LegacyPlannedActions.Count > 0;
 
-        public bool HasSuccessfulExecution =>
-            ExecutionPlan?.Steps.Any(static step => step.Status is AgentExecutionStepStatus.Completed) is true ||
-            LegacyExecutionResults.Any(static result => result.Succeeded);
+        public bool HasAcceptedExecution =>
+            ExecutionPlan?.Steps.Any(static step =>
+                step.Status is AgentExecutionStepStatus.Completed or AgentExecutionStepStatus.Queued) is true ||
+            LegacyExecutionResults.Any(static result =>
+                result.Outcome is ActionOutcome.Applied or ActionOutcome.Queued);
 
         public IEnumerable<string> GetPlannedStepLines()
         {
@@ -390,7 +392,12 @@ public class ComponentMockingReportTests
             {
                 foreach (var step in ExecutionPlan.Steps)
                 {
-                    var status = step.Status is AgentExecutionStepStatus.Completed ? "OK" : "FAIL";
+                    var status = step.Status switch
+                    {
+                        AgentExecutionStepStatus.Completed => "OK",
+                        AgentExecutionStepStatus.Queued => "QUEUED",
+                        _ => "FAIL"
+                    };
                     yield return $"[{status}] {step.TargetId}.{step.ActionId}";
                     if (!string.IsNullOrWhiteSpace(step.Message))
                     {
@@ -403,7 +410,12 @@ public class ComponentMockingReportTests
 
             foreach (var exec in LegacyExecutionResults)
             {
-                var status = exec.Succeeded ? "OK" : "FAIL";
+                var status = exec.Outcome switch
+                {
+                    ActionOutcome.Applied => "OK",
+                    ActionOutcome.Queued => "QUEUED",
+                    _ => "FAIL"
+                };
                 yield return $"[{status}] {exec.ComponentId}.{exec.ActionId}";
                 yield return $"     Message: {exec.Message}";
             }
@@ -726,4 +738,3 @@ public class ComponentMockingReportTests
 
     #endregion
 }
-

--- a/tests/AgentBlazor.Core.Tests/RuntimeExecutionPlansTests.cs
+++ b/tests/AgentBlazor.Core.Tests/RuntimeExecutionPlansTests.cs
@@ -24,6 +24,10 @@ public class RuntimeExecutionPlansTests
                     "show_at_risk_suppliers",
                     "semantic"),
                 new PlannedComponentAction(
+                    "AgentDialog",
+                    "open",
+                    "ui queued"),
+                new PlannedComponentAction(
                     "AgentForm",
                     "submit",
                     "ui")
@@ -34,7 +38,12 @@ public class RuntimeExecutionPlansTests
                     "supplier_compliance",
                     "show_at_risk_suppliers",
                     ActionOutcome.Applied,
-                    "Prepared a review.")
+                    "Prepared a review."),
+                new ComponentActionExecutionResult(
+                    "AgentDialog",
+                    "open",
+                    ActionOutcome.Queued,
+                    "Dialog open was queued.")
             ],
             pendingApprovals:
             [
@@ -65,6 +74,14 @@ public class RuntimeExecutionPlansTests
                 Assert.Equal(AgentApprovalMode.None, semantic.PolicyDecision.ApprovalMode);
                 Assert.Equal("supplier_compliance", semantic.TargetId);
                 Assert.Equal("show_at_risk_suppliers", semantic.ActionId);
+            },
+            queued =>
+            {
+                Assert.Equal(AgentExecutionStepKind.UiAction, queued.Kind);
+                Assert.Equal(AgentExecutionStepStatus.Queued, queued.Status);
+                Assert.False(queued.RequiresApproval);
+                Assert.Equal("AgentDialog", queued.TargetId);
+                Assert.Equal("open", queued.ActionId);
             },
             ui =>
             {

--- a/tests/AgentBlazor.Core.Tests/ServiceRegistrationTests.cs
+++ b/tests/AgentBlazor.Core.Tests/ServiceRegistrationTests.cs
@@ -819,6 +819,46 @@ public class ServiceRegistrationTests
     }
 
     [Fact]
+    public async Task ChatClientRuntimeAdapter_BlocksGeneratedUiActionApprovalCapabilityBeforePendingApproval()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<ApprovalToolInvokingChatClient>();
+        services.AddSingleton<IChatClient>(static sp => sp.GetRequiredService<ApprovalToolInvokingChatClient>());
+        services.AddAgentBlazorServices()
+            .UseChatClientRuntimeAdapter()
+            .AddCapability<ApprovalUiContractCapabilities>()
+            .AddAgent("approval-ui-agent", agent =>
+            {
+                agent.WithAllowedActions("approval_ui_contract.draft_reply");
+            });
+
+        await using var provider = services.BuildServiceProvider();
+
+        var adapter = provider.GetRequiredService<IAgentRuntimeAdapter>();
+
+        var response = await adapter.RunTurnAsync(new AgentTurnRequest(
+            "Generated UI action invoked: approval-confirmation.approve-draft.",
+            AgentName: "approval-ui-agent",
+            SessionId: "generated-ui-approval-guard",
+            GeneratedUiAction: new GeneratedUiActionInvocation(
+                "approval-confirmation",
+                "approve-draft",
+                "Approve draft reply",
+                new Dictionary<string, object?> { ["ticketId"] = "TCK-1042" })));
+
+        Assert.False(response.RequiresApproval);
+        Assert.Empty(response.PendingApprovals);
+        var blocked = Assert.Single(response.ExecutionPlan!.Steps);
+        Assert.Equal(AgentExecutionStepStatus.Blocked, blocked.Status);
+        Assert.False(blocked.RequiresApproval);
+        Assert.Equal("approval_ui_contract", blocked.TargetId);
+        Assert.Equal("draft_reply", blocked.ActionId);
+        Assert.Equal(
+            "Generated UI actions cannot request approval-gated action 'approval_ui_contract.draft_reply'. Ask for the action in chat to review and approve it.",
+            blocked.Message);
+    }
+
+    [Fact]
     public async Task ChatClientRuntimeAdapter_PersistsConversationTurnUsingScopedSessionKey()
     {
         var services = new ServiceCollection();
@@ -1827,7 +1867,8 @@ public class ServiceRegistrationTests
                 ["agentId"] = "workspace-tabs"
             }));
 
-        Assert.True(result.Succeeded);
+        Assert.False(result.Succeeded);
+        Assert.Equal(ActionOutcome.Queued, result.Outcome);
         Assert.Contains("Queued", result.Message, StringComparison.OrdinalIgnoreCase);
         Assert.True(intents.HasPending("Tabs", "workspace-tabs"));
     }
@@ -1857,7 +1898,8 @@ public class ServiceRegistrationTests
                 ["value"] = "EMEA"
             }));
 
-        Assert.True(result.Succeeded);
+        Assert.False(result.Succeeded);
+        Assert.Equal(ActionOutcome.Queued, result.Outcome);
         Assert.Contains("Queued", result.Message, StringComparison.OrdinalIgnoreCase);
         Assert.True(intents.HasPending("DataGrid", "supplier-grid-missing"));
     }
@@ -1879,7 +1921,8 @@ public class ServiceRegistrationTests
                 ["agentId"] = "supplier-grid-missing"
             }));
 
-        Assert.True(result.Succeeded);
+        Assert.False(result.Succeeded);
+        Assert.Equal(ActionOutcome.Queued, result.Outcome);
         Assert.Contains("Queued", result.Message, StringComparison.OrdinalIgnoreCase);
         Assert.True(intents.HasPending("DataGrid", "supplier-grid-missing"));
     }

--- a/tests/AgentBlazor.IntegrationTests/AgentRuntimeIntegrationTests.cs
+++ b/tests/AgentBlazor.IntegrationTests/AgentRuntimeIntegrationTests.cs
@@ -132,7 +132,7 @@ public partial class AgentRuntimeIntegrationTests
             response,
             AgentComponentCapabilityProfile.AgentDataGridComponentId,
             AgentComponentCapabilityProfile.DataGridFilterActionId,
-            succeeded: true,
+            succeeded: false,
             messageContains: "Queued"));
         Assert.DoesNotContain("Which column should I filter", response.ResponseText, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("What value should I filter by?", response.ResponseText, StringComparison.OrdinalIgnoreCase);
@@ -1443,4 +1443,3 @@ public partial class AgentRuntimeIntegrationTests
         }
     }
 }
-


### PR DESCRIPTION
## Summary
- add an explicit queued execution-step status instead of treating queued UI work as completed
- stop generated UI forwarded actions from creating approval loops for approval-gated capability/component actions
- update chat activity, traces, inspector records, AG-UI payload mapping, and tests to distinguish accepted/queued from executed/applied

## Verification
- dotnet build AgentBlazor.slnx -p:UseAppHost=false
- dotnet test tests/AgentBlazor.Core.Tests/AgentBlazor.Core.Tests.csproj -p:UseAppHost=false --filter "ServiceRegistrationTests|RuntimeExecutionPlansTests|PromptTracingTests|AgentActionDiscoveryTests"
- dotnet test tests/AgentBlazor.Components.Tests/AgentBlazor.Components.Tests.csproj -p:UseAppHost=false --filter "ExecutionPlanNarrativeFormatterTests|ExecutionStepNarrativeFormatterTests|WrapperActionExecutionTests"
- dotnet test tests/AgentBlazor.Core.Tests/AgentBlazor.Core.Tests.csproj -p:UseAppHost=false --filter ComponentMockingReportTests
- dotnet test tests/AgentBlazor.IntegrationTests/AgentBlazor.IntegrationTests.csproj -p:UseAppHost=false --filter "AgentRuntimeIntegrationTests"
- env -u OPENAI_API_KEY -u OpenAI__ApiKey dotnet test AgentBlazor.slnx -p:UseAppHost=false --no-build