### PR TITLE
Enforce route-locked agent resolution and hide demo execution details

### DIFF
--- a/demo/AgentBlazor.Demo/Components/Layout/DemoLayout.razor
+++ b/demo/AgentBlazor.Demo/Components/Layout/DemoLayout.razor
@@ -75,6 +75,8 @@
                          Description="@AssistantDescription"
                          DefaultAgentName="@DefaultAssistantAgent"
                          SessionId="@AssistantSessionId"
+                         LockAgentToCurrentRoute="@ShouldLockAssistantToRoute"
+                         ShowAgentSelector="@ShowAssistantSelector"
                          EnableGeneratedUi="true"
                          Placeholder="@AssistantPlaceholder"
                          Theme="_assistantTheme"
@@ -148,6 +150,8 @@
 
     private bool ShowAssistantPane => CurrentScenario is not null && IsWorkflowRoute && !IsComponentsRoute && !IsSupportInboxRoute;
     private bool ShowAssistantWidget => !ShowAssistantPane;
+    private bool ShouldLockAssistantToRoute => CurrentScenario is not null && IsWorkflowRoute;
+    private bool ShowAssistantSelector => !ShouldLockAssistantToRoute;
 
     private string AssistantWidgetWidth =>
         IsSupportInboxRoute

--- a/src/AgentBlazor.Core/Runtime/Adapters/ChatClientRuntimeAdapter.cs
+++ b/src/AgentBlazor.Core/Runtime/Adapters/ChatClientRuntimeAdapter.cs
@@ -1988,14 +1988,16 @@ public sealed class ChatClientRuntimeAdapter(
         IDictionary<string, string>? context)
     {
         if (!string.IsNullOrWhiteSpace(requestedName) &&
-            _agentRegistry.TryGet(requestedName, out var requested))
+            _agentRegistry.TryGet(requestedName, out var requested) &&
+            RuntimeTurnPreflight.AllowsLockedRoute(requested, context))
         {
             return requested;
         }
 
         if (RuntimeTurnPreflight.TryGetContextAgentName(context, out var contextAgentName) &&
             contextAgentName is not null &&
-            _agentRegistry.TryGet(contextAgentName, out var contextAgent))
+            _agentRegistry.TryGet(contextAgentName, out var contextAgent) &&
+            RuntimeTurnPreflight.AllowsLockedRoute(contextAgent, context))
         {
             return contextAgent;
         }

--- a/src/AgentBlazor.Core/Runtime/RuntimeTurnPreflight.cs
+++ b/src/AgentBlazor.Core/Runtime/RuntimeTurnPreflight.cs
@@ -46,6 +46,25 @@ internal static class RuntimeTurnPreflight
             return "No agents are registered.";
         }
 
+        if (IsAgentLockRequested(context) &&
+            context is not null &&
+            context.TryGetValue(AgentRuntimeContextKeys.CurrentRoute, out var currentRoute) &&
+            !string.IsNullOrWhiteSpace(currentRoute))
+        {
+            if (!string.IsNullOrWhiteSpace(requestedAgentName))
+            {
+                return $"Requested agent '{requestedAgentName}' is not configured for route '{currentRoute}'.";
+            }
+
+            if (context.TryGetValue(AgentRuntimeContextKeys.AgentName, out var lockedAgentName) &&
+                !string.IsNullOrWhiteSpace(lockedAgentName))
+            {
+                return $"Requested agent '{lockedAgentName}' is not configured for route '{currentRoute}'.";
+            }
+
+            return $"No route-locked agent is configured for '{currentRoute}'.";
+        }
+
         if (!string.IsNullOrWhiteSpace(requestedAgentName))
         {
             return $"Requested agent '{requestedAgentName}' is not registered.";
@@ -60,17 +79,37 @@ internal static class RuntimeTurnPreflight
 
         if (IsAgentLockRequested(context))
         {
-            if (context is not null &&
-                context.TryGetValue(AgentRuntimeContextKeys.CurrentRoute, out var currentRoute) &&
-                !string.IsNullOrWhiteSpace(currentRoute))
-            {
-                return $"No route-locked agent is configured for '{currentRoute}'.";
-            }
-
             return "Agent lock is enabled, but no matching registered agent could be resolved.";
         }
 
         return "No registered agent could be resolved for this request.";
+    }
+
+    public static bool AllowsLockedRoute(AgentRegistration registration, IDictionary<string, string>? context)
+    {
+        ArgumentNullException.ThrowIfNull(registration);
+
+        if (!IsAgentLockRequested(context) ||
+            context is null ||
+            !context.TryGetValue(AgentRuntimeContextKeys.CurrentRoute, out var currentRoute) ||
+            string.IsNullOrWhiteSpace(currentRoute))
+        {
+            return true;
+        }
+
+        var patterns = EnumerateRoutePatterns(registration).ToArray();
+        if (patterns.Length == 0)
+        {
+            return true;
+        }
+
+        var normalizedRoute = NormalizeRoute(currentRoute);
+        if (string.IsNullOrWhiteSpace(normalizedRoute))
+        {
+            return true;
+        }
+
+        return patterns.Any(pattern => RouteMatches(normalizedRoute, pattern));
     }
 
     public static string BuildNoAllowedActionsResponseText(
@@ -102,5 +141,60 @@ internal static class RuntimeTurnPreflight
         return registrations
             .OrderBy(static agent => agent.Name, StringComparer.OrdinalIgnoreCase)
             .FirstOrDefault();
+    }
+
+    private static IEnumerable<string> EnumerateRoutePatterns(AgentRegistration registration)
+    {
+        foreach (var key in new[] { "route", "routes", "route_prefix", "route_prefixes" })
+        {
+            if (!registration.Metadata.TryGetValue(key, out var rawValue) ||
+                string.IsNullOrWhiteSpace(rawValue))
+            {
+                continue;
+            }
+
+            foreach (var token in rawValue.Split([',', ';', '|'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            {
+                var normalized = NormalizeRoute(token);
+                if (!string.IsNullOrWhiteSpace(normalized))
+                {
+                    yield return normalized;
+                }
+            }
+        }
+    }
+
+    private static bool RouteMatches(string route, string pattern)
+        => string.Equals(route, pattern, StringComparison.OrdinalIgnoreCase) ||
+           route.StartsWith(pattern + "/", StringComparison.OrdinalIgnoreCase);
+
+    private static string? NormalizeRoute(string? route)
+    {
+        if (string.IsNullOrWhiteSpace(route))
+        {
+            return null;
+        }
+
+        var normalized = route.Trim();
+        if (Uri.TryCreate(normalized, UriKind.Absolute, out var absolute))
+        {
+            normalized = absolute.AbsolutePath;
+        }
+
+        var queryOrFragmentIndex = normalized.IndexOfAny(['?', '#']);
+        if (queryOrFragmentIndex >= 0)
+        {
+            normalized = normalized[..queryOrFragmentIndex];
+        }
+
+        if (!normalized.StartsWith('/'))
+        {
+            normalized = "/" + normalized;
+        }
+
+        normalized = normalized.TrimEnd('/');
+        return normalized.Length == 0
+            ? "/"
+            : normalized.ToLowerInvariant();
     }
 }

--- a/tests/AgentBlazor.Core.Tests/ServiceRegistrationTests.cs
+++ b/tests/AgentBlazor.Core.Tests/ServiceRegistrationTests.cs
@@ -396,6 +396,79 @@ public class ServiceRegistrationTests
     }
 
     [Fact]
+    public async Task ChatClientRuntimeAdapter_BlocksRequestedAgent_WhenRouteLockDoesNotMatchAgentRoute()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<RecordingChatClient>();
+        services.AddSingleton<IChatClient>(static sp => sp.GetRequiredService<RecordingChatClient>());
+        services.AddAgentBlazorServices()
+            .UseChatClientRuntimeAdapter()
+            .AddWorkflow<WorkflowScaffoldCapabilities>("support-agent", agent =>
+            {
+                agent.WithRoutePrefixes("/demo/workflows/support-inbox");
+            })
+            .AddWorkflow<LongCapabilityNameCapabilities>("file-agent", agent =>
+            {
+                agent.WithRoutePrefixes("/demo/workflows/file-audit-bundle");
+            });
+
+        await using var provider = services.BuildServiceProvider();
+
+        var adapter = provider.GetRequiredService<IAgentRuntimeAdapter>();
+        var chatClient = provider.GetRequiredService<RecordingChatClient>();
+
+        var response = await adapter.RunTurnAsync(new AgentTurnRequest(
+            "Show open tickets from this week",
+            AgentName: "file-agent",
+            SessionId: "route-lock-mismatch",
+            Context: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                [AgentRuntimeContextKeys.AgentLock] = bool.TrueString,
+                [AgentRuntimeContextKeys.CurrentRoute] = "/demo/workflows/support-inbox"
+            }));
+
+        Assert.Equal("none", response.AgentName);
+        Assert.Contains("Requested agent 'file-agent' is not configured for route '/demo/workflows/support-inbox'.", response.ResponseText, StringComparison.Ordinal);
+        Assert.Empty(chatClient.Requests);
+    }
+
+    [Fact]
+    public async Task ChatClientRuntimeAdapter_AllowsRequestedAgent_WhenRouteLockMatchesAgentRoute()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<RecordingChatClient>();
+        services.AddSingleton<IChatClient>(static sp => sp.GetRequiredService<RecordingChatClient>());
+        services.AddAgentBlazorServices()
+            .UseChatClientRuntimeAdapter()
+            .AddWorkflow<WorkflowScaffoldCapabilities>("support-agent", agent =>
+            {
+                agent.WithRoutePrefixes("/demo/workflows/support-inbox");
+            })
+            .AddWorkflow<LongCapabilityNameCapabilities>("file-agent", agent =>
+            {
+                agent.WithRoutePrefixes("/demo/workflows/file-audit-bundle");
+            });
+
+        await using var provider = services.BuildServiceProvider();
+
+        var adapter = provider.GetRequiredService<IAgentRuntimeAdapter>();
+        var chatClient = provider.GetRequiredService<RecordingChatClient>();
+
+        var response = await adapter.RunTurnAsync(new AgentTurnRequest(
+            "Show open tickets from this week",
+            AgentName: "support-agent",
+            SessionId: "route-lock-match",
+            Context: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                [AgentRuntimeContextKeys.AgentLock] = bool.TrueString,
+                [AgentRuntimeContextKeys.CurrentRoute] = "/demo/workflows/support-inbox"
+            }));
+
+        Assert.Equal("support-agent", response.AgentName);
+        Assert.Single(chatClient.Requests);
+    }
+
+    [Fact]
     public void CapabilityResult_HelperMethods_MergeStructuredOutcomeData()
     {
         var result = global::AgentBlazor.App.CapabilityResult.Success("Prepared the workflow.")


### PR DESCRIPTION
## Summary
- route-lock demo workflow widgets so support-inbox cannot retain a stale agent from another workflow route
- make runtime agent resolution reject requested/context agents whose route prefixes do not match the current route when agent lock is enabled
- add a public ShowExecutionDetails switch to chat surface/widget/panel/bar components
- hide execution-plan diagnostics in public demo workflow chats while keeping default developer behavior unchanged

## Verification
- dotnet test tests/AgentBlazor.Core.Tests/AgentBlazor.Core.Tests.csproj -p:UseAppHost=false --filter "ServiceRegistrationTests"
- dotnet test tests/AgentBlazor.Components.Tests/AgentBlazor.Components.Tests.csproj -p:UseAppHost=false --filter "AgentChatSurfaceTests|AgentChatAutomationSelectorTests"
- dotnet build demo/AgentBlazor.Demo/AgentBlazor.Demo.csproj -p:UseAppHost=false
- env -u OPENAI_API_KEY -u OpenAI__ApiKey dotnet test AgentBlazor.slnx -p:UseAppHost=false --no-build