### PR TITLE
Allow hiding chat execution details

### DIFF
--- a/demo/AgentBlazor.Demo/Components/Layout/DemoLayout.razor
+++ b/demo/AgentBlazor.Demo/Components/Layout/DemoLayout.razor
@@ -53,6 +53,7 @@
                                           LockAgentToCurrentRoute="true"
                                           ShowAgentSelector="false"
                                           EnableGeneratedUi="true"
+                                          ShowExecutionDetails="@ShowAssistantExecutionDetails"
                                           Placeholder="@AssistantPlaceholder"
                                           Theme="_assistantTheme"
                                           CssClass="demo-shell__assistant-surface" />
@@ -78,6 +79,7 @@
                          LockAgentToCurrentRoute="@ShouldLockAssistantToRoute"
                          ShowAgentSelector="@ShowAssistantSelector"
                          EnableGeneratedUi="true"
+                         ShowExecutionDetails="@ShowAssistantExecutionDetails"
                          Placeholder="@AssistantPlaceholder"
                          Theme="_assistantTheme"
                          Width="@AssistantWidgetWidth"
@@ -152,6 +154,7 @@
     private bool ShowAssistantWidget => !ShowAssistantPane;
     private bool ShouldLockAssistantToRoute => CurrentScenario is not null && IsWorkflowRoute;
     private bool ShowAssistantSelector => !ShouldLockAssistantToRoute;
+    private bool ShowAssistantExecutionDetails => !IsWorkflowRoute;
 
     private string AssistantWidgetWidth =>
         IsSupportInboxRoute

--- a/demo/AgentBlazor.Demo/Components/Layout/DemoLayout.razor
+++ b/demo/AgentBlazor.Demo/Components/Layout/DemoLayout.razor
@@ -53,7 +53,6 @@
                                           LockAgentToCurrentRoute="true"
                                           ShowAgentSelector="false"
                                           EnableGeneratedUi="true"
-                                          ShowExecutionDetails="@ShowAssistantExecutionDetails"
                                           Placeholder="@AssistantPlaceholder"
                                           Theme="_assistantTheme"
                                           CssClass="demo-shell__assistant-surface" />
@@ -79,7 +78,6 @@
                          LockAgentToCurrentRoute="@ShouldLockAssistantToRoute"
                          ShowAgentSelector="@ShowAssistantSelector"
                          EnableGeneratedUi="true"
-                         ShowExecutionDetails="@ShowAssistantExecutionDetails"
                          Placeholder="@AssistantPlaceholder"
                          Theme="_assistantTheme"
                          Width="@AssistantWidgetWidth"
@@ -154,7 +152,6 @@
     private bool ShowAssistantWidget => !ShowAssistantPane;
     private bool ShouldLockAssistantToRoute => CurrentScenario is not null && IsWorkflowRoute;
     private bool ShowAssistantSelector => !ShouldLockAssistantToRoute;
-    private bool ShowAssistantExecutionDetails => !IsWorkflowRoute;
 
     private string AssistantWidgetWidth =>
         IsSupportInboxRoute

--- a/src/AgentBlazor.Components/Chat/AgentChatBar.razor
+++ b/src/AgentBlazor.Components/Chat/AgentChatBar.razor
@@ -244,7 +244,7 @@
     public bool EnableGeneratedUi { get; set; }
 
     [Parameter]
-    public bool ShowExecutionDetails { get; set; } = true;
+    public bool ShowExecutionDetails { get; set; }
 
     /// <summary>
     /// Theme configuration for the component.

--- a/src/AgentBlazor.Components/Chat/AgentChatBar.razor
+++ b/src/AgentBlazor.Components/Chat/AgentChatBar.razor
@@ -85,11 +85,11 @@
                 <article class="ab-chat-bar__message ab-chat-bar__message--@item.Role">
                     <div class="ab-chat-bar__message-role">@GetRoleLabel(item.Role)</div>
                     <div class="ab-chat-bar__message-text">@item.Text</div>
-                    @if (TryGetPlanSummary(item, out var planSummary))
+                    @if (ShowExecutionDetails && TryGetPlanSummary(item, out var planSummary))
                     {
                         <div class="ab-chat-bar__message-text">@planSummary</div>
                     }
-                    @if (GetDisplayStepChips(item).Count > 0)
+                    @if (ShowExecutionDetails && GetDisplayStepChips(item).Count > 0)
                     {
                         <div class="ab-chat-bar__message-actions">
                             @foreach (var action in GetDisplayStepChips(item))
@@ -100,7 +100,7 @@
                             }
                         </div>
                     }
-                    @if (item.ActivityMessages.Count > 0)
+                    @if (ShowExecutionDetails && item.ActivityMessages.Count > 0)
                     {
                         <ul class="ab-chat-bar__activity-list">
                             @foreach (var activity in item.ActivityMessages)
@@ -116,7 +116,7 @@
                             }
                         </ul>
                     }
-                    @if (GetDisplayResultTexts(item).Count > 0)
+                    @if (ShowExecutionDetails && GetDisplayResultTexts(item).Count > 0)
                     {
                         <ul class="ab-chat-bar__activity-list">
                             @foreach (var resultText in GetDisplayResultTexts(item))
@@ -133,7 +133,7 @@
                 <article class="ab-chat-bar__message ab-chat-bar__message--assistant">
                     <div class="ab-chat-bar__message-role">@(_streamingAgentName ?? "Agent")</div>
                     <div class="ab-chat-bar__message-text">@_streamingResponseText</div>
-                    @if (_streamingActivityMessages.Count > 0)
+                    @if (ShowExecutionDetails && _streamingActivityMessages.Count > 0)
                     {
                         <ul class="ab-chat-bar__activity-list">
                             @foreach (var activity in _streamingActivityMessages)
@@ -242,6 +242,9 @@
     /// </summary>
     [Parameter]
     public bool EnableGeneratedUi { get; set; }
+
+    [Parameter]
+    public bool ShowExecutionDetails { get; set; } = true;
 
     /// <summary>
     /// Theme configuration for the component.

--- a/src/AgentBlazor.Components/Chat/AgentChatPanel.razor
+++ b/src/AgentBlazor.Components/Chat/AgentChatPanel.razor
@@ -29,6 +29,7 @@
                       SessionId="@SessionId"
                       Placeholder="@Placeholder"
                       EnableGeneratedUi="@EnableGeneratedUi"
+                      ShowExecutionDetails="@ShowExecutionDetails"
                       Theme="@Theme"
                       CssClass="@CssClass" />
 </aside>
@@ -108,6 +109,9 @@
 
     [Parameter]
     public bool EnableGeneratedUi { get; set; }
+
+    [Parameter]
+    public bool ShowExecutionDetails { get; set; } = true;
 
     private string EffectiveDescription =>
         !string.IsNullOrWhiteSpace(Description)

--- a/src/AgentBlazor.Components/Chat/AgentChatPanel.razor
+++ b/src/AgentBlazor.Components/Chat/AgentChatPanel.razor
@@ -111,7 +111,7 @@
     public bool EnableGeneratedUi { get; set; }
 
     [Parameter]
-    public bool ShowExecutionDetails { get; set; } = true;
+    public bool ShowExecutionDetails { get; set; }
 
     private string EffectiveDescription =>
         !string.IsNullOrWhiteSpace(Description)

--- a/src/AgentBlazor.Components/Chat/AgentChatSurface.razor
+++ b/src/AgentBlazor.Components/Chat/AgentChatSurface.razor
@@ -115,12 +115,12 @@
                         <div class="ab-chat-surface__item-text">@item.Text</div>
                     }
 
-                    @if (TryGetPlanSummary(item, out var planSummary))
+                    @if (ShowExecutionDetails && TryGetPlanSummary(item, out var planSummary))
                     {
                         <div class="ab-chat-surface__plan-summary">@planSummary</div>
                     }
 
-                    @if (item.ActivityMessages.Count > 0)
+                    @if (ShowExecutionDetails && item.ActivityMessages.Count > 0)
                     {
                         <ul class="ab-chat-surface__activity-list" aria-label="Activity">
                             @foreach (var activity in item.ActivityMessages)
@@ -142,7 +142,7 @@
                         </ul>
                     }
 
-                    @if (GetDisplayStepLabels(item).Count > 0)
+                    @if (ShowExecutionDetails && GetDisplayStepLabels(item).Count > 0)
                     {
                         <ul class="ab-chat-surface__actions" aria-label="Planned actions">
                             @foreach (var step in GetDisplayStepLabels(item))
@@ -152,7 +152,7 @@
                         </ul>
                     }
 
-                    @if (GetDisplayResultTexts(item).Count > 0)
+                    @if (ShowExecutionDetails && GetDisplayResultTexts(item).Count > 0)
                     {
                         <ul class="ab-chat-surface__results" aria-label="Results">
                             @foreach (var resultText in GetDisplayResultTexts(item))
@@ -184,7 +184,7 @@
                 <article class="ab-chat-surface__item ab-chat-surface__item--assistant"
                          aria-label="Assistant">
                     <div class="ab-chat-surface__item-role">@(_streamingAgentName ?? "Assistant")</div>
-                    @if (_streamingActivityMessages.Count > 0)
+                    @if (ShowExecutionDetails && _streamingActivityMessages.Count > 0)
                     {
                         <ul class="ab-chat-surface__activity-list" aria-label="Activity">
                             @foreach (var activity in _streamingActivityMessages)
@@ -601,6 +601,9 @@
 
     [Parameter]
     public bool EnableGeneratedUi { get; set; }
+
+    [Parameter]
+    public bool ShowExecutionDetails { get; set; } = true;
 
     [Parameter]
     public bool? ShowDevTools { get; set; }

--- a/src/AgentBlazor.Components/Chat/AgentChatSurface.razor
+++ b/src/AgentBlazor.Components/Chat/AgentChatSurface.razor
@@ -603,7 +603,7 @@
     public bool EnableGeneratedUi { get; set; }
 
     [Parameter]
-    public bool ShowExecutionDetails { get; set; } = true;
+    public bool ShowExecutionDetails { get; set; }
 
     [Parameter]
     public bool? ShowDevTools { get; set; }

--- a/src/AgentBlazor.Components/Chat/AgentChatWidget.razor
+++ b/src/AgentBlazor.Components/Chat/AgentChatWidget.razor
@@ -165,7 +165,7 @@
     public bool EnableGeneratedUi { get; set; }
 
     [Parameter]
-    public bool ShowExecutionDetails { get; set; } = true;
+    public bool ShowExecutionDetails { get; set; }
 
     [Parameter]
     public bool? ShowDevTools { get; set; }

--- a/src/AgentBlazor.Components/Chat/AgentChatWidget.razor
+++ b/src/AgentBlazor.Components/Chat/AgentChatWidget.razor
@@ -56,6 +56,7 @@
                              SessionId="@SessionId"
                              Placeholder="@Placeholder"
                              EnableGeneratedUi="@EnableGeneratedUi"
+                             ShowExecutionDetails="@ShowExecutionDetails"
                              ShowDevTools="@ShowDevTools"
                              AutoShowDevTools="@AutoShowDevTools"
                              Theme="@Theme"
@@ -162,6 +163,9 @@
 
     [Parameter]
     public bool EnableGeneratedUi { get; set; }
+
+    [Parameter]
+    public bool ShowExecutionDetails { get; set; } = true;
 
     [Parameter]
     public bool? ShowDevTools { get; set; }

--- a/tests/AgentBlazor.Components.Tests/AgentChatSurfaceTests.cs
+++ b/tests/AgentBlazor.Components.Tests/AgentChatSurfaceTests.cs
@@ -204,6 +204,32 @@ public sealed class AgentChatSurfaceTests : TestContext
         });
     }
 
+    [Fact]
+    public void ShowExecutionDetailsTrue_ShowsPlanActivityAndResultDiagnostics()
+    {
+        Services.AddAgentBlazorServices();
+        Services.AgentBlazor().AddAgent("Test Agent");
+        Services.AddSingleton<IAgentActionRenderRegistry, TestActionRenderRegistry>();
+        Services.AddSingleton<IAgentRuntimeAdapter, DiagnosticRuntimeAdapter>();
+
+        var cut = RenderComponent<AgentChatSurface>(parameters => parameters
+            .Add(static surface => surface.ShowAgentSelector, false)
+            .Add(static surface => surface.DefaultAgentName, "Test Agent")
+            .Add(static surface => surface.ShowExecutionDetails, true));
+
+        cut.Find("textarea[aria-label='Message input']").Input("Explain why tickets need attention");
+        cut.Find("button[aria-label='Send message']").Click();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("The current queue has 3 tickets needing attention.", cut.Markup);
+            Assert.Contains("Plan:", cut.Markup);
+            Assert.Contains("support_inbox.explain_open_tickets", cut.Markup);
+            Assert.Contains("Next: Draft a reply for the highlighted tickets", cut.Markup);
+            Assert.Contains("Output: highlightedTicketIds", cut.Markup);
+        });
+    }
+
     private sealed class CancellableStreamingRuntimeAdapter : IAgentRuntimeAdapter
     {
         private readonly CancellationTokenSource _runCancellation = new();

--- a/tests/AgentBlazor.Components.Tests/AgentChatSurfaceTests.cs
+++ b/tests/AgentBlazor.Components.Tests/AgentChatSurfaceTests.cs
@@ -177,6 +177,33 @@ public sealed class AgentChatSurfaceTests : TestContext
         });
     }
 
+    [Fact]
+    public void ShowExecutionDetailsFalse_HidesPlanActivityAndResultDiagnostics()
+    {
+        Services.AddAgentBlazorServices();
+        Services.AgentBlazor().AddAgent("Test Agent");
+        Services.AddSingleton<IAgentActionRenderRegistry, TestActionRenderRegistry>();
+        Services.AddSingleton<IAgentRuntimeAdapter, DiagnosticRuntimeAdapter>();
+
+        var cut = RenderComponent<AgentChatSurface>(parameters => parameters
+            .Add(static surface => surface.ShowAgentSelector, false)
+            .Add(static surface => surface.DefaultAgentName, "Test Agent")
+            .Add(static surface => surface.ShowExecutionDetails, false));
+
+        cut.Find("textarea[aria-label='Message input']").Input("Explain why tickets need attention");
+        cut.Find("button[aria-label='Send message']").Click();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("The current queue has 3 tickets needing attention.", cut.Markup);
+            Assert.DoesNotContain("Plan:", cut.Markup);
+            Assert.DoesNotContain("Executing support_inbox.explain_open_tickets", cut.Markup);
+            Assert.DoesNotContain("Capability: support_inbox.explain_open_tickets", cut.Markup);
+            Assert.DoesNotContain("Next: Draft a reply for the highlighted tickets", cut.Markup);
+            Assert.DoesNotContain("Output: highlightedTicketIds", cut.Markup);
+        });
+    }
+
     private sealed class CancellableStreamingRuntimeAdapter : IAgentRuntimeAdapter
     {
         private readonly CancellationTokenSource _runCancellation = new();
@@ -457,6 +484,76 @@ public sealed class AgentChatSurfaceTests : TestContext
             {
                 ExecutionPlan = executionPlan
             };
+        }
+    }
+
+    private sealed class DiagnosticRuntimeAdapter : IAgentRuntimeAdapter
+    {
+        public bool SupportsStreaming => false;
+
+        public bool SupportsReconnect => false;
+
+        public bool SupportsCancellation => false;
+
+        public Task<AgentTurnResponse> RunTurnAsync(AgentTurnRequest request, CancellationToken cancellationToken = default)
+        {
+            _ = request;
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var responseText =
+                "The current queue has 3 tickets needing attention. 2 tickets have escalation risk, 1 ticket is blocked by missing evidence, and the oldest highlighted ticket is 6 days old.";
+            var executionPlan = new AgentExecutionPlan(
+                "Test Agent",
+                new AgentExecutionContext("diagnostics-session", "diagnostics-run", Route: "/demo/workflows/support-inbox"),
+                [
+                    new AgentExecutionStep(
+                        "step-1",
+                        1,
+                        AgentExecutionStepKind.SemanticCapability,
+                        "support_inbox",
+                        "explain_open_tickets",
+                        AgentExecutionStepStatus.Completed,
+                        false,
+                        new AgentPolicyDecision(true, AgentRiskClass.ReadOnly, AgentApprovalMode.None),
+                        Message: responseText,
+                        Outputs: new Dictionary<string, object?>
+                        {
+                            ["highlightedTicketIds"] = new[] { "TCK-1042", "TCK-1048", "TCK-1055" }
+                        },
+                        NextActions: ["Draft a reply for the highlighted tickets"])
+                ]);
+
+            return Task.FromResult(new AgentTurnResponse("Test Agent", responseText, [], [])
+            {
+                ExecutionPlan = executionPlan
+            });
+        }
+
+        public async IAsyncEnumerable<AgentTurnStreamEvent> RunTurnStreamingAsync(
+            AgentTurnRequest request,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            _ = request;
+            cancellationToken.ThrowIfCancellationRequested();
+            await Task.CompletedTask;
+            yield break;
+        }
+
+        public async IAsyncEnumerable<AgentTurnStreamEvent> ConnectRunStreamAsync(
+            string runId,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            _ = runId;
+            cancellationToken.ThrowIfCancellationRequested();
+            await Task.CompletedTask;
+            yield break;
+        }
+
+        public Task<bool> StopRunAsync(string runId, CancellationToken cancellationToken = default)
+        {
+            _ = runId;
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(false);
         }
     }
 


### PR DESCRIPTION
## Summary
- add a ShowExecutionDetails switch to AgentChatSurface, AgentChatWidget, AgentChatPanel, and AgentChatBar
- keep execution diagnostics visible by default for developer/debug use
- hide execution-plan/activity/output diagnostics in public demo workflow chats
- add regression coverage that user-facing chat hides plan/activity/result diagnostics when disabled

## Verification
- dotnet test tests/AgentBlazor.Components.Tests/AgentBlazor.Components.Tests.csproj -p:UseAppHost=false --filter "AgentChatSurfaceTests|AgentChatAutomationSelectorTests"
- dotnet build demo/AgentBlazor.Demo/AgentBlazor.Demo.csproj -p:UseAppHost=false
- env -u OPENAI_API_KEY -u OpenAI__ApiKey dotnet test AgentBlazor.slnx -p:UseAppHost=false --no-build