### PR TITLE
Add hosted demo links to public docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Add an agent chat surface and deterministic app actions to a Blazor app.
 
 AgentBlazor gives a Blazor route a chat surface, explicit capabilities, approval-gated actions, and deterministic UI execution without replacing the normal app UI.
 
+Try the hosted demo:
+
+- https://demo.agentblazor.com/demo/workflows/support-inbox
+
 ## Install
 
 ```bash
@@ -80,6 +84,7 @@ Render one chat surface:
 - Home quickstart: `/`
 - Docs: `/docs`
 - Live demo: `/demo`
+- Hosted demo: https://demo.agentblazor.com/demo/workflows/support-inbox
 - Starter sample: `samples/AgentBlazor.Starter`
 - Starter sample route: `/ops-review`
 

--- a/docs/beta-testing.md
+++ b/docs/beta-testing.md
@@ -2,6 +2,8 @@
 
 Use this guide if you are testing AgentBlazor before launch.
 
+Hosted demo: https://demo.agentblazor.com/demo/workflows/support-inbox
+
 ## Goal
 
 Prove four things:
@@ -30,6 +32,10 @@ Use the support-inbox shape only:
 - one workflow
 - one chat surface
 - one approval-gated action
+
+Compare against the hosted support-inbox demo if you want a known-running reference:
+
+- https://demo.agentblazor.com/demo/workflows/support-inbox
 
 ## Exact Checks
 

--- a/docs/deployment/demo-container-apps.md
+++ b/docs/deployment/demo-container-apps.md
@@ -4,6 +4,10 @@ Recommended low-cost host: Azure Container Apps Consumption, using a public GHCR
 
 Use `demo.agentblazor.com` for the live demo. Keep `agentblazor.com` free for the landing page.
 
+Live URL:
+
+- https://demo.agentblazor.com/demo/workflows/support-inbox
+
 ## 1. Build The Image
 
 Run the `Demo Container` GitHub Actions workflow. It publishes:
@@ -79,6 +83,24 @@ DemoSecurity__RateLimiting__WindowSeconds=60
 ```
 
 Do not set `AgentBlazor:LicenseKey` for the public v1 demo unless you intentionally want Pro surfaces visible.
+
+## 5. Logging And Cost Guardrails
+
+Current demo observability is intentionally lightweight:
+
+- ASP.NET Core console logging is enabled at `Information` for `AgentBlazor` categories.
+- Azure Container Apps can stream container `stdout`/`stderr` logs without adding Application Insights code.
+- The Container Apps environment should use `--logs-destination none` to avoid persisted Azure Monitor / Log Analytics ingestion charges.
+- AgentBlazor prompt tracing is enabled in memory for runtime debugging, but traces are not persisted across container restarts.
+- The public agent endpoint is rate limited by client IP. The current deployment uses `20` requests per minute.
+
+What is not wired yet:
+
+- No Application Insights SDK or OpenTelemetry exporter is registered by the demo app.
+- No durable structured chat-request log exists yet for prompt length, route, agent, timing, status, or error.
+- No OpenAI token or cost usage tracker is stored by the demo app.
+
+For a low-cost public demo, prefer structured console logs first and keep Log Analytics/Application Insights ingestion off or minimal unless there is a specific incident to debug.
 
 ## Rollback
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -2,6 +2,8 @@
 
 Get one working AgentBlazor chat widget into a fresh Blazor app. Tested against a clean `dotnet new blazor` project with `AgentBlazor 0.1.0-preview.11`.
 
+Hosted demo: https://demo.agentblazor.com/demo/workflows/support-inbox
+
 AgentBlazor does not create a responding agent by default. You must register at least one workflow.
 
 ## 1. Install
@@ -174,5 +176,6 @@ Say hello
 
 ## Next
 
+- [Hosted demo](https://demo.agentblazor.com/demo/workflows/support-inbox)
 - [Starter sample](../samples/AgentBlazor.Starter/README.md)
 - [Hosted WebAssembly client](../src/AgentBlazor.Client/PACKAGE_README.md)

--- a/samples/AgentBlazor.Starter/README.md
+++ b/samples/AgentBlazor.Starter/README.md
@@ -4,7 +4,11 @@ This sample is a reference app, not the onboarding path.
 
 Use the public quickstart first:
 
-- [docs/quickstart.md](/home/ashdev/workspace/AgentBlazor/docs/quickstart.md)
+- [docs/quickstart.md](../../docs/quickstart.md)
+
+Hosted support-inbox demo:
+
+- https://demo.agentblazor.com/demo/workflows/support-inbox
 
 Then use this starter when you want to inspect a slightly fuller route-scoped workflow example with:
 

--- a/src/AgentBlazor.Components/PACKAGE_README.md
+++ b/src/AgentBlazor.Components/PACKAGE_README.md
@@ -2,6 +2,10 @@
 
 Add an agent chat surface and deterministic app actions to a Blazor app.
 
+Hosted demo:
+
+- https://demo.agentblazor.com/demo/workflows/support-inbox
+
 Install:
 
 ```bash
@@ -78,5 +82,6 @@ public sealed class SupportInboxCapabilities
 Docs and demo:
 
 - Repository: https://github.com/ashpeterson/AgentBlazor
+- Hosted demo: https://demo.agentblazor.com/demo/workflows/support-inbox
 - Quickstart: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/quickstart.md
 - Starter sample: https://github.com/ashpeterson/AgentBlazor/tree/master/samples/AgentBlazor.Starter


### PR DESCRIPTION
Adds the hosted support-inbox demo URL to the public README, package README, quickstart, beta guide, starter README, and demo deployment notes. Also documents the current lightweight demo logging/cost posture.