### PR TITLE
Add demo structured request logging

### DIFF
--- a/demo/AgentBlazor.Demo/Configuration/DemoLoggingOptions.cs
+++ b/demo/AgentBlazor.Demo/Configuration/DemoLoggingOptions.cs
@@ -1,0 +1,20 @@
+namespace AgentBlazor.Demo.Configuration;
+
+internal sealed class DemoLoggingOptions
+{
+    public const string SectionName = "DemoLogging";
+
+    public bool Enabled { get; set; } = true;
+
+    public string DirectoryPath { get; set; } = Path.Combine(Path.GetTempPath(), "agentblazor-demo-logs");
+
+    public string FileName { get; set; } = "chat-requests.jsonl";
+
+    public string? AccessToken { get; set; }
+
+    public bool IncludePromptPreview { get; set; }
+
+    public int PromptPreviewMaxLength { get; set; } = 160;
+
+    public int MaxTailLines { get; set; } = 500;
+}

--- a/demo/AgentBlazor.Demo/Program.cs
+++ b/demo/AgentBlazor.Demo/Program.cs
@@ -30,9 +30,11 @@ builder.Services.AddScoped<SupportInboxWorkflowService>();
 builder.Services.AddScoped<ResponseOrchestrationWorkflowService>();
 builder.Services.AddScoped<ReleaseDossierWorkflowService>();
 builder.Services.Configure<DemoSecurityOptions>(builder.Configuration.GetSection(DemoSecurityOptions.SectionName));
+builder.Services.Configure<DemoLoggingOptions>(builder.Configuration.GetSection(DemoLoggingOptions.SectionName));
 builder.Services.Configure<DemoRemoteStorageOptions>(builder.Configuration.GetSection(DemoRemoteStorageOptions.SectionName));
 builder.Services.AddHttpClient("demo-remote-storage");
 builder.Services.AddSingleton<IDemoRemoteStorageAdapter, DemoRemoteStorageAdapter>();
+builder.Services.AddSingleton<IDemoChatRequestLog, JsonlDemoChatRequestLog>();
 
 var demoSecurityOptions = builder.Configuration.GetSection(DemoSecurityOptions.SectionName).Get<DemoSecurityOptions>()
     ?? new DemoSecurityOptions();
@@ -89,6 +91,19 @@ builder.Services.PostConfigure<DemoRemoteStorageOptions>(options =>
     options.HttpBearerToken = FirstConfigured(
         Environment.GetEnvironmentVariable("DEMO_REMOTE_STORAGE_HTTP_BEARER_TOKEN"),
         options.HttpBearerToken);
+});
+
+builder.Services.PostConfigure<DemoLoggingOptions>(options =>
+{
+    options.DirectoryPath = FirstConfigured(
+            Environment.GetEnvironmentVariable("DEMO_LOG_DIRECTORY"),
+            Environment.GetEnvironmentVariable("DemoLogging__DirectoryPath"),
+            options.DirectoryPath)
+        ?? Path.Combine(Path.GetTempPath(), "agentblazor-demo-logs");
+    options.AccessToken = FirstConfigured(
+        Environment.GetEnvironmentVariable("DEMO_LOG_ACCESS_TOKEN"),
+        Environment.GetEnvironmentVariable("DemoLogging__AccessToken"),
+        options.AccessToken);
 });
 
 if (demoSecurityOptions.TrustForwardedHeaders)
@@ -151,6 +166,8 @@ builder.Services.AddAgentBlazor(options =>
     {
         options.UseProLicense(proLicenseKey, proDataDirectory);
     }
+
+    options.UseMiddleware<DemoChatRequestLoggingMiddleware>();
 
     options.ConfigureBuilder(agentBuilder =>
     {
@@ -303,6 +320,7 @@ app.MapStaticAssets();
 app.MapRazorComponents<App>()
     .AddInteractiveServerRenderMode();
 var agentEndpoints = app.MapAgentBlazorEndpoints();
+app.MapDemoLogEndpoints();
 
 if (demoSecurityOptions.RateLimiting.Enabled)
 {

--- a/demo/AgentBlazor.Demo/Services/DemoChatRequestLogEntry.cs
+++ b/demo/AgentBlazor.Demo/Services/DemoChatRequestLogEntry.cs
@@ -1,0 +1,63 @@
+using System.Text.Json.Serialization;
+
+namespace AgentBlazor.Demo.Services;
+
+internal sealed record DemoChatRequestLogEntry
+{
+    [JsonPropertyName("timestampUtc")]
+    public DateTimeOffset TimestampUtc { get; init; } = DateTimeOffset.UtcNow;
+
+    [JsonPropertyName("requestId")]
+    public required string RequestId { get; init; }
+
+    [JsonPropertyName("route")]
+    public string? Route { get; init; }
+
+    [JsonPropertyName("agentName")]
+    public string? AgentName { get; init; }
+
+    [JsonPropertyName("requestedAgentName")]
+    public string? RequestedAgentName { get; init; }
+
+    [JsonPropertyName("sessionHash")]
+    public string? SessionHash { get; init; }
+
+    [JsonPropertyName("promptLength")]
+    public int PromptLength { get; init; }
+
+    [JsonPropertyName("promptPreview")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? PromptPreview { get; init; }
+
+    [JsonPropertyName("durationMs")]
+    public long DurationMs { get; init; }
+
+    [JsonPropertyName("status")]
+    public required string Status { get; init; }
+
+    [JsonPropertyName("responseLength")]
+    public int ResponseLength { get; init; }
+
+    [JsonPropertyName("requiresApproval")]
+    public bool RequiresApproval { get; init; }
+
+    [JsonPropertyName("requiresClarification")]
+    public bool RequiresClarification { get; init; }
+
+    [JsonPropertyName("plannedActionCount")]
+    public int PlannedActionCount { get; init; }
+
+    [JsonPropertyName("executionResultCount")]
+    public int ExecutionResultCount { get; init; }
+
+    [JsonPropertyName("failedExecutionCount")]
+    public int FailedExecutionCount { get; init; }
+
+    [JsonPropertyName("errorType")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ErrorType { get; init; }
+
+    [JsonPropertyName("errorMessage")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ErrorMessage { get; init; }
+}

--- a/demo/AgentBlazor.Demo/Services/DemoChatRequestLoggingMiddleware.cs
+++ b/demo/AgentBlazor.Demo/Services/DemoChatRequestLoggingMiddleware.cs
@@ -1,0 +1,151 @@
+using System.Diagnostics;
+using System.Security.Cryptography;
+using System.Text;
+using AgentBlazor.Core.Runtime.Agents;
+using AgentBlazor.Core.Runtime.Middleware;
+using AgentBlazor.Demo.Configuration;
+using AgentBlazor.Execution;
+using Microsoft.Extensions.Options;
+
+namespace AgentBlazor.Demo.Services;
+
+internal sealed class DemoChatRequestLoggingMiddleware(
+    IDemoChatRequestLog requestLog,
+    IOptions<DemoLoggingOptions> options,
+    ILogger<DemoChatRequestLoggingMiddleware> logger) : IAgentTurnMiddleware
+{
+    private readonly DemoLoggingOptions _options = options.Value;
+
+    public async Task InvokeAsync(
+        AgentTurnContext context,
+        Func<CancellationToken, Task> next,
+        CancellationToken ct = default)
+    {
+        if (!_options.Enabled)
+        {
+            await next(ct);
+            return;
+        }
+
+        var requestId = Guid.NewGuid().ToString("n");
+        var stopwatch = Stopwatch.StartNew();
+
+        try
+        {
+            await next(ct);
+            stopwatch.Stop();
+
+            var response = context.Response;
+            var entry = CreateEntry(
+                context.Request,
+                requestId,
+                stopwatch.ElapsedMilliseconds,
+                response is null ? "missing-response" : "ok",
+                response);
+
+            await requestLog.AppendAsync(entry, ct);
+            logger.LogInformation(
+                "Demo chat request {RequestId} completed: route={Route} agent={AgentName} status={Status} promptLength={PromptLength} durationMs={DurationMs} planned={PlannedActionCount} executed={ExecutionResultCount} failed={FailedExecutionCount}",
+                entry.RequestId,
+                entry.Route,
+                entry.AgentName,
+                entry.Status,
+                entry.PromptLength,
+                entry.DurationMs,
+                entry.PlannedActionCount,
+                entry.ExecutionResultCount,
+                entry.FailedExecutionCount);
+        }
+        catch (Exception ex)
+        {
+            stopwatch.Stop();
+
+            var entry = CreateEntry(
+                context.Request,
+                requestId,
+                stopwatch.ElapsedMilliseconds,
+                "error",
+                context.Response,
+                ex);
+
+            await requestLog.AppendAsync(entry, CancellationToken.None);
+            logger.LogError(
+                ex,
+                "Demo chat request {RequestId} failed: route={Route} agent={AgentName} promptLength={PromptLength} durationMs={DurationMs}",
+                entry.RequestId,
+                entry.Route,
+                entry.AgentName,
+                entry.PromptLength,
+                entry.DurationMs);
+
+            throw;
+        }
+    }
+
+    private DemoChatRequestLogEntry CreateEntry(
+        AgentTurnRequest request,
+        string requestId,
+        long durationMs,
+        string status,
+        AgentTurnResponse? response,
+        Exception? exception = null)
+    {
+        var executionPlan = response?.ExecutionPlan;
+        IReadOnlyList<AgentExecutionStep> executionSteps = executionPlan?.Steps ?? [];
+        var failedExecutionCount = executionSteps.Count(static step =>
+            step.Status is not AgentExecutionStepStatus.Completed);
+
+        return new DemoChatRequestLogEntry
+        {
+            RequestId = requestId,
+            Route = TryGetContext(request, AgentRuntimeContextKeys.CurrentRoute),
+            AgentName = response?.AgentName,
+            RequestedAgentName = request.AgentName,
+            SessionHash = HashIdentifier(request.GetEffectiveSessionId()),
+            PromptLength = request.UserMessage.Length,
+            PromptPreview = _options.IncludePromptPreview
+                ? BuildPromptPreview(request.UserMessage, _options.PromptPreviewMaxLength)
+                : null,
+            DurationMs = durationMs,
+            Status = status,
+            ResponseLength = response?.ResponseText.Length ?? 0,
+            RequiresApproval = response?.RequiresApproval ?? false,
+            RequiresClarification = response?.RequiresClarification ?? false,
+            PlannedActionCount = executionPlan?.Steps.Count ?? response?.PlannedActions.Count ?? 0,
+            ExecutionResultCount = executionSteps.Count > 0
+                ? executionSteps.Count
+                : response?.ExecutionResults.Count ?? 0,
+            FailedExecutionCount = executionSteps.Count > 0
+                ? failedExecutionCount
+                : response?.ExecutionResults.Count(static result => !result.Succeeded) ?? 0,
+            ErrorType = exception?.GetType().Name,
+            ErrorMessage = exception?.Message
+        };
+    }
+
+    private static string? TryGetContext(AgentTurnRequest request, string key)
+    {
+        return request.Context is not null &&
+               request.Context.TryGetValue(key, out var value) &&
+               !string.IsNullOrWhiteSpace(value)
+            ? value
+            : null;
+    }
+
+    private static string HashIdentifier(string value)
+    {
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(value));
+        return Convert.ToHexString(bytes)[..16].ToLowerInvariant();
+    }
+
+    private static string BuildPromptPreview(string message, int maxLength)
+    {
+        var normalized = message.ReplaceLineEndings(" ").Trim();
+        if (normalized.Length <= maxLength)
+        {
+            return normalized;
+        }
+
+        return normalized[..Math.Max(1, maxLength)] + "...";
+    }
+}

--- a/demo/AgentBlazor.Demo/Services/DemoLogEndpointMapper.cs
+++ b/demo/AgentBlazor.Demo/Services/DemoLogEndpointMapper.cs
@@ -1,0 +1,60 @@
+using AgentBlazor.Demo.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace AgentBlazor.Demo.Services;
+
+internal static class DemoLogEndpointMapper
+{
+    public static void MapDemoLogEndpoints(this WebApplication app)
+    {
+        var group = app.MapGroup("/internal/demo-logs");
+
+        group.MapGet("/", async (
+            HttpContext httpContext,
+            IDemoChatRequestLog requestLog,
+            IOptions<DemoLoggingOptions> options,
+            int? lines,
+            CancellationToken cancellationToken) =>
+        {
+            if (!IsAuthorized(httpContext, options.Value))
+            {
+                return Results.NotFound();
+            }
+
+            var tail = await requestLog.ReadTailAsync(lines ?? 200, cancellationToken);
+            return Results.Text(string.Join(Environment.NewLine, tail), "application/x-ndjson");
+        });
+
+        group.MapGet("/download", (
+            HttpContext httpContext,
+            IDemoChatRequestLog requestLog,
+            IOptions<DemoLoggingOptions> options) =>
+        {
+            if (!IsAuthorized(httpContext, options.Value))
+            {
+                return Results.NotFound();
+            }
+
+            return File.Exists(requestLog.LogFilePath)
+                ? Results.File(requestLog.LogFilePath, "application/x-ndjson", "agentblazor-demo-chat-requests.jsonl")
+                : Results.NotFound();
+        });
+    }
+
+    private static bool IsAuthorized(HttpContext httpContext, DemoLoggingOptions options)
+    {
+        if (string.IsNullOrWhiteSpace(options.AccessToken))
+        {
+            return false;
+        }
+
+        if (httpContext.Request.Headers.TryGetValue("X-Demo-Log-Token", out var headerValues) &&
+            string.Equals(headerValues.ToString(), options.AccessToken, StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        return httpContext.Request.Query.TryGetValue("token", out var queryValues) &&
+               string.Equals(queryValues.ToString(), options.AccessToken, StringComparison.Ordinal);
+    }
+}

--- a/demo/AgentBlazor.Demo/Services/IDemoChatRequestLog.cs
+++ b/demo/AgentBlazor.Demo/Services/IDemoChatRequestLog.cs
@@ -1,0 +1,10 @@
+namespace AgentBlazor.Demo.Services;
+
+internal interface IDemoChatRequestLog
+{
+    string LogFilePath { get; }
+
+    Task AppendAsync(DemoChatRequestLogEntry entry, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<string>> ReadTailAsync(int lineCount, CancellationToken cancellationToken = default);
+}

--- a/demo/AgentBlazor.Demo/Services/JsonlDemoChatRequestLog.cs
+++ b/demo/AgentBlazor.Demo/Services/JsonlDemoChatRequestLog.cs
@@ -1,0 +1,64 @@
+using System.Text.Json;
+using AgentBlazor.Demo.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace AgentBlazor.Demo.Services;
+
+internal sealed class JsonlDemoChatRequestLog : IDemoChatRequestLog
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private readonly DemoLoggingOptions _options;
+
+    public JsonlDemoChatRequestLog(IOptions<DemoLoggingOptions> options)
+    {
+        _options = options.Value;
+        LogFilePath = Path.Combine(_options.DirectoryPath, _options.FileName);
+    }
+
+    public string LogFilePath { get; }
+
+    public async Task AppendAsync(DemoChatRequestLogEntry entry, CancellationToken cancellationToken = default)
+    {
+        if (!_options.Enabled)
+        {
+            return;
+        }
+
+        var line = JsonSerializer.Serialize(entry, JsonOptions);
+        Directory.CreateDirectory(_options.DirectoryPath);
+
+        await _gate.WaitAsync(cancellationToken);
+        try
+        {
+            await File.AppendAllTextAsync(LogFilePath, line + Environment.NewLine, cancellationToken);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public async Task<IReadOnlyList<string>> ReadTailAsync(int lineCount, CancellationToken cancellationToken = default)
+    {
+        if (!_options.Enabled || !File.Exists(LogFilePath))
+        {
+            return [];
+        }
+
+        var boundedLineCount = Math.Clamp(lineCount, 1, Math.Max(1, _options.MaxTailLines));
+
+        await _gate.WaitAsync(cancellationToken);
+        try
+        {
+            var lines = await File.ReadAllLinesAsync(LogFilePath, cancellationToken);
+            return lines.Length <= boundedLineCount
+                ? lines
+                : lines[^boundedLineCount..];
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+}

--- a/demo/AgentBlazor.Demo/appsettings.json
+++ b/demo/AgentBlazor.Demo/appsettings.json
@@ -22,6 +22,15 @@
       "QueueLimit": 0
     }
   },
+  "DemoLogging": {
+    "Enabled": true,
+    "DirectoryPath": "",
+    "FileName": "chat-requests.jsonl",
+    "AccessToken": "",
+    "IncludePromptPreview": false,
+    "PromptPreviewMaxLength": 160,
+    "MaxTailLines": 500
+  },
   "DemoRemoteStorage": {
     "Adapter": "InMemory",
     "HttpBaseUrl": "",

--- a/docs/deployment/demo-container-apps.md
+++ b/docs/deployment/demo-container-apps.md
@@ -33,6 +33,7 @@ Deploy:
 ```bash
 export OPENAI_API_KEY="<live-demo-openai-key>"
 export AGENTBLAZOR_DEMO_IMAGE="ghcr.io/ashpeterson/agentblazor-demo:latest"
+export DEMO_LOG_ACCESS_TOKEN="<long-random-token>"
 
 ./scripts/deploy/azure-container-apps-demo.sh
 ```
@@ -46,7 +47,9 @@ Container app: agentblazor-demo
 Ingress: external, target port 8080
 Scale: 0-2 replicas
 Secret: openai-api-key
+Optional secret: demo-log-access-token
 Rate limit: 20 agent requests per client IP per minute
+Demo request log: /tmp/agentblazor-demo-logs/chat-requests.jsonl
 ```
 
 The script prints the generated Azure hostname. Smoke test it before adding DNS:
@@ -80,6 +83,8 @@ OpenAI__Model=gpt-4o-mini
 DemoSecurity__TrustForwardedHeaders=true
 DemoSecurity__RateLimiting__PermitLimit=20
 DemoSecurity__RateLimiting__WindowSeconds=60
+DemoLogging__DirectoryPath=/tmp/agentblazor-demo-logs
+DemoLogging__AccessToken=secretref:demo-log-access-token
 ```
 
 Do not set `AgentBlazor:LicenseKey` for the public v1 demo unless you intentionally want Pro surfaces visible.
@@ -91,13 +96,36 @@ Current demo observability is intentionally lightweight:
 - ASP.NET Core console logging is enabled at `Information` for `AgentBlazor` categories.
 - Azure Container Apps can stream container `stdout`/`stderr` logs without adding Application Insights code.
 - The Container Apps environment should use `--logs-destination none` to avoid persisted Azure Monitor / Log Analytics ingestion charges.
+- Each agent turn is appended to a local JSONL file inside the container.
 - AgentBlazor prompt tracing is enabled in memory for runtime debugging, but traces are not persisted across container restarts.
 - The public agent endpoint is rate limited by client IP. The current deployment uses `20` requests per minute.
+
+The JSONL file records:
+
+- timestamp, request id, route, agent, hashed session id
+- prompt length, response length, duration, outcome, error type
+- approval/clarification flags and execution counts
+
+It does not record full prompt text unless `DemoLogging__IncludePromptPreview=true` is explicitly set.
+
+Access recent log lines:
+
+```bash
+curl -H "X-Demo-Log-Token: $DEMO_LOG_ACCESS_TOKEN" \
+  "https://demo.agentblazor.com/internal/demo-logs?lines=200"
+```
+
+Download the current file:
+
+```bash
+curl -H "X-Demo-Log-Token: $DEMO_LOG_ACCESS_TOKEN" \
+  -o agentblazor-demo-chat-requests.jsonl \
+  "https://demo.agentblazor.com/internal/demo-logs/download"
+```
 
 What is not wired yet:
 
 - No Application Insights SDK or OpenTelemetry exporter is registered by the demo app.
-- No durable structured chat-request log exists yet for prompt length, route, agent, timing, status, or error.
 - No OpenAI token or cost usage tracker is stored by the demo app.
 
 For a low-cost public demo, prefer structured console logs first and keep Log Analytics/Application Insights ingestion off or minimal unless there is a specific incident to debug.

--- a/scripts/deploy/azure-container-apps-demo.sh
+++ b/scripts/deploy/azure-container-apps-demo.sh
@@ -10,6 +10,7 @@ ENVIRONMENT_NAME="${ENVIRONMENT_NAME:-agentblazor-demo-env}"
 CONTAINER_APP_NAME="${CONTAINER_APP_NAME:-agentblazor-demo}"
 OPENAI_MODEL="${OPENAI_MODEL:-gpt-4o-mini}"
 RATE_LIMIT_PER_MINUTE="${RATE_LIMIT_PER_MINUTE:-20}"
+DEMO_LOG_DIRECTORY="${DEMO_LOG_DIRECTORY:-/tmp/agentblazor-demo-logs}"
 
 az extension add --name containerapp --upgrade >/dev/null
 
@@ -33,19 +34,52 @@ if az containerapp show --name "$CONTAINER_APP_NAME" --resource-group "$RESOURCE
     --secrets openai-api-key="$OPENAI_API_KEY" \
     --output none
 
+  if [[ -n "${DEMO_LOG_ACCESS_TOKEN:-}" ]]; then
+    az containerapp secret set \
+      --name "$CONTAINER_APP_NAME" \
+      --resource-group "$RESOURCE_GROUP" \
+      --secrets demo-log-access-token="$DEMO_LOG_ACCESS_TOKEN" \
+      --output none
+  fi
+
+  env_vars=(
+    ASPNETCORE_ENVIRONMENT=Production
+    OPENAI_API_KEY=secretref:openai-api-key
+    OpenAI__Model="$OPENAI_MODEL"
+    DemoSecurity__TrustForwardedHeaders=true
+    DemoSecurity__RateLimiting__PermitLimit="$RATE_LIMIT_PER_MINUTE"
+    DemoSecurity__RateLimiting__WindowSeconds=60
+    DemoLogging__DirectoryPath="$DEMO_LOG_DIRECTORY"
+  )
+
+  if [[ -n "${DEMO_LOG_ACCESS_TOKEN:-}" ]]; then
+    env_vars+=(DemoLogging__AccessToken=secretref:demo-log-access-token)
+  fi
+
   az containerapp update \
     --name "$CONTAINER_APP_NAME" \
     --resource-group "$RESOURCE_GROUP" \
     --image "$AGENTBLAZOR_DEMO_IMAGE" \
-    --set-env-vars \
-      ASPNETCORE_ENVIRONMENT=Production \
-      OPENAI_API_KEY=secretref:openai-api-key \
-      OpenAI__Model="$OPENAI_MODEL" \
-      DemoSecurity__TrustForwardedHeaders=true \
-      DemoSecurity__RateLimiting__PermitLimit="$RATE_LIMIT_PER_MINUTE" \
-      DemoSecurity__RateLimiting__WindowSeconds=60 \
+    --set-env-vars "${env_vars[@]}" \
     --output none
 else
+  env_vars=(
+    ASPNETCORE_ENVIRONMENT=Production
+    OPENAI_API_KEY=secretref:openai-api-key
+    OpenAI__Model="$OPENAI_MODEL"
+    DemoSecurity__TrustForwardedHeaders=true
+    DemoSecurity__RateLimiting__PermitLimit="$RATE_LIMIT_PER_MINUTE"
+    DemoSecurity__RateLimiting__WindowSeconds=60
+    DemoLogging__DirectoryPath="$DEMO_LOG_DIRECTORY"
+  )
+
+  secrets=(openai-api-key="$OPENAI_API_KEY")
+
+  if [[ -n "${DEMO_LOG_ACCESS_TOKEN:-}" ]]; then
+    secrets+=(demo-log-access-token="$DEMO_LOG_ACCESS_TOKEN")
+    env_vars+=(DemoLogging__AccessToken=secretref:demo-log-access-token)
+  fi
+
   az containerapp create \
     --name "$CONTAINER_APP_NAME" \
     --resource-group "$RESOURCE_GROUP" \
@@ -57,14 +91,8 @@ else
     --max-replicas 2 \
     --cpu 0.5 \
     --memory 1Gi \
-    --secrets openai-api-key="$OPENAI_API_KEY" \
-    --env-vars \
-      ASPNETCORE_ENVIRONMENT=Production \
-      OPENAI_API_KEY=secretref:openai-api-key \
-      OpenAI__Model="$OPENAI_MODEL" \
-      DemoSecurity__TrustForwardedHeaders=true \
-      DemoSecurity__RateLimiting__PermitLimit="$RATE_LIMIT_PER_MINUTE" \
-      DemoSecurity__RateLimiting__WindowSeconds=60 \
+    --secrets "${secrets[@]}" \
+    --env-vars "${env_vars[@]}" \
     --output none
 fi
 


### PR DESCRIPTION
Adds low-cost demo request observability without Application Insights or Log Analytics ingestion.\n\n- Logs each agent turn to console and local JSONL file\n- Records route, agent, hashed session id, prompt length, response length, duration, outcome, approval/clarification flags, execution counts, and errors\n- Does not log full prompt text by default\n- Adds protected /internal/demo-logs endpoints for tail/download access\n- Updates Azure deploy script for optional DEMO_LOG_ACCESS_TOKEN secret\n- Documents low-cost access and logging posture