### PR TITLE
Filter framework routes from demo traffic analytics

### DIFF
--- a/demo/AgentBlazor.Demo/Services/DemoLogEndpointMapper.cs
+++ b/demo/AgentBlazor.Demo/Services/DemoLogEndpointMapper.cs
@@ -1,5 +1,5 @@
-using AgentBlazor.Demo.Configuration;
 using System.Text.Json;
+using AgentBlazor.Demo.Configuration;
 using Microsoft.Extensions.Options;
 
 namespace AgentBlazor.Demo.Services;
@@ -113,6 +113,7 @@ internal static class DemoLogEndpointMapper
             .Select(ParseTraffic)
             .Where(static item => item is not null)
             .Select(static item => item!)
+            .Where(static item => IsPageViewRoute(item.Path))
             .ToArray();
         var chats = chatLines
             .Select(ParseChat)
@@ -204,6 +205,15 @@ internal static class DemoLogEndpointMapper
     }
 
     private sealed record TrafficSummaryItem(DateTimeOffset TimestampUtc, string Path, string VisitorHash);
+
+    private static bool IsPageViewRoute(string path)
+    {
+        return !path.StartsWith("/_blazor", StringComparison.OrdinalIgnoreCase) &&
+               !path.StartsWith("/_framework", StringComparison.OrdinalIgnoreCase) &&
+               !path.StartsWith("/_content", StringComparison.OrdinalIgnoreCase) &&
+               !path.StartsWith("/internal", StringComparison.OrdinalIgnoreCase) &&
+               !Path.HasExtension(path);
+    }
 
     private sealed record ChatSummaryItem(
         DateTimeOffset TimestampUtc,

--- a/demo/AgentBlazor.Demo/Services/DemoTrafficLoggingMiddleware.cs
+++ b/demo/AgentBlazor.Demo/Services/DemoTrafficLoggingMiddleware.cs
@@ -66,6 +66,7 @@ internal sealed class DemoTrafficLoggingMiddleware(
 
         var path = request.Path.Value ?? "/";
         if (path.StartsWith("/internal", StringComparison.OrdinalIgnoreCase) ||
+            path.StartsWith("/_blazor", StringComparison.OrdinalIgnoreCase) ||
             path.StartsWith("/_framework", StringComparison.OrdinalIgnoreCase) ||
             path.StartsWith("/_content", StringComparison.OrdinalIgnoreCase) ||
             path.StartsWith("/css", StringComparison.OrdinalIgnoreCase) ||


### PR DESCRIPTION
## Summary
- exclude Blazor circuit endpoints from demo traffic logging
- filter existing framework/internal/static paths out of the traffic summary

## Verification
- dotnet build demo/AgentBlazor.Demo/AgentBlazor.Demo.csproj -p:UseAppHost=false --no-restore