### PR TITLE
Start v0.2 week 1 commitments

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ dotnet add package AgentBlazor --version 0.1.0-preview.11
 
 The CLI is optional. Keep it out of the critical path unless you want scaffold help for an existing app.
 
+## Dependency Stability
+
+AgentBlazor builds on the Microsoft Agent Framework packages rather than a custom agent runtime. The core package currently depends on four GA packages: `Microsoft.Agents.AI`, `Microsoft.Agents.AI.Abstractions`, `Microsoft.Agents.AI.OpenAI`, and `Microsoft.Agents.AI.Workflows`.
+
+Two hosting packages are still preview dependencies: `Microsoft.Agents.AI.Hosting` and `Microsoft.Agents.AI.Hosting.AGUI.AspNetCore`. AgentBlazor keeps those behind its own registration and endpoint surface so app code does not need to bind directly to the preview hosting APIs for normal setup. Expect preview-version churn around hosted AG-UI transport before 1.0; the component/capability model is the stable surface this package is trying to protect.
+
 ## Minimal Setup
 
 Register the runtime in `Program.cs`:

--- a/demo/AgentBlazor.Demo/Configuration/DemoLoggingOptions.cs
+++ b/demo/AgentBlazor.Demo/Configuration/DemoLoggingOptions.cs
@@ -19,4 +19,8 @@ internal sealed class DemoLoggingOptions
     public int PromptPreviewMaxLength { get; set; } = 160;
 
     public int MaxTailLines { get; set; } = 500;
+
+    public decimal InputTokenCostPerMillion { get; set; } = 0.15m;
+
+    public decimal OutputTokenCostPerMillion { get; set; } = 0.60m;
 }

--- a/demo/AgentBlazor.Demo/Services/DemoChatRequestLogEntry.cs
+++ b/demo/AgentBlazor.Demo/Services/DemoChatRequestLogEntry.cs
@@ -38,6 +38,30 @@ internal sealed record DemoChatRequestLogEntry
     [JsonPropertyName("responseLength")]
     public int ResponseLength { get; init; }
 
+    [JsonPropertyName("model")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Model { get; init; }
+
+    [JsonPropertyName("prompt_tokens")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public long? PromptTokens { get; init; }
+
+    [JsonPropertyName("completion_tokens")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public long? CompletionTokens { get; init; }
+
+    [JsonPropertyName("total_tokens")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public long? TotalTokens { get; init; }
+
+    [JsonPropertyName("estimated_cost")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public decimal? EstimatedCost { get; init; }
+
+    [JsonPropertyName("estimated_cost_currency")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? EstimatedCostCurrency { get; init; }
+
     [JsonPropertyName("requiresApproval")]
     public bool RequiresApproval { get; init; }
 

--- a/demo/AgentBlazor.Demo/Services/DemoChatRequestLoggingMiddleware.cs
+++ b/demo/AgentBlazor.Demo/Services/DemoChatRequestLoggingMiddleware.cs
@@ -5,6 +5,7 @@ using AgentBlazor.Core.Runtime.Agents;
 using AgentBlazor.Core.Runtime.Middleware;
 using AgentBlazor.Demo.Configuration;
 using AgentBlazor.Execution;
+using AgentBlazor.Options;
 using Microsoft.Extensions.Options;
 
 namespace AgentBlazor.Demo.Services;
@@ -12,9 +13,11 @@ namespace AgentBlazor.Demo.Services;
 internal sealed class DemoChatRequestLoggingMiddleware(
     IDemoChatRequestLog requestLog,
     IOptions<DemoLoggingOptions> options,
+    IOptions<AgentBlazorOptions> agentOptions,
     ILogger<DemoChatRequestLoggingMiddleware> logger) : IAgentTurnMiddleware
 {
     private readonly DemoLoggingOptions _options = options.Value;
+    private readonly AgentBlazorOptions _agentOptions = agentOptions.Value;
 
     public async Task InvokeAsync(
         AgentTurnContext context,
@@ -91,9 +94,11 @@ internal sealed class DemoChatRequestLoggingMiddleware(
         Exception? exception = null)
     {
         var executionPlan = response?.ExecutionPlan;
+        var usage = response?.Usage;
         IReadOnlyList<AgentExecutionStep> executionSteps = executionPlan?.Steps ?? [];
         var failedExecutionCount = executionSteps.Count(static step =>
             step.Status is not AgentExecutionStepStatus.Completed);
+        var estimatedCost = EstimateCost(usage?.InputTokenCount, usage?.OutputTokenCount);
 
         return new DemoChatRequestLogEntry
         {
@@ -109,6 +114,12 @@ internal sealed class DemoChatRequestLoggingMiddleware(
             DurationMs = durationMs,
             Status = status,
             ResponseLength = response?.ResponseText.Length ?? 0,
+            Model = _agentOptions.Provider.Model,
+            PromptTokens = usage?.InputTokenCount,
+            CompletionTokens = usage?.OutputTokenCount,
+            TotalTokens = usage?.TotalTokenCount,
+            EstimatedCost = estimatedCost,
+            EstimatedCostCurrency = estimatedCost is null ? null : "USD",
             RequiresApproval = response?.RequiresApproval ?? false,
             RequiresClarification = response?.RequiresClarification ?? false,
             PlannedActionCount = executionPlan?.Steps.Count ?? response?.PlannedActions.Count ?? 0,
@@ -121,6 +132,18 @@ internal sealed class DemoChatRequestLoggingMiddleware(
             ErrorType = exception?.GetType().Name,
             ErrorMessage = exception?.Message
         };
+    }
+
+    private decimal? EstimateCost(long? inputTokens, long? outputTokens)
+    {
+        if (inputTokens is null && outputTokens is null)
+        {
+            return null;
+        }
+
+        var inputCost = (inputTokens ?? 0) / 1_000_000m * _options.InputTokenCostPerMillion;
+        var outputCost = (outputTokens ?? 0) / 1_000_000m * _options.OutputTokenCostPerMillion;
+        return Math.Round(inputCost + outputCost, 8, MidpointRounding.AwayFromZero);
     }
 
     private static string? TryGetContext(AgentTurnRequest request, string key)

--- a/demo/AgentBlazor.Demo/Services/DemoLogEndpointMapper.cs
+++ b/demo/AgentBlazor.Demo/Services/DemoLogEndpointMapper.cs
@@ -224,6 +224,11 @@ internal static class DemoLogEndpointMapper
                 last24hTurns = chats.Count(item => item.TimestampUtc >= now.AddHours(-24)),
                 approvalTurns = chats.Count(static item => item.RequiresApproval),
                 failedExecutionTurns = chats.Count(static item => item.FailedExecutionCount > 0),
+                promptTokens = chats.Sum(static item => item.PromptTokens ?? 0),
+                completionTokens = chats.Sum(static item => item.CompletionTokens ?? 0),
+                totalTokens = chats.Sum(static item => item.TotalTokens ?? 0),
+                estimatedCost = Math.Round(chats.Sum(static item => item.EstimatedCost ?? 0), 8, MidpointRounding.AwayFromZero),
+                estimatedCostCurrency = chats.Any(static item => item.EstimatedCost is not null) ? "USD" : null,
                 averageDurationMs = chats.Length == 0 ? 0 : Math.Round(chats.Average(static item => item.DurationMs), 1),
                 topRoutes = chats
                     .Where(static item => !string.IsNullOrWhiteSpace(item.Route))
@@ -268,7 +273,11 @@ internal static class DemoLogEndpointMapper
                 root.GetProperty("sessionHash").GetString() ?? "unknown",
                 root.GetProperty("durationMs").GetInt64(),
                 root.TryGetProperty("requiresApproval", out var requiresApproval) && requiresApproval.GetBoolean(),
-                root.TryGetProperty("failedExecutionCount", out var failedExecutionCount) ? failedExecutionCount.GetInt32() : 0);
+                root.TryGetProperty("failedExecutionCount", out var failedExecutionCount) ? failedExecutionCount.GetInt32() : 0,
+                TryGetInt64(root, "prompt_tokens"),
+                TryGetInt64(root, "completion_tokens"),
+                TryGetInt64(root, "total_tokens"),
+                TryGetDecimal(root, "estimated_cost"));
         }
         catch (JsonException)
         {
@@ -297,7 +306,29 @@ internal static class DemoLogEndpointMapper
         string SessionHash,
         long DurationMs,
         bool RequiresApproval,
-        int FailedExecutionCount);
+        int FailedExecutionCount,
+        long? PromptTokens,
+        long? CompletionTokens,
+        long? TotalTokens,
+        decimal? EstimatedCost);
+
+    private static long? TryGetInt64(JsonElement root, string propertyName)
+    {
+        return root.TryGetProperty(propertyName, out var property) &&
+               property.ValueKind is JsonValueKind.Number &&
+               property.TryGetInt64(out var value)
+            ? value
+            : null;
+    }
+
+    private static decimal? TryGetDecimal(JsonElement root, string propertyName)
+    {
+        return root.TryGetProperty(propertyName, out var property) &&
+               property.ValueKind is JsonValueKind.Number &&
+               property.TryGetDecimal(out var value)
+            ? value
+            : null;
+    }
 
     private static string BuildViewerHtml(object summary, IReadOnlyList<string> trafficTail, IReadOnlyList<string> chatTail, int lineCount)
     {

--- a/demo/AgentBlazor.Demo/appsettings.json
+++ b/demo/AgentBlazor.Demo/appsettings.json
@@ -30,7 +30,9 @@
     "AccessToken": "",
     "IncludePromptPreview": false,
     "PromptPreviewMaxLength": 160,
-    "MaxTailLines": 500
+    "MaxTailLines": 500,
+    "InputTokenCostPerMillion": 0.15,
+    "OutputTokenCostPerMillion": 0.60
   },
   "DemoRemoteStorage": {
     "Adapter": "InMemory",

--- a/docs/deployment/demo-container-apps.md
+++ b/docs/deployment/demo-container-apps.md
@@ -95,7 +95,8 @@ Current demo observability is intentionally lightweight:
 
 - ASP.NET Core console logging is enabled at `Information` for `AgentBlazor` categories.
 - Azure Container Apps can stream container `stdout`/`stderr` logs without adding Application Insights code.
-- The Container Apps environment should use `--logs-destination none` to avoid persisted Azure Monitor / Log Analytics ingestion charges.
+- The live Container Apps environment uses `logsDestination: null` / `--logs-destination none` to avoid persisted Azure Monitor / Log Analytics ingestion charges.
+- No Application Insights component is currently attached to the demo. This is deliberate for the free public demo unless there is a specific incident that requires Azure-side telemetry.
 - Each page view and agent turn is appended to local JSONL files inside the container.
 - AgentBlazor prompt tracing is enabled in memory for runtime debugging, but traces are not persisted across container restarts.
 - The public agent endpoint is rate limited by client IP. The current deployment uses `20` requests per minute.
@@ -104,6 +105,7 @@ The chat JSONL file records:
 
 - timestamp, request id, route, agent, hashed session id
 - prompt length, response length, duration, outcome, error type
+- model, prompt tokens, completion tokens, total tokens, estimated cost when provider usage metadata is available
 - approval/clarification flags and execution counts
 
 The traffic JSONL file records:
@@ -164,12 +166,9 @@ curl -H "X-Demo-Log-Token: $DEMO_LOG_ACCESS_TOKEN" \
   "https://demo.agentblazor.com/internal/demo-logs/traffic/download"
 ```
 
-What is not wired yet:
+The token cost estimate currently uses the configured `DemoLogging__InputTokenCostPerMillion` and `DemoLogging__OutputTokenCostPerMillion` values. The defaults match `gpt-4o-mini` text pricing at `$0.15` per 1M input tokens and `$0.60` per 1M output tokens.
 
-- No Application Insights SDK or OpenTelemetry exporter is registered by the demo app.
-- No OpenAI token or cost usage tracker is stored by the demo app.
-
-For a low-cost public demo, prefer structured console logs first and keep Log Analytics/Application Insights ingestion off or minimal unless there is a specific incident to debug.
+For a low-cost public demo, prefer structured file/console logs first and keep Log Analytics/Application Insights ingestion off or minimal unless there is a specific incident to debug.
 
 ## Rollback
 

--- a/docs/internal/v0.2-sprint-plan-2026-05-11.md
+++ b/docs/internal/v0.2-sprint-plan-2026-05-11.md
@@ -1,0 +1,389 @@
+# AgentBlazor v0.2 Sprint Plan
+
+Created: 2026-05-12  
+Sprint window: 2026-05-11 to 2026-06-09  
+Ship target: 0.2.0 by 2026-06-07, promotional post on 2026-06-09
+
+## Sprint Thesis
+
+v0.2 is not a broad feature sprint. It exists to close public commitment debt, ship structured error recovery, and decide whether entity exposure is realistic as a stretch goal.
+
+The default cut line is strict:
+
+- Must ship: structured errors designed for LLM recovery.
+- Must close: public demo/logging/token commitments from launch week.
+- Stretch only: read-only entity exposure and component canvas.
+- Do not touch: multi-library wrapper architecture, CLI changes, extra promotional surfaces.
+
+## GitHub Issue Context
+
+### Issue #8: Structured Error Responses Designed For LLM Recovery
+
+URL: https://github.com/ashpeterson/AgentBlazor/issues/8
+
+Status: open, assigned to `ashpeterson`, labelled `enhancement`.
+
+This is the v0.2 must-ship issue. It came from launch feedback about bad capability arguments and whether AgentBlazor has a standard way to return validation failures to the LLM in a recoverable shape.
+
+Existing issue detail:
+
+- `CapabilityResult` already supports structured success/failure with `NextActions` and `Warnings` for errors caught inside a method body.
+- The gap is binding-layer errors: wrong argument count, type mismatch, or missing required parameters fail before the capability method runs.
+- Today those failures can fall through as raw exception text instead of a structured `CapabilityResult.Failure`.
+- There is no documented convention for when to use `Summary`, `Warnings`, and `NextActions`.
+- Capability authors can skip validation and leak lower-level exceptions from DB calls or other dependencies.
+
+v0.2 direction from the issue:
+
+- Wrap capability invocation so binding-layer failures return `CapabilityResult.Failure`.
+- Include LLM-readable failure messages and `NextActions` that describe the expected signature or recovery path.
+- Document a capability-error convention for LLM recovery.
+- Consider analyzer/source-generator enforcement later, but not as the first v0.2 implementation.
+
+Open questions to answer in the design comment:
+
+- Should the structured error primitives eventually split into a Blazor-agnostic package?
+- Can the existing model-binding pipeline be extended, or do we need a wrapper layer around invocation?
+- Should one capability call return one structured error or multiple validation errors?
+
+Out of scope:
+
+- Generic exception handling.
+- Logging/telemetry.
+- Pre-prompt validation by an LLM judge.
+
+### Issue #1: Read-Only Entity Exposure For Query Planning + Component Canvas
+
+URL: https://github.com/ashpeterson/AgentBlazor/issues/1
+
+Status: open, assigned to `ashpeterson`, labelled `enhancement`.
+
+This is the v0.2 stretch goal only. It came from launch feedback about the gap between fully typed capability methods and unsafe free-form DB access.
+
+Existing issue detail:
+
+- Current capabilities are typed C# methods, which works for known workflows.
+- That model breaks down for ad-hoc data questions where the developer cannot pre-enumerate every query/display combination.
+- The proposed middle ground is to expose read-safe entity shapes to the agent for planning while still executing through typed, developer-controlled paths.
+- The component canvas would let the agent choose from registered display components such as table, chart, or summary card.
+
+Two separable parts:
+
+- Entity shape exposure: register DbContext entities or other data shapes as read-safe schema the agent may reason over.
+- Component canvas: render results through registered display components or an `AgentUiDocument`, not arbitrary Razor generation.
+
+Open questions:
+
+- How does this work with row-level security and multi-tenancy?
+- Is query planning LLM-generates-LINQ or constrained query templates?
+- What is the minimum useful component canvas set?
+
+Out of scope:
+
+- Write/mutation paths.
+- Free-form Razor generation.
+
+### Issue #2: Hosted Public Demo
+
+URL: https://github.com/ashpeterson/AgentBlazor/issues/2
+
+Status: open, assigned to `ashpeterson`, labelled `enhancement`.
+
+This issue tracks the public no-install demo commitment from launch feedback. Much of the core hosting work is now done, but the issue should not be treated as fully closed until the remaining operational commitments are verified.
+
+Original issue constraints:
+
+- Server-side OpenAI key only.
+- Rate limiting per IP/session.
+- Cost cap or kill switch.
+- No persistent user data.
+- Public URL by 2026-05-14.
+- Reply to original Reddit commenter when live.
+
+Current sprint interpretation:
+
+- Verify Application Insights or explicitly document that we are staying on free file-backed logs only.
+- Token/cost tracking must be live in demo logs.
+- Keep log access easy from any machine through the protected viewer.
+- Bot/noise traffic should not pollute the high-level summary.
+
+### Issue #3: Component-Library Support Beyond MudBlazor
+
+URL: https://github.com/ashpeterson/AgentBlazor/issues/3
+
+Status: open, assigned to `ashpeterson`, labelled `enhancement`.
+
+This is explicitly cut from v0.2.
+
+Existing issue detail:
+
+- Component-action wrappers are currently MudBlazor-coupled.
+- Capability/workflow model is library-agnostic.
+- Open strategic question: abstract wrappers across multiple libraries, or commit harder to MudBlazor and let other libraries plug in via custom wrappers.
+
+v0.2 decision:
+
+- Do not work on this during the sprint.
+- If asked publicly, say this is v0.3+ design work after structured errors are stable.
+
+## Week 1: 2026-05-11 To 2026-05-17
+
+Theme: close commitment debts, scope structured errors. No new feature implementation beyond logging/token commitment work.
+
+### Mon-Tue: README Dependencies And Demo Observability
+
+Tasks:
+
+- Add README dependency section listing the four GA MAF packages:
+  - `Microsoft.Agents.AI`
+  - `Microsoft.Agents.AI.Abstractions`
+  - `Microsoft.Agents.AI.OpenAI`
+  - `Microsoft.Agents.AI.Workflows`
+- List the two preview MAF packages:
+  - `Microsoft.Agents.AI.Hosting`
+  - `Microsoft.Agents.AI.Hosting.AGUI.AspNetCore`
+- Add two-paragraph framing about what dependency stability means for AgentBlazor.
+- Verify whether Application Insights is actually wired and visible in Azure.
+- If we deliberately stay free-only, document that the live demo uses protected JSONL logs rather than paid Azure telemetry.
+
+Estimate: 3-4 hours.
+
+### Wed-Thu: OpenAI Token And Cost Tracking
+
+Tasks:
+
+- Find where the OpenAI client response/usage metadata is available.
+- Add per-turn fields to demo JSONL logging:
+  - `prompt_tokens`
+  - `completion_tokens`
+  - `total_tokens`
+  - `estimated_cost`
+- Include these fields in the protected `/internal/demo-logs` output.
+- Include aggregate token/cost fields in `/internal/demo-logs/summary`.
+- Verify by hitting the live demo with a few prompts and checking the JSONL.
+
+Estimate: 4-5 hours.
+
+### Fri-Sun: Structured Errors Design Comment
+
+Tasks:
+
+- Read `CapabilityResult` and related result-shaping code.
+- Read the binding/invocation layer where bad arguments currently throw.
+- Read the chat/tool-result rendering path where failures are displayed to the LLM/user.
+- Post a design comment on issue #8 covering:
+  - typed result variants
+  - binding-layer wrapping approach
+  - conventions for `Summary`, `Warnings`, and `NextActions`
+  - recovery hint format
+  - worked example: invalid date range
+  - worked example: missing required argument
+  - worked example: invalid argument shape
+- Tag or reply to the structured-errors commenter if there is a GitHub/Reddit identity available.
+
+Estimate: 6-8 hours.
+
+### End-Of-Week Gate
+
+- README dependency section live on GitHub.
+- Demo observability decision documented and verified.
+- Token/cost tracking live in demo logs.
+- Structured errors design posted to issue #8.
+
+## Week 2: 2026-05-18 To 2026-05-24
+
+Theme: build structured errors. This is the implementation week.
+
+### Mon-Tue: Result Variants And Helpers
+
+Tasks:
+
+- Implement typed result variants for recoverable failures.
+- Add helpers such as `WithRecovery` and `WithExpectedShape`, or settle naming in the issue #8 design first.
+- Unit tests for each variant/helper.
+
+### Wed-Thu: Binding-Layer Wrapping
+
+Tasks:
+
+- Wrap invocation errors as structured `CapabilityResult.Failure`.
+- Cover failure modes:
+  - wrong arity
+  - type mismatch
+  - missing required parameter
+  - invalid null
+  - sync exception
+  - async exception
+- Ensure raw exception text is not the default LLM-facing result for recoverable invocation failures.
+
+### Fri: Chat Surface Recovery Display
+
+Tasks:
+
+- Update chat/tool result rendering to include structured recovery hints.
+- Ensure the LLM receives enough structured information to retry rather than spiral.
+- Keep end-user output clear and not over-technical.
+
+### Sat-Sun: Integration Testing
+
+Tasks:
+
+- Create an intentionally broken capability/workflow for tests.
+- Verify recovery behaviour end-to-end in the chat surface.
+- Capture screenshots or a short demo recording for later blog/release notes.
+
+### End-Of-Week Gate
+
+- Structured errors branch open.
+- All tests passing.
+- Demo workflow updated to show the new pattern as a reference.
+- CleanTest verification works from a local source.
+- Mid-sprint check completed on 2026-05-24.
+
+## Mid-Sprint Check: 2026-05-24
+
+Decision point:
+
+- If structured errors are on track and stable, attempt issue #1 entity exposure as a week 3 stretch goal.
+- If structured errors work but the binding layer is fragile, cut entity exposure and use week 3 to harden structured errors.
+- If structured errors are at risk, post a status update to issue #8 and adjust the ship scope.
+
+## Week 3: 2026-05-25 To 2026-05-31
+
+Theme: entity exposure stretch goal or structured errors hardening.
+
+### Path A: Structured Errors Clean, Attempt Entity Exposure
+
+Tasks:
+
+- Re-read issue #1 and source launch feedback.
+- Decide the read-only entity registration API shape.
+- Post a design comment to issue #1.
+- Prototype a DbContext-aware registration that exposes entity schema for planning.
+- Keep execution behind a typed method that owns safety.
+- Prototype one sample DbContext flow.
+
+End-of-week gate:
+
+- Entity exposure design posted.
+- Prototype branch open.
+- If sample works end-to-end, include in v0.2.
+- If rough, defer to v0.3 with the design preserved.
+
+### Path B: Structured Errors Need Hardening
+
+Tasks:
+
+- Fix edge cases found in integration testing.
+- Improve error templates.
+- Improve test coverage.
+- Document capability error conventions.
+- Publicly defer issue #1 to v0.3.
+
+End-of-week gate:
+
+- Structured errors stable enough to ship.
+- Entity exposure explicitly deferred if not attempted.
+
+## Week 4: 2026-06-01 To 2026-06-07
+
+Theme: ship 0.2.0, clean public surface, write the launch post.
+
+### Mon-Tue: Preview And Verification
+
+Tasks:
+
+- Cut the final preview before stable.
+- Run full CleanTest verification from the published preview.
+- Update README and NuGet README.
+- Write release notes covering:
+  - structured errors
+  - entity exposure, only if it landed
+  - public commitment work from week 1
+  - demo/logging improvements
+
+### Wed-Thu: Cleanup
+
+Tasks:
+
+- Delete `AgentBlazor.Licensing` from the public repo if still present and not required.
+- Audit demo workflows.
+- Retire or rewrite abstract workflows such as `response-orchestration` and `release-dossier` unless they are clearly understandable.
+- Ensure `demo.agentblazor.com` only shows recognisable workflows by Friday.
+
+### Fri-Sun: Blog And Stable Release
+
+Tasks:
+
+- Draft one blog post:
+  - option A: `What I learned shipping a Blazor agent UX library in 4 weeks`
+  - option B: `Structured errors for LLM recovery in .NET`
+- Cut 0.2.0 stable.
+- Publish to NuGet.org.
+- Edit and publish the blog post.
+
+End-of-week gate:
+
+- 0.2.0 published by 2026-06-07.
+- Release notes live.
+- Demo verified.
+- Blog post ready or published.
+
+## Launch Day: 2026-06-09
+
+Tasks:
+
+- Post to r/dotnet with Promotion flair.
+- Adapt the same post for r/csharp and r/Blazor.
+- Lead with:
+  - demo URL
+  - short architectural argument
+  - install command
+  - GitHub link
+- Reply to the structured-errors commenter with release notes/blog link.
+
+Do not post to Hacker News for this round.
+
+## Explicit Cuts
+
+- Multi-library/pluggable wrapper architecture.
+- CLI changes.
+- Hacker News.
+- dev.to.
+- LinkedIn long-form.
+- X threads.
+- Extra Reddit commitments beyond the planned June 9 post.
+
+## Discipline Tests
+
+### 1. No Structured-Errors Scope Creep
+
+Do not start entity exposure while implementing structured errors. Entity exposure starts only after the 2026-05-24 check-in and only if structured errors are clean.
+
+### 2. No Escape-Route Ideas
+
+When structured errors get boring, new ideas will look attractive. Write them down elsewhere and return to the sprint work.
+
+### 3. No New Public Commitments Before Old Ones Close
+
+README dependency framing, demo observability, and token/cost tracking must land before any new public commitments are made.
+
+## Non-Negotiables
+
+v0.2 scope:
+
+- Structured errors: must ship.
+- Entity exposure: stretch, conditional on mid-sprint check.
+- Public commitments from 2026-05-08 to 2026-05-09.
+- Path A cleanup: licensing project and demo workflow surface.
+- One blog post.
+
+v0.2 cuts:
+
+- Multi-library wrapper architecture.
+- CLI changes.
+- New promotional surfaces beyond the planned blog post and Reddit posts.
+
+Mid-sprint check: 2026-05-24  
+Stable ship target: 2026-06-07  
+Promotional post: 2026-06-09

--- a/src/AgentBlazor.Core/Runtime/Adapters/ChatClientRuntimeAdapter.cs
+++ b/src/AgentBlazor.Core/Runtime/Adapters/ChatClientRuntimeAdapter.cs
@@ -183,7 +183,7 @@ public sealed class ChatClientRuntimeAdapter(
                 options: null,
                 effectiveCancellationToken).ConfigureAwait(false);
 
-            var turnResponse = BuildTurnResponse(registration.Name, response.Text, request, turnState);
+            var turnResponse = BuildTurnResponse(registration.Name, response.Text, request, turnState, response.Usage);
             await StoreConversationTurnAsync(registration.Name, request, turnResponse, effectiveCancellationToken).ConfigureAwait(false);
             await RecordActionHistoryAsync(request, turnState, effectiveCancellationToken).ConfigureAwait(false);
             await StoreTraceAsync(traceBuilder, turnState, turnResponse, effectiveCancellationToken).ConfigureAwait(false);
@@ -414,12 +414,20 @@ public sealed class ChatClientRuntimeAdapter(
 
             var agent = await CreateAgentAsync(registration, request, turnState, effectiveCancellationToken).ConfigureAwait(false);
             CurrentTurnState.Value = turnState;
+            var usage = new UsageDetails();
+            var hasUsage = false;
             await foreach (var update in agent.RunStreamingAsync(
                                new ChatMessage(ChatRole.User, BuildUserMessage(request)),
                                sessionState.Session,
                                options: null,
                                effectiveCancellationToken).ConfigureAwait(false))
             {
+                if (ExtractUsage(update) is { } updateUsage)
+                {
+                    usage.Add(updateUsage);
+                    hasUsage = true;
+                }
+
                 foreach (var queuedEvent in turnState.DrainStreamEvents())
                 {
                     var emitted = queuedEvent with
@@ -511,7 +519,12 @@ public sealed class ChatClientRuntimeAdapter(
                     .ConfigureAwait(false);
             }
 
-            var turnResponse = BuildTurnResponse(registration.Name, responseText.ToString(), request, turnState);
+            var turnResponse = BuildTurnResponse(
+                registration.Name,
+                responseText.ToString(),
+                request,
+                turnState,
+                hasUsage ? usage : null);
             await StoreConversationTurnAsync(registration.Name, request, turnResponse, effectiveCancellationToken).ConfigureAwait(false);
             await RecordActionHistoryAsync(request, turnState, effectiveCancellationToken).ConfigureAwait(false);
             await StoreTraceAsync(traceBuilder, turnState, turnResponse, effectiveCancellationToken).ConfigureAwait(false);
@@ -2067,7 +2080,8 @@ public sealed class ChatClientRuntimeAdapter(
         string agentName,
         string responseText,
         AgentTurnRequest request,
-        TurnExecutionState turnState)
+        TurnExecutionState turnState,
+        UsageDetails? usage = null)
     {
         var executionPlan = RuntimeExecutionPlans.Build(
             agentName,
@@ -2101,7 +2115,20 @@ public sealed class ChatClientRuntimeAdapter(
             clarificationQuestion: clarificationQuestion,
             pendingApprovals: pendingApprovals,
             requiresApproval: turnState.RequiresApproval,
-            executionPlan: executionPlan);
+            executionPlan: executionPlan,
+            usage: usage);
+    }
+
+    private static UsageDetails? ExtractUsage(AgentResponseUpdate update)
+    {
+        UsageDetails? usage = null;
+        foreach (var usageContent in update.Contents.OfType<UsageContent>())
+        {
+            usage ??= new UsageDetails();
+            usage.Add(usageContent.Details);
+        }
+
+        return usage;
     }
 
     private AgentUiDocument? BuildGeneratedUi(TurnExecutionState turnState)

--- a/src/AgentBlazor.Core/Runtime/Agents/AgentTurnResponse.cs
+++ b/src/AgentBlazor.Core/Runtime/Agents/AgentTurnResponse.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using AgentBlazor.Core.Runtime.Components;
 using AgentBlazor.Core.Components;
 using AgentBlazor.Execution;
+using Microsoft.Extensions.AI;
 
 namespace AgentBlazor.Core.Runtime.Agents;
 
@@ -19,6 +20,7 @@ public sealed record AgentTurnResponse(
     public IReadOnlyList<PendingApproval> PendingApprovals { get; init; } = [];
     public AgentUiDocument? GeneratedUi { get; init; }
     public AgentExecutionPlan? ExecutionPlan { get; init; }
+    public UsageDetails? Usage { get; init; }
     public bool HasNormalizedExecutionPlan => ExecutionPlan?.Steps.Count > 0;
     public bool UsesLegacyCompatibilityPayload => !HasNormalizedExecutionPlan &&
         (PlannedActions.Count > 0 || ExecutionResults.Count > 0);

--- a/src/AgentBlazor.Core/Runtime/RuntimeTurnResponses.cs
+++ b/src/AgentBlazor.Core/Runtime/RuntimeTurnResponses.cs
@@ -2,6 +2,7 @@ using AgentBlazor.Core.Runtime.Agents;
 using AgentBlazor.Core.Components;
 using AgentBlazor.Core.Runtime.Components;
 using AgentBlazor.Execution;
+using Microsoft.Extensions.AI;
 
 namespace AgentBlazor.Core.Runtime;
 
@@ -16,7 +17,8 @@ internal static class RuntimeTurnResponses
         string? clarificationQuestion = null,
         IReadOnlyList<PendingApproval>? pendingApprovals = null,
         bool? requiresApproval = null,
-        AgentExecutionPlan? executionPlan = null)
+        AgentExecutionPlan? executionPlan = null,
+        UsageDetails? usage = null)
     {
         var effectiveClarification = clarificationQuestion
             ?? executionResults.FirstOrDefault(static result => result.Outcome is ActionOutcome.NeedsClarification)?.Message;
@@ -32,7 +34,8 @@ internal static class RuntimeTurnResponses
             ClarificationQuestion = effectiveClarification,
             RequiresApproval = requiresApproval ?? effectivePendingApprovals.Count > 0,
             PendingApprovals = effectivePendingApprovals,
-            ExecutionPlan = executionPlan
+            ExecutionPlan = executionPlan,
+            Usage = usage
         };
 
         return RuntimeGeneratedUi.Attach(response, generatedUi);


### PR DESCRIPTION
## Summary
- add the v0.2 sprint plan with linked GitHub issue detail
- document AgentBlazor dependency stability around GA vs preview MAF packages
- verify/document free demo observability posture
- carry token usage through runtime responses into demo JSONL logging and summary output

## Verification
- dotnet build demo/AgentBlazor.Demo/AgentBlazor.Demo.csproj -p:UseAppHost=false
- dotnet test tests/AgentBlazor.Core.Tests/AgentBlazor.Core.Tests.csproj --no-restore
- dotnet test tests/AgentBlazor.Components.Tests/AgentBlazor.Components.Tests.csproj --no-restore