### PR TITLE
Add structured capability error recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ dotnet run --project samples/AgentBlazor.Starter/AgentBlazor.Starter.csproj
 ## Docs
 
 - [Quickstart](docs/quickstart.md)
+- [Recoverable capability errors](docs/capability-errors.md)
 - [Beta testing](docs/beta-testing.md)
 - [Starter sample](samples/AgentBlazor.Starter/README.md)
 - [Advanced CLI](docs/advanced/cli.md)

--- a/docs/capability-errors.md
+++ b/docs/capability-errors.md
@@ -1,0 +1,87 @@
+# Recoverable Capability Errors
+
+AgentBlazor sends `CapabilityResult` back to the model after a tool call. If an action cannot run, return a result the model can recover from instead of throwing raw exceptions or burying instructions in prose.
+
+## Convention
+
+- `Summary`: say why the current action did not complete.
+- `NextActions`: tell the model exactly what to do next.
+- `Warnings`: use only for non-fatal caveats.
+- `Outputs`: include compact machine-readable metadata such as `errorCode`, `parameterName`, and `expectedShape`.
+- `NeedsClarification`: use only when the user must provide missing information.
+
+## Invalid Arguments
+
+Use `InvalidArguments` when the model supplied values but the requested operation is not valid.
+
+```csharp
+[AgentAction("Find orders in a date range")]
+public CapabilityResult FindOrders(DateOnly startDate, DateOnly endDate)
+{
+    if (endDate < startDate)
+    {
+        return CapabilityResult
+            .InvalidArguments("The end date must be on or after the start date.")
+            .WithOutput("errorCode", "invalid_date_range")
+            .WithOutput("parameterName", "endDate")
+            .WithOutput("expectedShape", "date on or after startDate")
+            .WithNextAction("Retry with an endDate that is on or after startDate.");
+    }
+
+    return CapabilityResult.Success("Found matching orders.");
+}
+```
+
+## Missing User Input
+
+Use `MissingArgument` when the user needs to provide a required value.
+
+```csharp
+return CapabilityResult.MissingArgument(
+    parameterName: "ticketId",
+    expectedShape: "a ticket ID such as TCK-1042",
+    actionId: "support_inbox.draft_ticket_reply");
+```
+
+This sets `RequiresClarification`, so the chat surface can ask the user for the missing value.
+
+## Invalid Shape
+
+Use `InvalidArgumentShape` when the model can repair the call without asking the user.
+
+```csharp
+return CapabilityResult.InvalidArgumentShape(
+    parameterName: "ticketId",
+    expectedShape: "a string such as TCK-1042",
+    actualShape: "object",
+    actionId: "support_inbox.draft_ticket_reply");
+```
+
+The runtime also returns this automatically when a reflected `[AgentAction]` receives an argument that cannot be bound to the method parameter type.
+
+## Recoverable Failures
+
+Use `RecoverableFailure` for validation-style failures from inside the method body.
+
+```csharp
+return CapabilityResult
+    .RecoverableFailure("The ticket is blocked until billing evidence is attached.")
+    .WithOutput("errorCode", "missing_billing_evidence")
+    .WithOutput("ticketId", ticketId)
+    .WithNextAction("Ask for billing evidence before drafting the reply again.");
+```
+
+Unexpected exceptions are treated as terse failures by the runtime. Do not rely on exception text as the model-facing recovery path.
+
+## Runtime Wrapping
+
+The reflection registry wraps common binding failures before the method runs:
+
+- missing required parameter
+- invalid scalar shape
+- invalid enum value
+- invalid array/object shape
+- required `null`
+- missing runtime context
+
+The normalized execution plan carries `Summary`, `Warnings`, `NextActions`, and `Outputs` into the chat UI. The semantic capability tool result also returns the full serialized `CapabilityResult`, so the model sees the recovery hints.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -179,3 +179,4 @@ Say hello
 - [Hosted demo](https://demo.agentblazor.com/demo/workflows/support-inbox)
 - [Starter sample](../samples/AgentBlazor.Starter/README.md)
 - [Hosted WebAssembly client](../src/AgentBlazor.Client/PACKAGE_README.md)
+- [Recoverable capability errors](capability-errors.md)

--- a/src/AgentBlazor.Core/App/CapabilityResult.cs
+++ b/src/AgentBlazor.Core/App/CapabilityResult.cs
@@ -82,6 +82,40 @@ public sealed record CapabilityResult(string Summary)
         Succeeded = false
     };
 
+    public static CapabilityResult InvalidArguments(string summary) => Failure(summary)
+        .WithOutput("errorCode", "invalid_arguments");
+
+    public static CapabilityResult MissingArgument(
+        string parameterName,
+        string expectedShape,
+        string actionId)
+        => NeedsClarification(
+                $"Required parameter '{parameterName}' is missing for capability action '{actionId}'.")
+            .WithOutput("errorCode", "missing_argument")
+            .WithOutput("parameterName", parameterName)
+            .WithOutput("expectedShape", expectedShape)
+            .WithOutput("actionId", actionId)
+            .WithNextAction(
+                $"Ask the user for '{parameterName}' or retry only if it can be inferred from conversation context.");
+
+    public static CapabilityResult InvalidArgumentShape(
+        string parameterName,
+        string expectedShape,
+        string actualShape,
+        string actionId)
+        => InvalidArguments(
+                $"Parameter '{parameterName}' for capability action '{actionId}' must be {expectedShape}, but received {actualShape}.")
+            .WithOutput("errorCode", "invalid_argument_shape")
+            .WithOutput("parameterName", parameterName)
+            .WithOutput("expectedShape", expectedShape)
+            .WithOutput("actualShape", actualShape)
+            .WithOutput("actionId", actionId)
+            .WithNextAction(
+                $"Retry capability action '{actionId}' with '{parameterName}' as {expectedShape}.");
+
+    public static CapabilityResult RecoverableFailure(string summary) => Failure(summary)
+        .WithOutput("errorCode", "recoverable_failure");
+
     public static CapabilityResult Blocked(string summary) => new(summary)
     {
         Succeeded = false,

--- a/src/AgentBlazor.Core/App/ReflectionAgentCapabilityRegistry.cs
+++ b/src/AgentBlazor.Core/App/ReflectionAgentCapabilityRegistry.cs
@@ -232,25 +232,65 @@ internal sealed class ReflectionAgentCapabilityRegistry(IEnumerable<Type> capabi
             }
 
             var key = ResolveArgumentKey(parameter, parameterAttribute);
-            if (!TryGetArgValue(arguments, key, parameter.ParameterType, out var value))
+            var binding = BindArgument(arguments, key, parameter.ParameterType);
+            if (binding.Status is CapabilityArgumentBindStatus.Bound &&
+                binding.Value is null &&
+                IsParameterRequired(parameter, parameterAttribute))
+            {
+                return CapabilityResult.InvalidArgumentShape(
+                    key,
+                    DescribeExpectedShape(parameter.ParameterType),
+                    "null",
+                    info.ActionId);
+            }
+
+            if (binding.Status is not CapabilityArgumentBindStatus.Bound)
             {
                 if (!string.IsNullOrWhiteSpace(parameterAttribute?.ContextKey))
                 {
-                    return CapabilityResult.Failure(
-                        $"Required runtime context '{parameterAttribute.ContextKey}' is missing for capability action '{info.ActionId}'.");
+                    return CapabilityResult
+                        .InvalidArguments(
+                            $"Required runtime context '{parameterAttribute.ContextKey}' is missing for capability action '{info.ActionId}'.")
+                        .WithOutput("errorCode", "missing_runtime_context")
+                        .WithOutput("parameterName", key)
+                        .WithOutput("expectedShape", DescribeExpectedShape(parameter.ParameterType))
+                        .WithOutput("actionId", info.ActionId)
+                        .WithOutput("contextKey", parameterAttribute.ContextKey)
+                        .WithNextAction(
+                            $"Ensure runtime context '{parameterAttribute.ContextKey}' is supplied before invoking '{info.ActionId}'.");
                 }
 
                 if (IsParameterRequired(parameter, parameterAttribute))
                 {
-                    return CapabilityResult.NeedsClarification(
-                        $"Required parameter '{key}' is missing for capability action '{info.ActionId}'.");
+                    if (binding.Status is CapabilityArgumentBindStatus.InvalidShape)
+                    {
+                        return CapabilityResult.InvalidArgumentShape(
+                            key,
+                            DescribeExpectedShape(parameter.ParameterType),
+                            binding.ActualShape ?? "unknown",
+                            info.ActionId);
+                    }
+
+                    return CapabilityResult.MissingArgument(
+                        key,
+                        DescribeExpectedShape(parameter.ParameterType),
+                        info.ActionId);
+                }
+
+                if (binding.Status is CapabilityArgumentBindStatus.InvalidShape)
+                {
+                    return CapabilityResult.InvalidArgumentShape(
+                        key,
+                        DescribeExpectedShape(parameter.ParameterType),
+                        binding.ActualShape ?? "unknown",
+                        info.ActionId);
                 }
 
                 invocationArgs[i] = parameter.HasDefaultValue ? parameter.DefaultValue : GetDefault(parameter.ParameterType);
                 continue;
             }
 
-            invocationArgs[i] = value;
+            invocationArgs[i] = binding.Value;
         }
 
         try
@@ -295,14 +335,30 @@ internal sealed class ReflectionAgentCapabilityRegistry(IEnumerable<Type> capabi
         }
         catch (TargetInvocationException tie) when (tie.InnerException is not null)
         {
-            return CapabilityResult.Failure(
-                $"Capability action '{info.ActionId}' failed: {tie.InnerException.Message}");
+            return BuildInvocationFailure(info, tie.InnerException);
         }
         catch (Exception ex)
         {
-            return CapabilityResult.Failure(
-                $"Capability action '{info.ActionId}' failed: {ex.Message}");
+            return BuildInvocationFailure(info, ex);
         }
+    }
+
+    private static CapabilityResult BuildInvocationFailure(CapabilityActionCacheInfo info, Exception exception)
+    {
+        if (exception is ArgumentException or FormatException or InvalidOperationException)
+        {
+            var summary = $"Capability action '{info.ActionId}' failed: {exception.Message}";
+            return CapabilityResult.RecoverableFailure(summary)
+                .WithOutput("actionId", info.ActionId)
+                .WithOutput("exceptionType", exception.GetType().Name)
+                .WithNextAction(
+                    $"Review the arguments and retry '{info.ActionId}' only if the requested operation can be corrected.");
+        }
+
+        return CapabilityResult.Failure($"Capability action '{info.ActionId}' failed unexpectedly.")
+            .WithOutput("errorCode", "capability_invocation_failed")
+            .WithOutput("actionId", info.ActionId)
+            .WithOutput("exceptionType", exception.GetType().Name);
     }
 
     private static object ResolveInstance(IServiceProvider serviceProvider, Type capabilityType)
@@ -561,38 +617,33 @@ internal sealed class ReflectionAgentCapabilityRegistry(IEnumerable<Type> capabi
         return true;
     }
 
-    private static bool TryGetArgValue(
+    private static CapabilityArgumentBinding BindArgument(
         IReadOnlyDictionary<string, object?> arguments,
         string key,
-        Type targetType,
-        out object? value)
+        Type targetType)
     {
-        value = null;
         if (!arguments.TryGetValue(key, out var raw))
         {
-            return false;
+            return CapabilityArgumentBinding.Missing;
         }
 
         if (raw is null)
         {
-            value = null;
-            return true;
+            return CapabilityArgumentBinding.Bound(null);
         }
 
         var underlyingType = Nullable.GetUnderlyingType(targetType) ?? targetType;
 
         if (underlyingType.IsInstanceOfType(raw))
         {
-            value = raw;
-            return true;
+            return CapabilityArgumentBinding.Bound(raw);
         }
 
         try
         {
             if (raw is JsonElement json)
             {
-                value = JsonSerializer.Deserialize(json.GetRawText(), targetType, JsonOptions);
-                return true;
+                return CapabilityArgumentBinding.Bound(JsonSerializer.Deserialize(json.GetRawText(), targetType, JsonOptions));
             }
 
             if (underlyingType != typeof(string))
@@ -601,24 +652,90 @@ internal sealed class ReflectionAgentCapabilityRegistry(IEnumerable<Type> capabi
                 var deserialized = JsonSerializer.Deserialize(serialized, targetType, JsonOptions);
                 if (deserialized is not null || !targetType.IsValueType || Nullable.GetUnderlyingType(targetType) is not null)
                 {
-                    value = deserialized;
-                    return true;
+                    return CapabilityArgumentBinding.Bound(deserialized);
                 }
             }
 
             if (underlyingType.IsEnum)
             {
-                value = Enum.Parse(underlyingType, raw.ToString()!, ignoreCase: true);
-                return true;
+                return CapabilityArgumentBinding.Bound(Enum.Parse(underlyingType, raw.ToString()!, ignoreCase: true));
             }
 
-            value = Convert.ChangeType(raw, underlyingType);
-            return true;
+            return CapabilityArgumentBinding.Bound(Convert.ChangeType(raw, underlyingType));
         }
         catch
         {
-            return false;
+            return CapabilityArgumentBinding.Invalid(DescribeActualShape(raw));
         }
+    }
+
+    private static string DescribeExpectedShape(Type type)
+    {
+        var underlyingType = Nullable.GetUnderlyingType(type) ?? type;
+        if (underlyingType.IsArray)
+        {
+            return $"array of {DescribeExpectedShape(underlyingType.GetElementType()!)}";
+        }
+
+        if (TryGetEnumerableElementType(underlyingType, out var elementType))
+        {
+            return $"array of {DescribeExpectedShape(elementType)}";
+        }
+
+        if (underlyingType.IsEnum)
+        {
+            return $"one of: {string.Join(", ", Enum.GetNames(underlyingType))}";
+        }
+
+        return GetJsonSchemaType(underlyingType) switch
+        {
+            "integer" => "an integer",
+            "number" => "a number",
+            "boolean" => "a boolean",
+            "string" => "a string",
+            "object" => $"an object matching {underlyingType.Name}",
+            var value => value
+        };
+    }
+
+    private static string DescribeActualShape(object value)
+    {
+        if (value is JsonElement json)
+        {
+            return json.ValueKind switch
+            {
+                JsonValueKind.Array => "array",
+                JsonValueKind.Object => "object",
+                JsonValueKind.String => "string",
+                JsonValueKind.Number => "number",
+                JsonValueKind.True or JsonValueKind.False => "boolean",
+                JsonValueKind.Null => "null",
+                _ => json.ValueKind.ToString().ToLowerInvariant()
+            };
+        }
+
+        if (value is string)
+        {
+            return "string";
+        }
+
+        if (value is bool)
+        {
+            return "boolean";
+        }
+
+        if (value is System.Collections.IEnumerable && value is not string)
+        {
+            return "array";
+        }
+
+        var type = value.GetType();
+        if (type.IsPrimitive || type == typeof(decimal))
+        {
+            return "number";
+        }
+
+        return "object";
     }
 
     private static object? GetDefault(Type type) =>
@@ -669,4 +786,26 @@ internal sealed class ReflectionAgentCapabilityRegistry(IEnumerable<Type> capabi
         AvailabilityMember? AvailabilityCheck);
 
     private sealed record AvailabilityMember(PropertyInfo? Property, MethodInfo? Method);
+
+    private enum CapabilityArgumentBindStatus
+    {
+        Bound,
+        Missing,
+        InvalidShape
+    }
+
+    private sealed record CapabilityArgumentBinding(
+        CapabilityArgumentBindStatus Status,
+        object? Value,
+        string? ActualShape)
+    {
+        public static CapabilityArgumentBinding Missing { get; } =
+            new(CapabilityArgumentBindStatus.Missing, null, null);
+
+        public static CapabilityArgumentBinding Bound(object? value) =>
+            new(CapabilityArgumentBindStatus.Bound, value, null);
+
+        public static CapabilityArgumentBinding Invalid(string actualShape) =>
+            new(CapabilityArgumentBindStatus.InvalidShape, null, actualShape);
+    }
 }

--- a/tests/AgentBlazor.Core.Tests/AgentCapabilityRegistryTests.cs
+++ b/tests/AgentBlazor.Core.Tests/AgentCapabilityRegistryTests.cs
@@ -119,6 +119,142 @@ public class AgentCapabilityRegistryTests
         Assert.False(result.Succeeded);
         Assert.True(result.RequiresClarification);
         Assert.Contains("supplierIds", result.ClarificationQuestion, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal("missing_argument", result.Outputs["errorCode"]);
+        Assert.Equal("supplierIds", result.Outputs["parameterName"]);
+        Assert.Equal("supplier_compliance.prepare_remediation", result.Outputs["actionId"]);
+        Assert.Contains(result.NextActions, action => action.Contains("supplierIds", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenRequiredArgumentHasInvalidShape_ReturnsStructuredFailure()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(new CapabilityGate { CanPrepare = true });
+        services.AddSingleton<CapabilityRecorder>();
+        services.AddAgentBlazorServices()
+            .AddCapability<SupplierCapabilities>();
+
+        await using var provider = services.BuildServiceProvider();
+        var registry = provider.GetRequiredService<IAgentCapabilityRegistry>();
+
+        var result = await registry.ExecuteAsync(
+            "supplier_compliance.show_at_risk_suppliers",
+            new Dictionary<string, object?>
+            {
+                ["days"] = new { value = "soon" }
+            },
+            provider);
+
+        Assert.False(result.Succeeded);
+        Assert.False(result.RequiresClarification);
+        Assert.Equal("invalid_argument_shape", result.Outputs["errorCode"]);
+        Assert.Equal("days", result.Outputs["parameterName"]);
+        Assert.Equal("an integer", result.Outputs["expectedShape"]);
+        Assert.Equal("object", result.Outputs["actualShape"]);
+        Assert.Contains("days", result.Summary, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(result.NextActions, action => action.Contains("days", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenEnumArgumentHasInvalidValue_ReturnsStructuredFailure()
+    {
+        var services = new ServiceCollection();
+        services.AddAgentBlazorServices()
+            .AddCapability<TicketCapabilities>();
+
+        await using var provider = services.BuildServiceProvider();
+        var registry = provider.GetRequiredService<IAgentCapabilityRegistry>();
+
+        var result = await registry.ExecuteAsync(
+            "ticket_workflow.prioritize_ticket",
+            new Dictionary<string, object?>
+            {
+                ["priority"] = "urgent-ish"
+            },
+            provider);
+
+        Assert.False(result.Succeeded);
+        Assert.Equal("invalid_argument_shape", result.Outputs["errorCode"]);
+        Assert.Equal("priority", result.Outputs["parameterName"]);
+        Assert.Contains(nameof(TicketPriority.High), result.Outputs["expectedShape"]?.ToString(), StringComparison.Ordinal);
+        Assert.Contains("priority", result.Summary, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenRequiredArgumentIsNull_ReturnsStructuredFailure()
+    {
+        var services = new ServiceCollection();
+        services.AddAgentBlazorServices()
+            .AddCapability<TicketCapabilities>();
+
+        await using var provider = services.BuildServiceProvider();
+        var registry = provider.GetRequiredService<IAgentCapabilityRegistry>();
+
+        var result = await registry.ExecuteAsync(
+            "ticket_workflow.summarize_ticket",
+            new Dictionary<string, object?>
+            {
+                ["ticketId"] = null
+            },
+            provider);
+
+        Assert.False(result.Succeeded);
+        Assert.Equal("invalid_argument_shape", result.Outputs["errorCode"]);
+        Assert.Equal("ticketId", result.Outputs["parameterName"]);
+        Assert.Equal("null", result.Outputs["actualShape"]);
+        Assert.DoesNotContain("Object reference", result.Summary, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenCapabilityThrowsValidationException_ReturnsRecoverableFailure()
+    {
+        var services = new ServiceCollection();
+        services.AddAgentBlazorServices()
+            .AddCapability<TicketCapabilities>();
+
+        await using var provider = services.BuildServiceProvider();
+        var registry = provider.GetRequiredService<IAgentCapabilityRegistry>();
+
+        var result = await registry.ExecuteAsync(
+            "ticket_workflow.summarize_ticket",
+            new Dictionary<string, object?>
+            {
+                ["ticketId"] = "BAD-1"
+            },
+            provider);
+
+        Assert.False(result.Succeeded);
+        Assert.Equal("recoverable_failure", result.Outputs["errorCode"]);
+        Assert.Equal("ticket_workflow.summarize_ticket", result.Outputs["actionId"]);
+        Assert.Equal(nameof(ArgumentException), result.Outputs["exceptionType"]);
+        Assert.Contains("ticketId must start with TCK-", result.Summary, StringComparison.Ordinal);
+        Assert.Contains(result.NextActions, action => action.Contains("summarize_ticket", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenAsyncCapabilityThrowsUnexpectedException_ReturnsTerseFailure()
+    {
+        var services = new ServiceCollection();
+        services.AddAgentBlazorServices()
+            .AddCapability<TicketCapabilities>();
+
+        await using var provider = services.BuildServiceProvider();
+        var registry = provider.GetRequiredService<IAgentCapabilityRegistry>();
+
+        var result = await registry.ExecuteAsync(
+            "ticket_workflow.sync_external_ticket",
+            new Dictionary<string, object?>
+            {
+                ["ticketId"] = "TCK-1042"
+            },
+            provider);
+
+        Assert.False(result.Succeeded);
+        Assert.Equal("capability_invocation_failed", result.Outputs["errorCode"]);
+        Assert.Equal("ticket_workflow.sync_external_ticket", result.Outputs["actionId"]);
+        Assert.Equal(nameof(ApplicationException), result.Outputs["exceptionType"]);
+        Assert.Equal("Capability action 'ticket_workflow.sync_external_ticket' failed unexpectedly.", result.Summary);
+        Assert.DoesNotContain("upstream CRM token", result.Summary, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -174,6 +310,29 @@ public class AgentCapabilityRegistryTests
 
         Assert.True(result.Succeeded);
         Assert.Equal("ctx-123", recorder.LastSessionId);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenRuntimeContextIsMissing_ReturnsStructuredFailure()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<CapabilityRecorder>();
+        services.AddAgentBlazorServices()
+            .AddCapability<ContextCapabilities>();
+
+        await using var provider = services.BuildServiceProvider();
+        var registry = provider.GetRequiredService<IAgentCapabilityRegistry>();
+
+        var result = await registry.ExecuteAsync(
+            "context_scoped.capture_session",
+            new Dictionary<string, object?>(),
+            provider);
+
+        Assert.False(result.Succeeded);
+        Assert.False(result.RequiresClarification);
+        Assert.Equal("missing_runtime_context", result.Outputs["errorCode"]);
+        Assert.Equal(AgentRuntimeContextKeys.SessionId, result.Outputs["contextKey"]);
+        Assert.Contains(result.NextActions, action => action.Contains("runtime context", StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]
@@ -256,6 +415,40 @@ public class AgentCapabilityRegistryTests
             await Task.Delay(TimeSpan.FromSeconds(30), cancellationToken);
             return CapabilityResult.Success("Unexpected completion.");
         }
+    }
+
+    [AgentCapability("ticket_workflow", Name = "Ticket Workflow", Category = "Support")]
+    public sealed class TicketCapabilities
+    {
+        [AgentAction("Prioritize a ticket", ActionId = "prioritize_ticket")]
+        public CapabilityResult PrioritizeTicket(
+            [AgentParam("Ticket priority", Required = true)] TicketPriority priority)
+            => CapabilityResult.Success($"Priority set to {priority}.");
+
+        [AgentAction("Summarize a ticket", ActionId = "summarize_ticket")]
+        public CapabilityResult SummarizeTicket([AgentParam("Ticket ID", Required = true)] string ticketId)
+        {
+            if (!ticketId.StartsWith("TCK-", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new ArgumentException("ticketId must start with TCK-.", nameof(ticketId));
+            }
+
+            return CapabilityResult.Success($"Summarized {ticketId}.");
+        }
+
+        [AgentAction("Sync an external ticket", ActionId = "sync_external_ticket")]
+        public async Task<CapabilityResult> SyncExternalTicketAsync([AgentParam("Ticket ID", Required = true)] string ticketId)
+        {
+            await Task.Yield();
+            throw new ApplicationException($"upstream CRM token rejected while syncing {ticketId}");
+        }
+    }
+
+    public enum TicketPriority
+    {
+        Low,
+        Medium,
+        High
     }
 
     public sealed class CapabilityGate

--- a/tests/AgentBlazor.Core.Tests/RuntimeAdapterCapabilityProjectionTests.cs
+++ b/tests/AgentBlazor.Core.Tests/RuntimeAdapterCapabilityProjectionTests.cs
@@ -182,6 +182,44 @@ public class RuntimeAdapterCapabilityProjectionTests
     }
 
     [Fact]
+    public async Task ChatClientRuntimeAdapter_ReturnsStructuredCapabilityResult_ToModelToolCall()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<InvalidCapabilityArgumentChatClient>();
+        services.AddSingleton<IChatClient>(static sp => sp.GetRequiredService<InvalidCapabilityArgumentChatClient>());
+        services.AddSingleton(new CapabilityRecorder());
+        services.AddAgentBlazorServices()
+            .UseChatClientRuntimeAdapter()
+            .AddCapability<SupplierCapabilities>()
+            .AddAgent("supplier-agent", agent =>
+            {
+                agent.WithAllowedActions("supplier_compliance.show_at_risk_suppliers");
+            });
+
+        await using var provider = services.BuildServiceProvider();
+
+        var adapter = provider.GetRequiredService<IAgentRuntimeAdapter>();
+        var chatClient = provider.GetRequiredService<InvalidCapabilityArgumentChatClient>();
+
+        var response = await adapter.RunTurnAsync(new AgentTurnRequest(
+            "Show at-risk suppliers",
+            AgentName: "supplier-agent",
+            SessionId: "capability-structured-error"));
+
+        Assert.Contains("Parameter 'days'", response.ResponseText, StringComparison.Ordinal);
+        Assert.NotNull(chatClient.ToolResult);
+        Assert.Contains("\"errorCode\":\"invalid_argument_shape\"", chatClient.ToolResult, StringComparison.Ordinal);
+        Assert.Contains("\"parameterName\":\"days\"", chatClient.ToolResult, StringComparison.Ordinal);
+        Assert.Contains("\"expectedShape\":\"an integer\"", chatClient.ToolResult, StringComparison.Ordinal);
+        Assert.Contains("\"nextActions\"", chatClient.ToolResult, StringComparison.OrdinalIgnoreCase);
+
+        var step = Assert.Single(response.ExecutionPlan!.Steps);
+        Assert.Equal(AgentExecutionStepStatus.Failed, step.Status);
+        Assert.Equal("invalid_argument_shape", step.Outputs?["errorCode"]);
+        Assert.Contains(step.NextActions ?? [], action => action.Contains("days", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
     public async Task ChatClientRuntimeAdapter_RecordsSemanticCapabilityHistory_FromExecutionPlan()
     {
         var services = new ServiceCollection();
@@ -672,6 +710,50 @@ public class RuntimeAdapterCapabilityProjectionTests
             IEnumerable<ChatMessage> messages,
             ChatOptions? options = null,
             [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            var response = await GetResponseAsync(messages, options, cancellationToken);
+            yield return new ChatResponseUpdate(ChatRole.Assistant, response.Text);
+        }
+
+        public object? GetService(Type serviceType, object? serviceKey = null)
+        {
+            _ = serviceType;
+            _ = serviceKey;
+            return null;
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class InvalidCapabilityArgumentChatClient : IChatClient
+    {
+        public string? ToolResult { get; private set; }
+
+        public async Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> messages,
+            ChatOptions? options = null,
+            CancellationToken cancellationToken = default)
+        {
+            _ = messages;
+            var tool = Assert.Single(
+                options?.Tools?.OfType<AIFunction>().Where(static function =>
+                    function.Name.Contains("capability_supplier_compliance_show_at_risk_suppliers", StringComparison.OrdinalIgnoreCase)) ??
+                []);
+            var result = await tool.InvokeAsync(new AIFunctionArguments(new Dictionary<string, object?>
+            {
+                ["days"] = new { value = "soon" }
+            }), cancellationToken);
+            ToolResult = result?.ToString();
+
+            return new ChatResponse(new ChatMessage(ChatRole.Assistant, "structured-error-observed"));
+        }
+
+        public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IEnumerable<ChatMessage> messages,
+            ChatOptions? options = null,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
             var response = await GetResponseAsync(messages, options, cancellationToken);
             yield return new ChatResponseUpdate(ChatRole.Assistant, response.Text);


### PR DESCRIPTION
## Summary
- add recoverable `CapabilityResult` helpers for invalid arguments, missing arguments, invalid shapes, and recoverable failures
- wrap capability binding/invocation failures with structured metadata and recovery hints
- prove model-facing semantic capability tool results receive structured `CapabilityResult` payloads
- document recoverable capability error conventions

## Verification
- dotnet test tests/AgentBlazor.Core.Tests/AgentBlazor.Core.Tests.csproj --no-restore
- dotnet test tests/AgentBlazor.Components.Tests/AgentBlazor.Components.Tests.csproj --no-restore
- dotnet build demo/AgentBlazor.Demo/AgentBlazor.Demo.csproj -p:UseAppHost=false
- git diff --check

Closes #8
