### PR TITLE
Filter bot probes from demo analytics

### DIFF
--- a/demo/AgentBlazor.Demo/Services/DemoLogEndpointMapper.cs
+++ b/demo/AgentBlazor.Demo/Services/DemoLogEndpointMapper.cs
@@ -189,7 +189,7 @@ internal static class DemoLogEndpointMapper
             .Select(ParseTraffic)
             .Where(static item => item is not null)
             .Select(static item => item!)
-            .Where(static item => IsPageViewRoute(item.Path))
+            .Where(static item => DemoTrafficRouteFilter.IsHumanPageViewRoute(item.Path))
             .ToArray();
         var chats = chatLines
             .Select(ParseChat)
@@ -290,15 +290,6 @@ internal static class DemoLogEndpointMapper
     }
 
     private sealed record TrafficSummaryItem(DateTimeOffset TimestampUtc, string Path, string VisitorHash);
-
-    private static bool IsPageViewRoute(string path)
-    {
-        return !path.StartsWith("/_blazor", StringComparison.OrdinalIgnoreCase) &&
-               !path.StartsWith("/_framework", StringComparison.OrdinalIgnoreCase) &&
-               !path.StartsWith("/_content", StringComparison.OrdinalIgnoreCase) &&
-               !path.StartsWith("/internal", StringComparison.OrdinalIgnoreCase) &&
-               !Path.HasExtension(path);
-    }
 
     private sealed record ChatSummaryItem(
         DateTimeOffset TimestampUtc,

--- a/demo/AgentBlazor.Demo/Services/DemoTrafficLoggingMiddleware.cs
+++ b/demo/AgentBlazor.Demo/Services/DemoTrafficLoggingMiddleware.cs
@@ -65,18 +65,7 @@ internal sealed class DemoTrafficLoggingMiddleware(
         }
 
         var path = request.Path.Value ?? "/";
-        if (path.StartsWith("/internal", StringComparison.OrdinalIgnoreCase) ||
-            path.StartsWith("/_blazor", StringComparison.OrdinalIgnoreCase) ||
-            path.StartsWith("/_framework", StringComparison.OrdinalIgnoreCase) ||
-            path.StartsWith("/_content", StringComparison.OrdinalIgnoreCase) ||
-            path.StartsWith("/css", StringComparison.OrdinalIgnoreCase) ||
-            path.StartsWith("/js", StringComparison.OrdinalIgnoreCase) ||
-            path.StartsWith("/lib", StringComparison.OrdinalIgnoreCase))
-        {
-            return false;
-        }
-
-        if (Path.HasExtension(path))
+        if (!DemoTrafficRouteFilter.IsHumanPageViewRoute(path))
         {
             return false;
         }

--- a/demo/AgentBlazor.Demo/Services/DemoTrafficRouteFilter.cs
+++ b/demo/AgentBlazor.Demo/Services/DemoTrafficRouteFilter.cs
@@ -1,0 +1,32 @@
+namespace AgentBlazor.Demo.Services;
+
+internal static class DemoTrafficRouteFilter
+{
+    public static bool IsHumanPageViewRoute(string? path)
+    {
+        path = string.IsNullOrWhiteSpace(path) ? "/" : path;
+
+        if (path.StartsWith("/_blazor", StringComparison.OrdinalIgnoreCase) ||
+            path.StartsWith("/_framework", StringComparison.OrdinalIgnoreCase) ||
+            path.StartsWith("/_content", StringComparison.OrdinalIgnoreCase) ||
+            path.StartsWith("/internal", StringComparison.OrdinalIgnoreCase) ||
+            path.StartsWith("/css", StringComparison.OrdinalIgnoreCase) ||
+            path.StartsWith("/js", StringComparison.OrdinalIgnoreCase) ||
+            path.StartsWith("/lib", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (path.StartsWith("/.", StringComparison.OrdinalIgnoreCase) ||
+            path.StartsWith("/wp-", StringComparison.OrdinalIgnoreCase) ||
+            path.StartsWith("/wp/", StringComparison.OrdinalIgnoreCase) ||
+            path.StartsWith("/phpmyadmin", StringComparison.OrdinalIgnoreCase) ||
+            path.StartsWith("/pma", StringComparison.OrdinalIgnoreCase) ||
+            path.Equals("/xmlrpc.php", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        return !Path.HasExtension(path);
+    }
+}

--- a/tests/AgentBlazor.IntegrationTests/DemoTrafficRouteFilterTests.cs
+++ b/tests/AgentBlazor.IntegrationTests/DemoTrafficRouteFilterTests.cs
@@ -1,0 +1,33 @@
+using AgentBlazor.Demo.Services;
+
+namespace AgentBlazor.IntegrationTests;
+
+public class DemoTrafficRouteFilterTests
+{
+    [Theory]
+    [InlineData("/")]
+    [InlineData("/demo")]
+    [InlineData("/demo/workflows/support-inbox")]
+    [InlineData("/docs/quickstart")]
+    public void IsHumanPageViewRoute_AllowsBrowserRoutes(string path)
+    {
+        Assert.True(DemoTrafficRouteFilter.IsHumanPageViewRoute(path));
+    }
+
+    [Theory]
+    [InlineData("/_blazor")]
+    [InlineData("/_framework/blazor.web.js")]
+    [InlineData("/_content/AgentBlazor/AgentBlazor.min.js")]
+    [InlineData("/internal/demo-logs")]
+    [InlineData("/lib/bootstrap/dist/css/bootstrap.min.css")]
+    [InlineData("/favicon.png")]
+    [InlineData("/.git/HEAD")]
+    [InlineData("/wp-admin/")]
+    [InlineData("/wp-login.php")]
+    [InlineData("/xmlrpc.php")]
+    [InlineData("/phpmyadmin")]
+    public void IsHumanPageViewRoute_RejectsFrameworkAssetsAndBotProbes(string path)
+    {
+        Assert.False(DemoTrafficRouteFilter.IsHumanPageViewRoute(path));
+    }
+}


### PR DESCRIPTION
Keeps hosted-demo analytics focused on real browser page views instead of bot probes or framework assets.\n\nChanges:\n- share the route filter between traffic logging and summary aggregation\n- exclude framework/static routes and common probes like /.git/HEAD, wp-admin, xmlrpc, phpMyAdmin\n- add integration coverage for allowed demo/docs routes and rejected noise routes\n\nVerification:\n- dotnet test tests/AgentBlazor.IntegrationTests/AgentBlazor.IntegrationTests.csproj --no-restore\n- git diff --check