### PR TITLE
Add daily cost guard for hosted demo

### DIFF
--- a/demo/AgentBlazor.Demo/Configuration/DemoLoggingOptions.cs
+++ b/demo/AgentBlazor.Demo/Configuration/DemoLoggingOptions.cs
@@ -23,4 +23,8 @@ internal sealed class DemoLoggingOptions
     public decimal InputTokenCostPerMillion { get; set; } = 0.15m;
 
     public decimal OutputTokenCostPerMillion { get; set; } = 0.60m;
+
+    public bool DailyCostLimitEnabled { get; set; } = true;
+
+    public decimal DailyCostLimitUsd { get; set; } = 2.00m;
 }

--- a/demo/AgentBlazor.Demo/Services/DemoChatRequestLoggingMiddleware.cs
+++ b/demo/AgentBlazor.Demo/Services/DemoChatRequestLoggingMiddleware.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Security.Cryptography;
 using System.Text;
+using System.Text.Json;
 using AgentBlazor.Core.Runtime.Agents;
 using AgentBlazor.Core.Runtime.Middleware;
 using AgentBlazor.Demo.Configuration;
@@ -35,6 +36,31 @@ internal sealed class DemoChatRequestLoggingMiddleware(
 
         try
         {
+            if (await IsDailyCostLimitExceededAsync(ct))
+            {
+                stopwatch.Stop();
+                context.Response = new AgentTurnResponse(
+                    context.Request.AgentName ?? "AgentBlazor Demo",
+                    "The hosted demo is temporarily unavailable because today's usage cap has been reached. Try the quickstart locally or check back tomorrow.",
+                    [],
+                    []);
+
+                var cappedEntry = CreateEntry(
+                    context.Request,
+                    requestId,
+                    stopwatch.ElapsedMilliseconds,
+                    "cost-limit",
+                    context.Response);
+
+                await requestLog.AppendAsync(cappedEntry, ct);
+                logger.LogWarning(
+                    "Demo chat request {RequestId} blocked by daily cost limit: route={Route} agent={AgentName}",
+                    cappedEntry.RequestId,
+                    cappedEntry.Route,
+                    cappedEntry.AgentName);
+                return;
+            }
+
             await next(ct);
             stopwatch.Stop();
 
@@ -144,6 +170,56 @@ internal sealed class DemoChatRequestLoggingMiddleware(
         var inputCost = (inputTokens ?? 0) / 1_000_000m * _options.InputTokenCostPerMillion;
         var outputCost = (outputTokens ?? 0) / 1_000_000m * _options.OutputTokenCostPerMillion;
         return Math.Round(inputCost + outputCost, 8, MidpointRounding.AwayFromZero);
+    }
+
+    private async Task<bool> IsDailyCostLimitExceededAsync(CancellationToken cancellationToken)
+    {
+        if (!_options.DailyCostLimitEnabled || _options.DailyCostLimitUsd <= 0)
+        {
+            return false;
+        }
+
+        IReadOnlyList<string> lines;
+        try
+        {
+            lines = await requestLog.ReadAllAsync(cancellationToken);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or JsonException)
+        {
+            logger.LogWarning(ex, "Unable to read demo chat request log for cost-limit check.");
+            return false;
+        }
+
+        var today = DateTimeOffset.UtcNow.Date;
+        var currentCost = lines.Sum(line => TryReadTodayEstimatedCost(line, today));
+        return currentCost >= _options.DailyCostLimitUsd;
+    }
+
+    private static decimal TryReadTodayEstimatedCost(string line, DateTime todayUtc)
+    {
+        try
+        {
+            using var document = JsonDocument.Parse(line);
+            var root = document.RootElement;
+            if (!root.TryGetProperty("timestampUtc", out var timestampProperty) ||
+                timestampProperty.GetDateTimeOffset().UtcDateTime.Date != todayUtc ||
+                !root.TryGetProperty("estimated_cost", out var costProperty) ||
+                costProperty.ValueKind is not JsonValueKind.Number ||
+                !costProperty.TryGetDecimal(out var cost))
+            {
+                return 0;
+            }
+
+            return cost;
+        }
+        catch (JsonException)
+        {
+            return 0;
+        }
+        catch (FormatException)
+        {
+            return 0;
+        }
     }
 
     private static string? TryGetContext(AgentTurnRequest request, string key)

--- a/demo/AgentBlazor.Demo/appsettings.json
+++ b/demo/AgentBlazor.Demo/appsettings.json
@@ -32,7 +32,9 @@
     "PromptPreviewMaxLength": 160,
     "MaxTailLines": 500,
     "InputTokenCostPerMillion": 0.15,
-    "OutputTokenCostPerMillion": 0.60
+    "OutputTokenCostPerMillion": 0.60,
+    "DailyCostLimitEnabled": true,
+    "DailyCostLimitUsd": 2.00
   },
   "DemoRemoteStorage": {
     "Adapter": "InMemory",

--- a/tests/AgentBlazor.IntegrationTests/DemoChatRequestLoggingMiddlewareTests.cs
+++ b/tests/AgentBlazor.IntegrationTests/DemoChatRequestLoggingMiddlewareTests.cs
@@ -1,0 +1,98 @@
+using AgentBlazor.Core.Runtime.Agents;
+using AgentBlazor.Core.Runtime.Middleware;
+using AgentBlazor.Demo.Configuration;
+using AgentBlazor.Demo.Services;
+using AgentBlazor.Options;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace AgentBlazor.IntegrationTests;
+
+public class DemoChatRequestLoggingMiddlewareTests
+{
+    [Fact]
+    public async Task InvokeAsync_WhenDailyCostLimitExceeded_ShortCircuitsWithoutCallingNext()
+    {
+        using var directory = new TempLogDirectory();
+        var today = new DateTimeOffset(DateTime.UtcNow.Date, TimeSpan.Zero).ToString("O");
+        await File.WriteAllTextAsync(
+            Path.Combine(directory.Path, "chat-requests.jsonl"),
+            $$"""
+            {"timestampUtc":"{{today}}","estimated_cost":0.03}
+
+            """);
+        var middleware = CreateMiddleware(directory.Path, dailyCostLimitUsd: 0.01m);
+        var context = new AgentTurnContext(new AgentTurnRequest("hello", AgentName: "Support Inbox Agent"));
+        var nextCalled = false;
+
+        await middleware.InvokeAsync(
+            context,
+            _ =>
+            {
+                nextCalled = true;
+                return Task.CompletedTask;
+            });
+
+        Assert.False(nextCalled);
+        Assert.NotNull(context.Response);
+        Assert.Contains("usage cap", context.Response!.ResponseText, StringComparison.OrdinalIgnoreCase);
+        var lines = await File.ReadAllLinesAsync(Path.Combine(directory.Path, "chat-requests.jsonl"));
+        Assert.Contains(lines, static line => line.Contains("\"status\":\"cost-limit\"", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task InvokeAsync_WhenDailyCostLimitNotExceeded_CallsNextAndLogsTurn()
+    {
+        using var directory = new TempLogDirectory();
+        var middleware = CreateMiddleware(directory.Path, dailyCostLimitUsd: 1.00m);
+        var context = new AgentTurnContext(new AgentTurnRequest("hello", AgentName: "Support Inbox Agent"));
+
+        await middleware.InvokeAsync(
+            context,
+            _ =>
+            {
+                context.Response = new AgentTurnResponse("Support Inbox Agent", "hello back", [], []);
+                return Task.CompletedTask;
+            });
+
+        Assert.NotNull(context.Response);
+        var line = Assert.Single(await File.ReadAllLinesAsync(Path.Combine(directory.Path, "chat-requests.jsonl")));
+        Assert.Contains("\"status\":\"ok\"", line, StringComparison.Ordinal);
+    }
+
+    private static DemoChatRequestLoggingMiddleware CreateMiddleware(string directoryPath, decimal dailyCostLimitUsd)
+    {
+        var options = new DemoLoggingOptions
+        {
+            DirectoryPath = directoryPath,
+            DailyCostLimitEnabled = true,
+            DailyCostLimitUsd = dailyCostLimitUsd
+        };
+
+        var requestLog = new JsonlDemoChatRequestLog(Microsoft.Extensions.Options.Options.Create(options));
+        return new DemoChatRequestLoggingMiddleware(
+            requestLog,
+            Microsoft.Extensions.Options.Options.Create(options),
+            Microsoft.Extensions.Options.Options.Create(new AgentBlazorOptions()),
+            NullLogger<DemoChatRequestLoggingMiddleware>.Instance);
+    }
+
+    private sealed class TempLogDirectory : IDisposable
+    {
+        public TempLogDirectory()
+        {
+            Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"agentblazor-demo-tests-{Guid.NewGuid():n}");
+            Directory.CreateDirectory(Path);
+        }
+
+        public string Path { get; }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(Path))
+            {
+                Directory.Delete(Path, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds a free JSONL-backed daily usage cap for the hosted demo.\n\nBehavior:\n- before each agent turn, the demo sums today's logged estimated OpenAI cost\n- if the configured daily cap is reached, the middleware short-circuits with a friendly unavailable message\n- blocked turns are logged with status=cost-limit\n- default cap is enabled at 2.00 USD/day and can be overridden through DemoLogging configuration\n\nExisting rate limiting remains applied to the AgentBlazor endpoint policy.\n\nVerification:\n- dotnet test tests/AgentBlazor.IntegrationTests/AgentBlazor.IntegrationTests.csproj --no-restore\n- git diff --check