### PR TITLE
Update sprint status and structured error demo reference

### DIFF
--- a/demo/AgentBlazor.Demo/Services/SupportInboxWorkflowService.cs
+++ b/demo/AgentBlazor.Demo/Services/SupportInboxWorkflowService.cs
@@ -10,6 +10,17 @@ internal sealed class SupportInboxCapabilities(SupportInboxWorkflowService workf
     public Task<CapabilityResult> ShowOpenTicketsAsync(
         [AgentParam("Include tickets from the last N days", Required = false)] int days = 7)
     {
+        if (days is < 1 or > 30)
+        {
+            return Task.FromResult(CapabilityResult
+                .InvalidArguments("The support inbox review window must be between 1 and 30 days.")
+                .WithOutput("errorCode", "invalid_review_window")
+                .WithOutput("parameterName", "days")
+                .WithOutput("expectedShape", "an integer from 1 to 30")
+                .WithOutput("actualValue", days)
+                .WithNextAction("Retry support_inbox.show_open_tickets with days between 1 and 30."));
+        }
+
         var summary = workflow.FocusOpenTickets(days);
         return Task.FromResult(CapabilityResult.Success(summary) with
         {

--- a/docs/capability-errors.md
+++ b/docs/capability-errors.md
@@ -73,6 +73,16 @@ return CapabilityResult
 
 Unexpected exceptions are treated as terse failures by the runtime. Do not rely on exception text as the model-facing recovery path.
 
+## Demo Reference
+
+The hosted support-inbox demo includes a simple structured-error path without approval noise:
+
+```text
+Show open tickets from the last 90 days
+```
+
+The `show_open_tickets` capability rejects review windows outside 1-30 days with `errorCode=invalid_review_window`, `parameterName=days`, `expectedShape=an integer from 1 to 30`, and a `NextActions` retry hint. This is the reference pattern for validation that the model can repair without asking the user a new question.
+
 ## Runtime Wrapping
 
 The reflection registry wraps common binding failures before the method runs:

--- a/docs/internal/v0.2-sprint-plan-2026-05-11.md
+++ b/docs/internal/v0.2-sprint-plan-2026-05-11.md
@@ -4,6 +4,23 @@ Created: 2026-05-12
 Sprint window: 2026-05-11 to 2026-06-09  
 Ship target: 0.2.0 by 2026-06-07, promotional post on 2026-06-09
 
+## Current Status: 2026-05-13
+
+Week 1 commitment debt is closed ahead of the original end-of-week gate:
+
+- README dependency/stability section is live.
+- Hosted demo is live at `https://demo.agentblazor.com/`.
+- Demo observability is live through protected JSONL logs and `/internal/demo-logs/summary`.
+- Token and estimated-cost tracking are live in the demo logs.
+- Demo traffic analytics filter framework routes, static assets, and common bot probes.
+- Demo endpoint rate limiting is enabled.
+- Demo daily cost guard is enabled with a default `$2.00` estimated-cost cap.
+- Azure Container App scale is pinned to one replica so file-backed logs are consistent.
+- Issue #2 is closed with deployment evidence.
+- Issue #8 is closed after structured-error design, implementation, chat rendering, and runtime adapter regression coverage landed.
+
+Week 2 is no longer an implementation-from-zero week. Treat it as hardening, documentation, CleanTest/package verification, and demo-reference cleanup. Do not start issue #1 entity exposure before the 2026-05-24 check-in unless structured errors remain stable after the verification pass.
+
 ## Sprint Thesis
 
 v0.2 is not a broad feature sprint. It exists to close public commitment debt, ship structured error recovery, and decide whether entity exposure is realistic as a stretch goal.
@@ -21,7 +38,7 @@ The default cut line is strict:
 
 URL: https://github.com/ashpeterson/AgentBlazor/issues/8
 
-Status: open, assigned to `ashpeterson`, labelled `enhancement`.
+Status: closed on 2026-05-13. Design, runtime binding wrappers, chat rendering, documentation, and runtime adapter regressions have landed.
 
 This is the v0.2 must-ship issue. It came from launch feedback about bad capability arguments and whether AgentBlazor has a standard way to return validation failures to the LLM in a recoverable shape.
 
@@ -87,9 +104,9 @@ Out of scope:
 
 URL: https://github.com/ashpeterson/AgentBlazor/issues/2
 
-Status: open, assigned to `ashpeterson`, labelled `enhancement`.
+Status: closed on 2026-05-13 with live deployment evidence.
 
-This issue tracks the public no-install demo commitment from launch feedback. Much of the core hosting work is now done, but the issue should not be treated as fully closed until the remaining operational commitments are verified.
+This issue tracked the public no-install demo commitment from launch feedback. It is now closed; further demo work belongs to specific hardening issues rather than reopening this umbrella commitment.
 
 Original issue constraints:
 
@@ -129,6 +146,8 @@ v0.2 decision:
 ## Week 1: 2026-05-11 To 2026-05-17
 
 Theme: close commitment debts, scope structured errors. No new feature implementation beyond logging/token commitment work.
+
+Status: complete as of 2026-05-13.
 
 ### Mon-Tue: README Dependencies And Demo Observability
 
@@ -185,57 +204,61 @@ Estimate: 6-8 hours.
 
 ### End-Of-Week Gate
 
-- README dependency section live on GitHub.
-- Demo observability decision documented and verified.
-- Token/cost tracking live in demo logs.
-- Structured errors design posted to issue #8.
+- [x] README dependency section live on GitHub.
+- [x] Demo observability decision documented and verified.
+- [x] Token/cost tracking live in demo logs.
+- [x] Structured errors design posted to issue #8.
+- [x] Hosted demo issue #2 closed with deployment evidence.
 
 ## Week 2: 2026-05-18 To 2026-05-24
 
-Theme: build structured errors. This is the implementation week.
+Theme: harden structured errors, verify install/package shape, and make the demo reference clear. The main implementation landed early; this week is now about proving it is reliable.
 
 ### Mon-Tue: Result Variants And Helpers
 
 Tasks:
 
-- Implement typed result variants for recoverable failures.
-- Add helpers such as `WithRecovery` and `WithExpectedShape`, or settle naming in the issue #8 design first.
-- Unit tests for each variant/helper.
+- [x] Implement typed result variants for recoverable failures.
+- [x] Unit tests for each variant/helper.
+- Verify the published/local package path still exposes the intended helpers and docs.
 
 ### Wed-Thu: Binding-Layer Wrapping
 
 Tasks:
 
-- Wrap invocation errors as structured `CapabilityResult.Failure`.
-- Cover failure modes:
+- [x] Wrap invocation errors as structured `CapabilityResult.Failure`.
+- [x] Cover failure modes:
   - wrong arity
   - type mismatch
   - missing required parameter
   - invalid null
   - sync exception
   - async exception
-- Ensure raw exception text is not the default LLM-facing result for recoverable invocation failures.
+- [x] Ensure raw exception text is not the default LLM-facing result for recoverable invocation failures.
+- Re-run focused regression tests after any demo/reference edits.
 
 ### Fri: Chat Surface Recovery Display
 
 Tasks:
 
-- Update chat/tool result rendering to include structured recovery hints.
-- Ensure the LLM receives enough structured information to retry rather than spiral.
-- Keep end-user output clear and not over-technical.
+- [x] Update chat/tool result rendering to include structured recovery hints.
+- [x] Ensure the LLM receives enough structured information to retry rather than spiral.
+- [x] Keep end-user output clear and not over-technical by hiding diagnostics unless execution details are enabled.
+- Verify one demo workflow shows a clear structured-error path without approval/UI noise.
 
 ### Sat-Sun: Integration Testing
 
 Tasks:
 
-- Create an intentionally broken capability/workflow for tests.
-- Verify recovery behaviour end-to-end in the chat surface.
-- Capture screenshots or a short demo recording for later blog/release notes.
+- [x] Runtime adapter regressions cover missing argument, invalid shape, recoverable validation failure, and sanitized unexpected exception.
+- [x] Chat rendering regressions cover structured-error details on/off.
+- Run CleanTest/local-source verification.
+- Capture one short demo/reference artifact only after the workflow is clear.
 
 ### End-Of-Week Gate
 
-- Structured errors branch open.
-- All tests passing.
+- [x] Structured errors branch merged.
+- [x] All merged PR checks passing.
 - Demo workflow updated to show the new pattern as a reference.
 - CleanTest verification works from a local source.
 - Mid-sprint check completed on 2026-05-24.

--- a/tests/AgentBlazor.IntegrationTests/SupportInboxWorkflowIntegrationTests.cs
+++ b/tests/AgentBlazor.IntegrationTests/SupportInboxWorkflowIntegrationTests.cs
@@ -90,4 +90,21 @@ public class SupportInboxWorkflowIntegrationTests
         Assert.Null(workflow.CurrentDraft);
         Assert.Empty(workflow.HighlightedTicketIds);
     }
+
+    [Fact]
+    public async Task ShowOpenTicketsAsync_ReturnsStructuredErrorForInvalidReviewWindow()
+    {
+        var workflow = new SupportInboxWorkflowService();
+        var capabilities = new SupportInboxCapabilities(workflow);
+
+        var result = await capabilities.ShowOpenTicketsAsync(90);
+
+        Assert.False(result.Succeeded);
+        Assert.Equal("invalid_review_window", result.Outputs["errorCode"]);
+        Assert.Equal("days", result.Outputs["parameterName"]);
+        Assert.Equal("an integer from 1 to 30", result.Outputs["expectedShape"]);
+        Assert.Equal(90, result.Outputs["actualValue"]);
+        Assert.Contains(result.NextActions, action => action.Contains("show_open_tickets", StringComparison.OrdinalIgnoreCase));
+        Assert.Empty(workflow.HighlightedTicketIds);
+    }
 }


### PR DESCRIPTION
Updates the v0.2 sprint plan to reflect the current state after the hosted demo and structured-error work landed.\n\nAlso adds a clear support-inbox structured-error reference path: invalid review windows now return a recoverable CapabilityResult with error metadata and retry guidance instead of silently coercing the input.\n\nVerification:\n- dotnet test tests/AgentBlazor.IntegrationTests/AgentBlazor.IntegrationTests.csproj --no-restore\n- git diff --check