### PR TITLE
Fix quickstart chat shell smoke path

### DIFF
--- a/scripts/smoke-test-local-package.ps1
+++ b/scripts/smoke-test-local-package.ps1
@@ -419,7 +419,6 @@ app.Run();
 @using Microsoft.AspNetCore.Components.Web.Virtualization
 @using Microsoft.JSInterop
 @using AgentBlazor.Components
-@using MudBlazor
 @using $ProjectName
 @using $ProjectName.Components
 @using $ProjectName.Components.Layout
@@ -428,32 +427,29 @@ app.Run();
     $mainLayoutContent = @"
 @inherits LayoutComponentBase
 
-<MudThemeProvider />
-<MudPopoverProvider />
-<MudDialogProvider />
-<MudSnackbarProvider />
-
-<div class="page">
-    <div class="sidebar">
-        <NavMenu />
-    </div>
-
-    <main>
-        <div class="top-row px-4">
-            <a href="https://learn.microsoft.com/aspnet/core/" target="_blank">About</a>
+<AgentBlazorShell>
+    <div class="page">
+        <div class="sidebar">
+            <NavMenu />
         </div>
 
-        <article class="content px-4">
-            @Body
-        </article>
-    </main>
-</div>
+        <main>
+            <div class="top-row px-4">
+                <a href="https://learn.microsoft.com/aspnet/core/" target="_blank">About</a>
+            </div>
 
-<div id="blazor-error-ui" data-nosnippet>
-    An unhandled error has occurred.
-    <a href="." class="reload">Reload</a>
-    <span class="dismiss">x</span>
-</div>
+            <article class="content px-4">
+                @Body
+            </article>
+        </main>
+    </div>
+
+    <div id="blazor-error-ui" data-nosnippet>
+        An unhandled error has occurred.
+        <a href="." class="reload">Reload</a>
+        <span class="dismiss">x</span>
+    </div>
+</AgentBlazorShell>
 "@
 
     $homeContent = @"
@@ -464,12 +460,6 @@ app.Run();
 <h1>Package smoke test</h1>
 
 <p>Package restore, host wiring, and chat surface are active.</p>
-
-<AgentChatWidget
-    Title="Assistant"
-    Placeholder="Ask me anything..."
-    Width="28rem"
-    Height="60vh" />
 "@
 
     $serviceInterfaceContent = @"

--- a/src/AgentBlazor.Components/Chat/AgentChatPanel.razor
+++ b/src/AgentBlazor.Components/Chat/AgentChatPanel.razor
@@ -116,7 +116,7 @@
     private string EffectiveDescription =>
         !string.IsNullOrWhiteSpace(Description)
             ? Description
-            : "Register an agent with ConfigureBuilder(builder => builder.AddWorkflow<T>(\"agent-name\")) before expecting the panel to respond.";
+            : "Ask an agent to work with this Blazor app.";
 
     private string _panelStyle
     {

--- a/src/AgentBlazor.Components/Chat/AgentChatWidget.razor
+++ b/src/AgentBlazor.Components/Chat/AgentChatWidget.razor
@@ -180,7 +180,7 @@
     private string EffectiveDescription =>
         !string.IsNullOrWhiteSpace(Description)
             ? Description
-            : "Register an agent with ConfigureBuilder(builder => builder.AddWorkflow<T>(\"agent-name\")) before expecting the widget to respond.";
+            : "Ask an agent to work with this Blazor app.";
 
     private string HostStyle
     {

--- a/src/AgentBlazor.Components/PACKAGE_README.md
+++ b/src/AgentBlazor.Components/PACKAGE_README.md
@@ -52,7 +52,7 @@ app.MapAgentBlazorEndpoints();
 
 `AddAgentBlazor(...)` alone does not create a responding agent. Register at least one workflow or agent inside `options.ConfigureBuilder(...)`.
 
-For the current public preview, mount `AgentChatWidget` directly in an interactive layout or page. The `AgentBlazorShell` child-content/widget fix lands in the next preview.
+Mount `AgentBlazorShell` in an interactive layout or page. It wraps the AgentBlazor providers and includes the floating chat widget.
 
 ```csharp
 [AgentCapability("support_inbox")]
@@ -74,9 +74,9 @@ public sealed class SupportInboxCapabilities
 ```razor
 @using AgentBlazor.Components
 
-<AgentChatWidget
-    Title="Support inbox"
-    Placeholder="Show open tickets, explain the queue, or draft a reply..." />
+<AgentBlazorShell>
+    @Body
+</AgentBlazorShell>
 ```
 
 Docs and demo:

--- a/tests/AgentBlazor.Components.Tests/AgentChatAutomationSelectorTests.cs
+++ b/tests/AgentBlazor.Components.Tests/AgentChatAutomationSelectorTests.cs
@@ -41,6 +41,34 @@ public sealed class AgentChatAutomationSelectorTests : TestContext
     }
 
     [Fact]
+    public void ChatPanel_DefaultDescription_DoesNotShowNoAgentGuidance()
+    {
+        AddChatServices();
+
+        var cut = RenderComponent<AgentChatPanel>(parameters => parameters
+            .Add(static panel => panel.ShowAgentSelector, false)
+            .Add(static panel => panel.DefaultAgentName, "Test Agent"));
+
+        Assert.Contains("Ask an agent to work with this Blazor app.", cut.Markup, StringComparison.Ordinal);
+        Assert.DoesNotContain("Register an agent", cut.Markup, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ChatWidget_DefaultDescription_DoesNotShowNoAgentGuidance()
+    {
+        AddChatServices();
+
+        var cut = RenderComponent<AgentChatWidget>(parameters => parameters
+            .Add(static widget => widget.ShowAgentSelector, false)
+            .Add(static widget => widget.DefaultAgentName, "Test Agent"));
+
+        cut.Find("button.ab-chat-widget__bubble").Click();
+
+        Assert.Contains("Ask an agent to work with this Blazor app.", cut.Markup, StringComparison.Ordinal);
+        Assert.DoesNotContain("Register an agent", cut.Markup, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void ChatBar_RendersStableAutomationSelectorsAndAccessibleControls()
     {
         AddChatServices();


### PR DESCRIPTION
## Summary
- update the local package smoke script to mount AgentBlazorShell instead of page-local Mud providers plus AgentChatWidget
- replace misleading default widget/panel no-agent copy with neutral copy when an agent is registered
- update the package README to document AgentBlazorShell as the current mount path
- add component tests covering the default widget/panel description

## Verification
- dotnet test tests/AgentBlazor.Components.Tests/AgentBlazor.Components.Tests.csproj --no-restore -v minimal
- manually repacked local 0.1.0-preview.11 packages, restored a fresh Blazor app from an isolated local feed, built it, ran it, and verified / renders AgentBlazorShell/AgentChatWidget with the hello workflow selected and without the stale registration warning

## Notes
- pwsh is not installed in this environment, so I could not execute scripts/smoke-test-local-package.ps1 directly. I ran the equivalent steps manually from bash.