### PR TITLE
Update sprint status after CleanTest verification

### DIFF
--- a/docs/internal/v0.2-sprint-plan-2026-05-11.md
+++ b/docs/internal/v0.2-sprint-plan-2026-05-11.md
@@ -16,6 +16,7 @@ Week 1 commitment debt is closed ahead of the original end-of-week gate:
 - Demo endpoint rate limiting is enabled.
 - Demo daily cost guard is enabled with a default `$2.00` estimated-cost cap.
 - Azure Container App scale is pinned to one replica so file-backed logs are consistent.
+- CleanTest/local-source verification passed with `AgentBlazorShell` as the documented mount path.
 - Issue #2 is closed with deployment evidence.
 - Issue #8 is closed after structured-error design, implementation, chat rendering, and runtime adapter regression coverage landed.
 
@@ -252,7 +253,7 @@ Tasks:
 
 - [x] Runtime adapter regressions cover missing argument, invalid shape, recoverable validation failure, and sanitized unexpected exception.
 - [x] Chat rendering regressions cover structured-error details on/off.
-- Run CleanTest/local-source verification.
+- [x] Run CleanTest/local-source verification.
 - Capture one short demo/reference artifact only after the workflow is clear.
 
 ### End-Of-Week Gate


### PR DESCRIPTION
## Summary
- mark CleanTest/local-source verification complete in the v0.2 sprint plan
- record that verification covered AgentBlazorShell as the documented mount path

## Verification
- documentation-only change
- live token/cost logging verified against demo.agentblazor.com before this update