### PR TITLE
Add structured error runtime probe reference

### DIFF
--- a/demo/AgentBlazor.Demo/Components/Pages/Demo/RuntimeProbeWorkflow.razor
+++ b/demo/AgentBlazor.Demo/Components/Pages/Demo/RuntimeProbeWorkflow.razor
@@ -8,11 +8,19 @@
         <p class="wf-shell__eyebrow">Runtime test</p>
         <h1>Runtime probe</h1>
         <p>
-            Use this page to test cancel, approve, and reconnect behavior.
+            Use this page to test cancel, approve, reconnect, and structured error recovery behavior.
         </p>
     </header>
 
     <div class="wf-shell__grid">
+        <article class="wf-card wf-card--reference">
+            <h2>Structured error recovery</h2>
+            <ol class="wf-list">
+                <li>Send: <code>run the structured error date range probe from 2026-05-10 to 2026-05-01</code></li>
+                <li>Confirm the action returns <code>invalid_date_range</code>, not a raw exception.</li>
+                <li>Confirm the recovery hint says to retry with an end date on or after the start date.</li>
+            </ol>
+        </article>
         <article class="wf-card">
             <h2>Cancel run</h2>
             <ol class="wf-list">
@@ -52,6 +60,11 @@
         border-radius: 1rem;
         padding: 1.25rem;
         background: rgba(8, 20, 32, 0.72);
+    }
+
+    .wf-card--reference {
+        border-color: rgba(99, 232, 181, 0.42);
+        background: linear-gradient(135deg, rgba(11, 73, 58, 0.78), rgba(8, 20, 32, 0.72));
     }
 
     .wf-shell__eyebrow {

--- a/demo/AgentBlazor.Demo/Services/DemoScenarioCatalog.cs
+++ b/demo/AgentBlazor.Demo/Services/DemoScenarioCatalog.cs
@@ -212,18 +212,20 @@ internal static class DemoScenarioCatalog
             "runtime-probe",
             DemoScenarioScale.Advanced,
             "Runtime probe",
-            "A narrow runtime behavior probe for cancellation and long-running action handling.",
+            "A narrow runtime behavior probe for structured errors, cancellation, and long-running action handling.",
             "/demo/workflows/runtime-probe",
             "Open runtime probe",
             "Runtime probe assistant",
-            "Run the cancellation probe, then stop it.",
-            "Run the runtime cancellation probe, then stop.",
+            "Run a structured error probe, then inspect the recovery hint.",
+            "Run the structured error date range probe from 2026-05-10 to 2026-05-01.",
             "Runtime Probe Agent",
             [
+                "Run the structured error date range probe from 2026-05-10 to 2026-05-01",
                 "Run the runtime cancellation probe",
                 "Stop the probe"
             ],
             [
+                "Structured errors",
                 "Runtime behavior",
                 "Cancellation",
                 "Long-running action visibility"

--- a/demo/AgentBlazor.Demo/Services/RuntimeProbeCapabilities.cs
+++ b/demo/AgentBlazor.Demo/Services/RuntimeProbeCapabilities.cs
@@ -32,4 +32,27 @@ public sealed class RuntimeProbeCapabilities
         return CapabilityResult.Success("Runtime reconnect probe completed.")
             .WithOutput("probe", "RECONNECTED");
     }
+
+    [AgentAction("Run the structured error date range probe", ActionId = "run_structured_error_date_range_probe")]
+    public Task<CapabilityResult> RunStructuredErrorDateRangeProbeAsync(DateOnly startDate, DateOnly endDate)
+    {
+        if (endDate < startDate)
+        {
+            return Task.FromResult(
+                CapabilityResult
+                    .InvalidArguments("The end date must be on or after the start date.")
+                    .WithOutput("errorCode", "invalid_date_range")
+                    .WithOutput("expectedShape", new { startDate = "yyyy-mm-dd", endDate = "yyyy-mm-dd" })
+                    .WithOutput("startDate", startDate)
+                    .WithOutput("endDate", endDate)
+                    .WithNextAction("Retry with an endDate that is on or after startDate."));
+        }
+
+        return Task.FromResult(
+            CapabilityResult
+                .Success($"Structured error probe accepted the date range from {startDate:yyyy-MM-dd} to {endDate:yyyy-MM-dd}.")
+                .WithOutput("probe", "STRUCTURED_ERROR_DATE_RANGE_OK")
+                .WithOutput("startDate", startDate)
+                .WithOutput("endDate", endDate));
+    }
 }

--- a/docs/internal/v0.2-sprint-plan-2026-05-11.md
+++ b/docs/internal/v0.2-sprint-plan-2026-05-11.md
@@ -260,7 +260,7 @@ Tasks:
 
 - [x] Structured errors branch merged.
 - [x] All merged PR checks passing.
-- Demo workflow updated to show the new pattern as a reference.
+- [x] Demo workflow updated to show the new pattern as a reference.
 - CleanTest verification works from a local source.
 - Mid-sprint check completed on 2026-05-24.
 

--- a/tests/AgentBlazor.IntegrationTests/RuntimeProbeWorkflowIntegrationTests.cs
+++ b/tests/AgentBlazor.IntegrationTests/RuntimeProbeWorkflowIntegrationTests.cs
@@ -1,0 +1,39 @@
+using AgentBlazor.Demo.Services;
+
+namespace AgentBlazor.IntegrationTests;
+
+public class RuntimeProbeWorkflowIntegrationTests
+{
+    [Fact]
+    public async Task StructuredErrorDateRangeProbe_ReturnsRecoverableInvalidDateRange()
+    {
+        var capabilities = new RuntimeProbeCapabilities();
+
+        var result = await capabilities.RunStructuredErrorDateRangeProbeAsync(
+            new DateOnly(2026, 5, 10),
+            new DateOnly(2026, 5, 1));
+
+        Assert.False(result.Succeeded);
+        Assert.False(result.RequiresClarification);
+        Assert.Contains("end date must be on or after the start date", result.Summary, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal("invalid_date_range", result.Outputs["errorCode"]);
+        Assert.Equal(new DateOnly(2026, 5, 10), result.Outputs["startDate"]);
+        Assert.Equal(new DateOnly(2026, 5, 1), result.Outputs["endDate"]);
+        Assert.Contains(result.NextActions, action => action.Contains("Retry with an endDate", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task StructuredErrorDateRangeProbe_ReturnsSuccessForValidRange()
+    {
+        var capabilities = new RuntimeProbeCapabilities();
+
+        var result = await capabilities.RunStructuredErrorDateRangeProbeAsync(
+            new DateOnly(2026, 5, 1),
+            new DateOnly(2026, 5, 10));
+
+        Assert.True(result.Succeeded);
+        Assert.Equal("STRUCTURED_ERROR_DATE_RANGE_OK", result.Outputs["probe"]);
+        Assert.Equal(new DateOnly(2026, 5, 1), result.Outputs["startDate"]);
+        Assert.Equal(new DateOnly(2026, 5, 10), result.Outputs["endDate"]);
+    }
+}

--- a/tests/e2e/specs/workflows-and-paid.spec.cjs
+++ b/tests/e2e/specs/workflows-and-paid.spec.cjs
@@ -54,7 +54,7 @@ const workflowScenarios = [
     name: "runtime probe",
     route: "/demo/workflows/runtime-probe",
     heading: /Runtime probe/i,
-    marker: "run the runtime cancellation probe"
+    marker: "run the structured error date range probe"
   }
 ];
 


### PR DESCRIPTION
## Summary
- add a runtime-probe capability that returns a structured invalid date range error with outputs and recovery hint
- make the runtime-probe page and scenario prompt lead with the structured-error reference path
- update e2e marker coverage and add integration tests for invalid/valid date-range probe behavior
- mark the sprint demo-reference task complete

## Verification
- dotnet test tests/AgentBlazor.IntegrationTests/AgentBlazor.IntegrationTests.csproj --no-restore --filter "RuntimeProbeWorkflowIntegrationTests|DemoTrafficRouteFilterTests" -v minimal
- dotnet build demo/AgentBlazor.Demo/AgentBlazor.Demo.csproj --no-restore -v minimal
- local browser smoke against http://127.0.0.1:5299/demo/workflows/runtime-probe verified the structured-error marker, invalid_date_range marker, and interactive assistant surface