### PR TITLE
Verify structured error docs and package links

### DIFF
--- a/docs/capability-errors.md
+++ b/docs/capability-errors.md
@@ -75,13 +75,15 @@ Unexpected exceptions are treated as terse failures by the runtime. Do not rely 
 
 ## Demo Reference
 
-The hosted support-inbox demo includes a simple structured-error path without approval noise:
+The hosted runtime-probe demo includes a simple structured-error path without approval or generated-UI noise:
 
 ```text
-Show open tickets from the last 90 days
+Run the structured error date range probe
 ```
 
-The `show_open_tickets` capability rejects review windows outside 1-30 days with `errorCode=invalid_review_window`, `parameterName=days`, `expectedShape=an integer from 1 to 30`, and a `NextActions` retry hint. This is the reference pattern for validation that the model can repair without asking the user a new question.
+The reflection registry rejects the call before invoking the method because the required `startDate` parameter is missing. The chat receives a structured `missing_argument` result with `parameterName=startDate`, an `expectedShape`, a clarification question, and a `NextActions` recovery hint. This is the reference pattern for binding-layer failures that should be recoverable by the model or clarified with the user instead of surfacing raw exception text.
+
+For in-method validation, the same runtime-probe capability returns `errorCode=invalid_date_range` when `endDate` is earlier than `startDate`. Use that shape when your method body can validate supplied arguments but the requested operation is not valid.
 
 ## Runtime Wrapping
 

--- a/docs/internal/v0.2-sprint-plan-2026-05-11.md
+++ b/docs/internal/v0.2-sprint-plan-2026-05-11.md
@@ -221,7 +221,7 @@ Tasks:
 
 - [x] Implement typed result variants for recoverable failures.
 - [x] Unit tests for each variant/helper.
-- Verify the published/local package path still exposes the intended helpers and docs.
+- [x] Verify the published/local package path still exposes the intended helpers and docs.
 
 ### Wed-Thu: Binding-Layer Wrapping
 
@@ -236,7 +236,7 @@ Tasks:
   - sync exception
   - async exception
 - [x] Ensure raw exception text is not the default LLM-facing result for recoverable invocation failures.
-- Re-run focused regression tests after any demo/reference edits.
+- [x] Re-run focused regression tests after any demo/reference edits.
 
 ### Fri: Chat Surface Recovery Display
 

--- a/src/AgentBlazor.Components/PACKAGE_README.md
+++ b/src/AgentBlazor.Components/PACKAGE_README.md
@@ -83,5 +83,7 @@ Docs and demo:
 
 - Repository: https://github.com/ashpeterson/AgentBlazor
 - Hosted demo: https://demo.agentblazor.com/demo/workflows/support-inbox
+- Structured error reference: https://demo.agentblazor.com/demo/workflows/runtime-probe
 - Quickstart: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/quickstart.md
+- Recoverable capability errors: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/capability-errors.md
 - Starter sample: https://github.com/ashpeterson/AgentBlazor/tree/master/samples/AgentBlazor.Starter


### PR DESCRIPTION
## Summary
- update recoverable capability error docs to use the live runtime-probe structured-error reference
- add structured-error docs/demo links to the NuGet package README
- mark package-doc and focused-regression sprint tasks complete

## Verification
- `dotnet test tests/AgentBlazor.Core.Tests/AgentBlazor.Core.Tests.csproj --no-restore --filter "AgentCapabilityRegistryTests|RuntimeAdapterCapabilityProjectionTests|ServiceRegistrationTests.CapabilityResult_HelperMethods_MergeStructuredOutcomeData" -v minimal`
- `dotnet test tests/AgentBlazor.Components.Tests/AgentBlazor.Components.Tests.csproj --no-restore --filter "AgentChatSurfaceTests" -v minimal`
- `dotnet test tests/AgentBlazor.IntegrationTests/AgentBlazor.IntegrationTests.csproj --no-restore --filter "RuntimeProbeWorkflowIntegrationTests|SupportInboxWorkflowIntegrationTests|DemoChatRequestLoggingMiddlewareTests" -v minimal`
- `dotnet pack src/AgentBlazor.Components/AgentBlazor.Components.csproj -c Release -o .tmp/structured-error-pack -p:PackageVersion=0.1.0-preview.regression --no-restore -v minimal`
- inspected packaged `PACKAGE_README.md` from the generated `.nupkg`

## Notes
- Existing warning remains: `OpenTelemetry.Api` 1.13.1 has NU1902 moderate severity advisory.
