### PR TITLE
Mark structured error demo verification complete

### DIFF
--- a/docs/internal/v0.2-sprint-plan-2026-05-11.md
+++ b/docs/internal/v0.2-sprint-plan-2026-05-11.md
@@ -245,7 +245,7 @@ Tasks:
 - [x] Update chat/tool result rendering to include structured recovery hints.
 - [x] Ensure the LLM receives enough structured information to retry rather than spiral.
 - [x] Keep end-user output clear and not over-technical by hiding diagnostics unless execution details are enabled.
-- Verify one demo workflow shows a clear structured-error path without approval/UI noise.
+- [x] Verify one demo workflow shows a clear structured-error path without approval/UI noise.
 
 ### Sat-Sun: Integration Testing
 


### PR DESCRIPTION
## Summary
- marks the Week 2 structured-error demo verification item complete after the hosted runtime-probe recorder passed
- evidence artifact was generated locally under artifacts/video/structured-error-reference-live-20260514 and remains uncommitted

## Verification
- node scripts/video/record-structured-error-reference.cjs artifacts/video/structured-error-reference-live-20260514

Transcript confirmed the runtime-probe route returns a clean missing startDate clarification without approval or generated-UI noise.