### PR TITLE
Record broad structured error regression pass

### DIFF
--- a/docs/internal/v0.2-sprint-plan-2026-05-11.md
+++ b/docs/internal/v0.2-sprint-plan-2026-05-11.md
@@ -4,7 +4,7 @@ Created: 2026-05-12
 Sprint window: 2026-05-11 to 2026-06-09  
 Ship target: 0.2.0 by 2026-06-07, promotional post on 2026-06-09
 
-## Current Status: 2026-05-13
+## Current Status: 2026-05-14
 
 Week 1 commitment debt is closed ahead of the original end-of-week gate:
 
@@ -19,6 +19,8 @@ Week 1 commitment debt is closed ahead of the original end-of-week gate:
 - CleanTest/local-source verification passed with `AgentBlazorShell` as the documented mount path.
 - Issue #2 is closed with deployment evidence.
 - Issue #8 is closed after structured-error design, implementation, chat rendering, and runtime adapter regression coverage landed.
+- Hosted runtime-probe verification passed on 2026-05-14 and captured a clean `missing_argument` transcript without approval or generated-UI noise.
+- Broad local regression on `origin/master` passed on 2026-05-14 with `dotnet test AgentBlazor.slnx --no-restore -v minimal` (`280` core, `154` integration, `119` component tests passed; `1` known component test skipped).
 
 Week 2 is no longer an implementation-from-zero week. Treat it as hardening, documentation, CleanTest/package verification, and demo-reference cleanup. Do not start issue #1 entity exposure before the 2026-05-24 check-in unless structured errors remain stable after the verification pass.
 


### PR DESCRIPTION
## Summary
- updates the v0.2 sprint status with the 2026-05-14 hosted runtime-probe verification
- records the broad local solution regression pass from origin/master

## Verification
- node scripts/video/record-structured-error-reference.cjs artifacts/video/structured-error-reference-live-20260514
- dotnet test AgentBlazor.slnx --no-restore -v minimal

Note: the existing OpenTelemetry.Api NU1902 moderate-severity warning remains.