### PR TITLE
Simplify public demo launchpad

### DIFF
--- a/demo/AgentBlazor.Demo/Components/Pages/Demo/DemoHome.razor
+++ b/demo/AgentBlazor.Demo/Components/Pages/Demo/DemoHome.razor
@@ -11,7 +11,7 @@
             <MudChip T="string" Color="Color.Primary" Variant="Variant.Filled" Size="Size.Small">Live demo</MudChip>
             <MudText Typo="Typo.h4" Class="mt-4 mb-2">Pick the workflow size you want to see.</MudText>
             <MudText Typo="Typo.body2" Color="Color.Secondary">
-                Start small with one support reply, scale the same route into blockers and handoff, or open the advanced multi-surface flows.
+                Start small with one support reply, then scale the same route into blockers, escalation, and handoff.
             </MudText>
         </div>
 

--- a/demo/AgentBlazor.Demo/Services/DemoScenarioCatalog.cs
+++ b/demo/AgentBlazor.Demo/Services/DemoScenarioCatalog.cs
@@ -90,7 +90,10 @@ internal static class DemoScenarioCatalog
                 "Multiple workflow surfaces",
                 "Guided recovery",
                 "Cross-page packet preparation"
-            ]),
+            ])
+        {
+            ShowOnLaunchpad = false
+        },
         new(
             "release-dossier",
             DemoScenarioScale.Advanced,
@@ -111,7 +114,10 @@ internal static class DemoScenarioCatalog
                 "Recipe readiness",
                 "Evidence bundle checks",
                 "Release approval package"
-            ]),
+            ])
+        {
+            ShowOnLaunchpad = false
+        },
         new(
             "supplier-compliance",
             DemoScenarioScale.Advanced,

--- a/tests/e2e/specs/home.spec.cjs
+++ b/tests/e2e/specs/home.spec.cjs
@@ -26,6 +26,8 @@ test.describe("Landing page", () => {
     await expect(page).toHaveURL(/\/demo$/);
     await expect(page.getByRole("heading", { name: /pick the workflow size you want to see/i }).first()).toBeVisible();
     await expect(page.getByRole("heading", { name: "Quick: draft one safe reply" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Advanced: response orchestration" })).toHaveCount(0);
+    await expect(page.getByRole("heading", { name: "Advanced: release dossier" })).toHaveCount(0);
 
     await page.getByRole("link", { name: "Start with quick demo" }).click();
     await expect(page).toHaveURL(/\/demo\/workflows\/support-inbox/);


### PR DESCRIPTION
## Summary
- hides the abstract response-orchestration and release-dossier flows from the public /demo launchpad
- keeps their direct routes and tests intact for advanced/internal validation
- updates launchpad copy to focus the public demo on support workflow scaling
- adds an e2e assertion so the abstract cards do not return to the launchpad accidentally

## Verification
- dotnet build demo/AgentBlazor.Demo/AgentBlazor.Demo.csproj -c Release -p:RuntimeIdentifier=linux-x64 --no-restore -v minimal
- cd tests/e2e && npx playwright test specs/home.spec.cjs --config=playwright.config.cjs

Note: existing OpenTelemetry.Api NU1902 warning remains.