### PR TITLE
Add schema-only EF entity exposure

### DIFF
--- a/.github/workflows/publish-nuget-org.yml
+++ b/.github/workflows/publish-nuget-org.yml
@@ -122,6 +122,15 @@ jobs:
           --skip-duplicate
           --timeout 120
 
+      - name: Publish Entity Framework Core package to nuget.org
+        run: >
+          dotnet nuget push
+          "src/AgentBlazor.EntityFrameworkCore/bin/Release/AgentBlazor.EntityFrameworkCore.${{ inputs.package_version }}.nupkg"
+          --source "https://api.nuget.org/v3/index.json"
+          --api-key "${{ secrets.NUGET_API_KEY }}"
+          --skip-duplicate
+          --timeout 120
+
       - name: Publish CLI tool package to nuget.org
         run: >
           dotnet nuget push
@@ -148,6 +157,7 @@ jobs:
             src/AgentBlazor.Components/bin/Release/AgentBlazor.${{ inputs.package_version }}.nupkg
             src/AgentBlazor.Client/bin/Release/AgentBlazor.Client.${{ inputs.package_version }}.nupkg
             src/AgentBlazor.Client/bin/Release/AgentBlazor.Client.${{ inputs.package_version }}.snupkg
+            src/AgentBlazor.EntityFrameworkCore/bin/Release/AgentBlazor.EntityFrameworkCore.${{ inputs.package_version }}.nupkg
             src/AgentBlazor.Cli/bin/Release/AgentBlazor.Cli.${{ inputs.package_version }}.nupkg
             src/AgentBlazor.Cli/bin/Release/AgentBlazor.Cli.${{ inputs.package_version }}.snupkg
           if-no-files-found: error

--- a/AgentBlazor.sln
+++ b/AgentBlazor.sln
@@ -27,6 +27,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AgentBlazor.Core", "src\Age
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AgentBlazor.Components", "src\AgentBlazor.Components\AgentBlazor.Components.csproj", "{C630BAFA-6ABF-EDAF-C4B1-35F4BD0BE377}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AgentBlazor.EntityFrameworkCore", "src\AgentBlazor.EntityFrameworkCore\AgentBlazor.EntityFrameworkCore.csproj", "{4213AC9D-E315-42CF-BD4B-D2BBDBE4E2F5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -69,6 +71,10 @@ Global
 		{C630BAFA-6ABF-EDAF-C4B1-35F4BD0BE377}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C630BAFA-6ABF-EDAF-C4B1-35F4BD0BE377}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C630BAFA-6ABF-EDAF-C4B1-35F4BD0BE377}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4213AC9D-E315-42CF-BD4B-D2BBDBE4E2F5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4213AC9D-E315-42CF-BD4B-D2BBDBE4E2F5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4213AC9D-E315-42CF-BD4B-D2BBDBE4E2F5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4213AC9D-E315-42CF-BD4B-D2BBDBE4E2F5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -83,6 +89,7 @@ Global
 		{0B18F255-E9E8-69CB-9686-2CBC6BE4736C} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{3984386D-9C63-4E50-F8DC-F53D30F1EBB8} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{C630BAFA-6ABF-EDAF-C4B1-35F4BD0BE377} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{4213AC9D-E315-42CF-BD4B-D2BBDBE4E2F5} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {17D0A3CF-1A01-4804-83AA-0BD1DD152EC2}

--- a/AgentBlazor.slnx
+++ b/AgentBlazor.slnx
@@ -11,6 +11,7 @@
     <Project Path="src/AgentBlazor.Cli.Analysis/AgentBlazor.Cli.Analysis.csproj" />
     <Project Path="src/AgentBlazor.Components/AgentBlazor.Components.csproj" />
     <Project Path="src/AgentBlazor.Core/AgentBlazor.Core.csproj" />
+    <Project Path="src/AgentBlazor.EntityFrameworkCore/AgentBlazor.EntityFrameworkCore.csproj" />
     <Project Path="src/AgentBlazor.Hosting/AgentBlazor.Hosting.csproj" />
     <Project Path="src/AgentBlazor.Licensing/AgentBlazor.Licensing.csproj" />
     <Project Path="src/AgentBlazor.ProviderAdapters/AgentBlazor.ProviderAdapters.csproj" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,7 +14,7 @@
     <PackageVersion Include="Microsoft.Agents.AI.Hosting.AGUI.AspNetCore" Version="[1.1.0-preview.260410.1]" />
     <PackageVersion Include="Microsoft.Agents.AI.OpenAI" Version="[1.1.0]" />
     <PackageVersion Include="Microsoft.Agents.AI.Workflows" Version="[1.1.0]" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.4" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.4" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.3" />

--- a/demo/AgentBlazor.Demo/Program.cs
+++ b/demo/AgentBlazor.Demo/Program.cs
@@ -3,6 +3,7 @@ using AgentBlazor.Demo.Configuration;
 using AgentBlazor.Demo.Components;
 using AgentBlazor.Demo.Data;
 using AgentBlazor.Demo.Services;
+using AgentBlazor.Core.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.Extensions.Logging;
@@ -174,6 +175,32 @@ builder.Services.AddAgentBlazor(options =>
     {
         agentBuilder.EnablePromptTracing();
 
+        agentBuilder.AddDataSchema(new AgentDataSchemaSet
+        {
+            Name = "support-data",
+            Description = "Read-safe support ticket fields used by the support inbox workflow. This is planning context only; ticket reads and drafts still go through typed workflow actions.",
+            Entities =
+            [
+                new AgentEntitySchema
+                {
+                    Name = "support_tickets",
+                    Description = "Support tickets visible in the demo queue.",
+                    ClrTypeName = typeof(SupportTicketRow).FullName,
+                    Properties =
+                    [
+                        new AgentEntityPropertySchema { Name = "Id", Type = "string", IsKey = true, Description = "Ticket identifier such as TCK-1042." },
+                        new AgentEntityPropertySchema { Name = "Subject", Type = "string", Description = "Customer-visible ticket subject." },
+                        new AgentEntityPropertySchema { Name = "Team", Type = "string", Description = "Owning support team." },
+                        new AgentEntityPropertySchema { Name = "Priority", Type = "string", Description = "Priority label such as High or Medium." },
+                        new AgentEntityPropertySchema { Name = "AgeDays", Type = "integer", Description = "Age of the ticket in days." },
+                        new AgentEntityPropertySchema { Name = "WaitingOnReply", Type = "boolean", Description = "Whether the customer is waiting on a support reply." },
+                        new AgentEntityPropertySchema { Name = "EscalationRisk", Type = "boolean", Description = "Whether the ticket is at risk of escalation." },
+                        new AgentEntityPropertySchema { Name = "MissingEvidence", Type = "boolean", Description = "Whether draft preparation is blocked by missing evidence." }
+                    ]
+                }
+            ]
+        });
+
         agentBuilder.AddAgent("Workflow Hub Agent", agent =>
         {
             agent.WithDescription("Focused on routing users toward the right semantic workflow showcase and explaining the workflow-first product story.");
@@ -224,6 +251,7 @@ builder.Services.AddAgentBlazor(options =>
                 agent.WithInstructions(sharedAgentInstructions);
             }
             agent.WithAllowedComponents("AgentDataGrid", "AgentDialog");
+            agent.WithDataSchemas("support-data");
             agent.WithRoutePrefixes("/demo/workflows/support-inbox");
         });
 

--- a/scripts/smoke-test-local-package.ps1
+++ b/scripts/smoke-test-local-package.ps1
@@ -60,6 +60,11 @@ $packageDefinitions = @(
         OutputDir = Join-Path $repoRoot "src\AgentBlazor.Client\bin\Release"
     },
     @{
+        Id = "AgentBlazor.EntityFrameworkCore"
+        Project = Join-Path $repoRoot "src\AgentBlazor.EntityFrameworkCore\AgentBlazor.EntityFrameworkCore.csproj"
+        OutputDir = Join-Path $repoRoot "src\AgentBlazor.EntityFrameworkCore\bin\Release"
+    },
+    @{
         Id = "AgentBlazor.Cli"
         Project = Join-Path $repoRoot "src\AgentBlazor.Cli\AgentBlazor.Cli.csproj"
         OutputDir = Join-Path $repoRoot "src\AgentBlazor.Cli\bin\Release"
@@ -134,6 +139,7 @@ function Clear-LocalPackageCache {
         "agentblazor",
         "agentblazor.core",
         "agentblazor.hosting",
+        "agentblazor.entityframeworkcore",
         "agentblazor.licensing",
         "agentblazor.provideradapters",
         "agentblazor.cli"

--- a/src/AgentBlazor.Core/Agents/AgentRegistration.cs
+++ b/src/AgentBlazor.Core/Agents/AgentRegistration.cs
@@ -19,6 +19,9 @@ public sealed class AgentRegistration
 
     public IReadOnlyList<string> ToolAssemblyNames { get; init; } = Array.Empty<string>();
 
+    public IReadOnlySet<string> AllowedDataSchemas { get; init; } =
+        new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
     public IReadOnlyDictionary<string, string> Metadata { get; init; } =
         new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 }

--- a/src/AgentBlazor.Core/Agents/AgentRegistrationBuilder.cs
+++ b/src/AgentBlazor.Core/Agents/AgentRegistrationBuilder.cs
@@ -7,6 +7,7 @@ public sealed class AgentRegistrationBuilder
     private readonly HashSet<string> _allowedComponents = new(StringComparer.OrdinalIgnoreCase);
     private readonly HashSet<string> _allowedActions = new(StringComparer.OrdinalIgnoreCase);
     private readonly HashSet<string> _allowedCapabilityActions = new(StringComparer.OrdinalIgnoreCase);
+    private readonly HashSet<string> _allowedDataSchemas = new(StringComparer.OrdinalIgnoreCase);
     private readonly HashSet<string> _toolAssemblyNames = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, string> _metadata = new(StringComparer.OrdinalIgnoreCase);
 
@@ -95,6 +96,16 @@ public sealed class AgentRegistrationBuilder
         return this;
     }
 
+    public AgentRegistrationBuilder WithDataSchemas(params string[] schemaNames)
+    {
+        foreach (var schemaName in schemaNames.Where(static name => !string.IsNullOrWhiteSpace(name)))
+        {
+            _allowedDataSchemas.Add(schemaName.Trim());
+        }
+
+        return this;
+    }
+
     public AgentRegistrationBuilder WithMetadata(string key, string value)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(key);
@@ -136,6 +147,7 @@ public sealed class AgentRegistrationBuilder
         AllowedActions = new HashSet<string>(_allowedActions, StringComparer.OrdinalIgnoreCase),
         AllowedCapabilityActions = new HashSet<string>(_allowedCapabilityActions, StringComparer.OrdinalIgnoreCase),
         ToolAssemblyNames = _toolAssemblyNames.ToArray(),
+        AllowedDataSchemas = new HashSet<string>(_allowedDataSchemas, StringComparer.OrdinalIgnoreCase),
         Metadata = new Dictionary<string, string>(_metadata, StringComparer.OrdinalIgnoreCase)
     };
 

--- a/src/AgentBlazor.Core/Data/AgentDataSchema.cs
+++ b/src/AgentBlazor.Core/Data/AgentDataSchema.cs
@@ -1,0 +1,34 @@
+namespace AgentBlazor.Core.Data;
+
+public sealed record AgentDataSchemaSet
+{
+    public required string Name { get; init; }
+
+    public string? Description { get; init; }
+
+    public IReadOnlyList<AgentEntitySchema> Entities { get; init; } = [];
+}
+
+public sealed record AgentEntitySchema
+{
+    public required string Name { get; init; }
+
+    public string? ClrTypeName { get; init; }
+
+    public string? Description { get; init; }
+
+    public IReadOnlyList<AgentEntityPropertySchema> Properties { get; init; } = [];
+}
+
+public sealed record AgentEntityPropertySchema
+{
+    public required string Name { get; init; }
+
+    public required string Type { get; init; }
+
+    public bool IsNullable { get; init; }
+
+    public bool IsKey { get; init; }
+
+    public string? Description { get; init; }
+}

--- a/src/AgentBlazor.Core/Data/IAgentDataSchemaCatalog.cs
+++ b/src/AgentBlazor.Core/Data/IAgentDataSchemaCatalog.cs
@@ -1,0 +1,10 @@
+namespace AgentBlazor.Core.Data;
+
+public interface IAgentDataSchemaCatalog
+{
+    IReadOnlyList<AgentDataSchemaSet> GetAll();
+
+    IReadOnlyList<AgentDataSchemaSet> GetAllowed(IEnumerable<string> schemaNames);
+
+    bool TryGet(string name, out AgentDataSchemaSet schemaSet);
+}

--- a/src/AgentBlazor.Core/Data/InMemoryAgentDataSchemaCatalog.cs
+++ b/src/AgentBlazor.Core/Data/InMemoryAgentDataSchemaCatalog.cs
@@ -1,0 +1,48 @@
+namespace AgentBlazor.Core.Data;
+
+public sealed class InMemoryAgentDataSchemaCatalog : IAgentDataSchemaCatalog
+{
+    private readonly Dictionary<string, AgentDataSchemaSet> _schemas = new(StringComparer.OrdinalIgnoreCase);
+
+    public InMemoryAgentDataSchemaCatalog(IEnumerable<AgentDataSchemaSet>? schemas = null)
+    {
+        foreach (var schema in schemas ?? [])
+        {
+            AddOrUpdate(schema);
+        }
+    }
+
+    public void AddOrUpdate(AgentDataSchemaSet schemaSet)
+    {
+        ArgumentNullException.ThrowIfNull(schemaSet);
+        ArgumentException.ThrowIfNullOrWhiteSpace(schemaSet.Name);
+
+        _schemas[schemaSet.Name] = schemaSet;
+    }
+
+    public IReadOnlyList<AgentDataSchemaSet> GetAll() => [.. _schemas.Values];
+
+    public IReadOnlyList<AgentDataSchemaSet> GetAllowed(IEnumerable<string> schemaNames)
+    {
+        ArgumentNullException.ThrowIfNull(schemaNames);
+
+        var allowed = new List<AgentDataSchemaSet>();
+        foreach (var name in schemaNames)
+        {
+            if (!string.IsNullOrWhiteSpace(name) && _schemas.TryGetValue(name, out var schema))
+            {
+                allowed.Add(schema);
+            }
+        }
+
+        return allowed;
+    }
+
+    public bool TryGet(string name, out AgentDataSchemaSet schemaSet)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+#pragma warning disable CS8601
+        return _schemas.TryGetValue(name, out schemaSet);
+#pragma warning restore CS8601
+    }
+}

--- a/src/AgentBlazor.Core/Runtime/Adapters/ChatClientRuntimeAdapter.cs
+++ b/src/AgentBlazor.Core/Runtime/Adapters/ChatClientRuntimeAdapter.cs
@@ -9,6 +9,7 @@ using AgentBlazor.Agents;
 using AgentBlazor.App;
 using AgentBlazor.Components;
 using AgentBlazor.Core.Components;
+using AgentBlazor.Core.Data;
 using AgentBlazor.Core.Runtime;
 using AgentBlazor.Core.Runtime.Agents;
 using AgentBlazor.Core.Runtime.Components;
@@ -47,6 +48,7 @@ public sealed class ChatClientRuntimeAdapter(
     IActionHistoryStore? actionHistoryStore = null,
     IAgentSharedStateStore? sharedStateStore = null,
     IAgentServiceToolRegistry? serviceToolRegistry = null,
+    IAgentDataSchemaCatalog? dataSchemaCatalog = null,
     IEnumerable<IMcpToolProvider>? mcpToolProviders = null,
     IAgentBlazorEntitlementService? entitlementService = null,
     IOptions<PromptTracingOptions>? promptTracingOptions = null,
@@ -77,6 +79,7 @@ public sealed class ChatClientRuntimeAdapter(
     private readonly IActionHistoryStore? _actionHistoryStore = actionHistoryStore;
     private readonly IAgentSharedStateStore? _sharedStateStore = sharedStateStore;
     private readonly IAgentServiceToolRegistry? _serviceToolRegistry = serviceToolRegistry;
+    private readonly IAgentDataSchemaCatalog? _dataSchemaCatalog = dataSchemaCatalog;
     private readonly IEnumerable<IMcpToolProvider>? _mcpToolProviders = mcpToolProviders;
     private readonly IAgentBlazorEntitlementService? _entitlementService = entitlementService;
     private readonly IOptions<PromptTracingOptions>? _promptTracingOptions = promptTracingOptions;
@@ -2034,12 +2037,86 @@ public sealed class ChatClientRuntimeAdapter(
 
     private string? ResolveInstructions(AgentRegistration registration)
     {
+        var dataSchemaInstructions = BuildDataSchemaInstructions(registration);
+        if (!string.IsNullOrWhiteSpace(registration.Instructions) &&
+            !string.IsNullOrWhiteSpace(dataSchemaInstructions))
+        {
+            return $"{registration.Instructions.Trim()}\n\n{dataSchemaInstructions}";
+        }
+
         if (!string.IsNullOrWhiteSpace(registration.Instructions))
         {
             return registration.Instructions;
         }
 
-        return null;
+        return dataSchemaInstructions;
+    }
+
+    private string? BuildDataSchemaInstructions(AgentRegistration registration)
+    {
+        if (_dataSchemaCatalog is null || registration.AllowedDataSchemas.Count == 0)
+        {
+            return null;
+        }
+
+        var schemaSets = _dataSchemaCatalog.GetAllowed(registration.AllowedDataSchemas);
+        if (schemaSets.Count == 0)
+        {
+            return null;
+        }
+
+        var builder = new StringBuilder();
+        builder.AppendLine("# READ-SAFE DATA SCHEMAS");
+        builder.AppendLine("The following entity schemas are exposed for planning context only. They do not grant query or mutation capability. Use registered workflow actions to read or change data.");
+
+        foreach (var schemaSet in schemaSets)
+        {
+            builder.Append("- Schema: ").Append(schemaSet.Name);
+            if (!string.IsNullOrWhiteSpace(schemaSet.Description))
+            {
+                builder.Append(" - ").Append(schemaSet.Description);
+            }
+
+            builder.AppendLine();
+
+            foreach (var entity in schemaSet.Entities)
+            {
+                builder.Append("  - Entity: ").Append(entity.Name);
+                if (!string.IsNullOrWhiteSpace(entity.Description))
+                {
+                    builder.Append(" - ").Append(entity.Description);
+                }
+
+                builder.AppendLine();
+
+                foreach (var property in entity.Properties)
+                {
+                    builder.Append("    - ")
+                        .Append(property.Name)
+                        .Append(": ")
+                        .Append(property.Type);
+
+                    if (property.IsKey)
+                    {
+                        builder.Append(", key");
+                    }
+
+                    if (property.IsNullable)
+                    {
+                        builder.Append(", nullable");
+                    }
+
+                    if (!string.IsNullOrWhiteSpace(property.Description))
+                    {
+                        builder.Append(" - ").Append(property.Description);
+                    }
+
+                    builder.AppendLine();
+                }
+            }
+        }
+
+        return builder.ToString().Trim();
     }
 
     private async Task<AgentTurnResponse> BuildNoAgentResponseAsync(

--- a/src/AgentBlazor.Core/Services/AgentBlazorBuilder.cs
+++ b/src/AgentBlazor.Core/Services/AgentBlazorBuilder.cs
@@ -1,6 +1,7 @@
 using AgentBlazor.Agents;
 using AgentBlazor.App;
 using AgentBlazor.Components;
+using AgentBlazor.Core.Data;
 using AgentBlazor.Core.Runtime.Adapters;
 using AgentBlazor.Core.Runtime.Conversation;
 using AgentBlazor.Core.Runtime.Interfaces;
@@ -73,6 +74,23 @@ public sealed class AgentBlazorBuilder
     {
         ArgumentNullException.ThrowIfNull(configure);
         _store.ComponentCatalogConfigurators.Add(configure);
+        return this;
+    }
+
+    public AgentBlazorBuilder AddDataSchema(AgentDataSchemaSet schemaSet)
+    {
+        ArgumentNullException.ThrowIfNull(schemaSet);
+        ArgumentException.ThrowIfNullOrWhiteSpace(schemaSet.Name);
+
+        _store.DataSchemaSets.RemoveAll(s => string.Equals(s.Name, schemaSet.Name, StringComparison.OrdinalIgnoreCase));
+        _store.DataSchemaSets.Add(schemaSet);
+        return this;
+    }
+
+    public AgentBlazorBuilder AddDataSchema(Func<IServiceProvider, AgentDataSchemaSet> schemaFactory)
+    {
+        ArgumentNullException.ThrowIfNull(schemaFactory);
+        _store.DataSchemaFactories.Add(schemaFactory);
         return this;
     }
 

--- a/src/AgentBlazor.Core/Services/AgentBlazorConfigurationStore.cs
+++ b/src/AgentBlazor.Core/Services/AgentBlazorConfigurationStore.cs
@@ -1,5 +1,6 @@
 using AgentBlazor.Agents;
 using AgentBlazor.Components;
+using AgentBlazor.Core.Data;
 
 namespace AgentBlazor.Services;
 
@@ -10,4 +11,8 @@ internal sealed class AgentBlazorConfigurationStore
     public List<Action<ComponentCapabilityCatalogBuilder>> ComponentCatalogConfigurators { get; } = [];
 
     public List<Type> CapabilityTypes { get; } = [];
+
+    public List<AgentDataSchemaSet> DataSchemaSets { get; } = [];
+
+    public List<Func<IServiceProvider, AgentDataSchemaSet>> DataSchemaFactories { get; } = [];
 }

--- a/src/AgentBlazor.Core/Services/AgentBlazorServiceCollectionExtensions.cs
+++ b/src/AgentBlazor.Core/Services/AgentBlazorServiceCollectionExtensions.cs
@@ -18,6 +18,7 @@ using AgentBlazor.Core.Runtime.Tools;
 using AgentBlazor.Core.Runtime.Tracing;
 using AgentBlazor.Core.Components;
 using AgentBlazor.Core.Runtime;
+using AgentBlazor.Core.Data;
 using AgentBlazor.Core.Paid;
 using AgentBlazor.Core.Paid.Analytics;
 using AgentBlazor.Core.Paid.Audit;
@@ -74,6 +75,10 @@ public static class AgentBlazorServiceCollectionExtensions
         services.TryAddScoped<IAgentComponentRegistry, CircuitAgentComponentRegistry>();
 
         services.TryAddSingleton<IAgentUiToolCatalog, DefaultAgentUiToolCatalog>();
+        services.TryAddSingleton<IAgentDataSchemaCatalog>(sp =>
+            BuildDataSchemaCatalog(
+                sp,
+                sp.GetRequiredService<AgentBlazorConfigurationStore>()));
 
         services.TryAddSingleton<IAgentRuntimeAdapter>(sp =>
         {
@@ -186,5 +191,19 @@ public static class AgentBlazorServiceCollectionExtensions
         }
 
         return registry;
+    }
+
+    private static IAgentDataSchemaCatalog BuildDataSchemaCatalog(
+        IServiceProvider serviceProvider,
+        AgentBlazorConfigurationStore store)
+    {
+        var catalog = new InMemoryAgentDataSchemaCatalog(store.DataSchemaSets);
+
+        foreach (var factory in store.DataSchemaFactories)
+        {
+            catalog.AddOrUpdate(factory(serviceProvider));
+        }
+
+        return catalog;
     }
 }

--- a/src/AgentBlazor.EntityFrameworkCore/AgentBlazor.EntityFrameworkCore.csproj
+++ b/src/AgentBlazor.EntityFrameworkCore/AgentBlazor.EntityFrameworkCore.csproj
@@ -1,0 +1,27 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <Description>Optional Entity Framework Core schema exposure for AgentBlazor planning context.</Description>
+    <PackageTags>blazor;aspnetcore;ai;agents;entity-framework;efcore;schema</PackageTags>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>false</IncludeSymbols>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AgentBlazor.Core\AgentBlazor.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
+    <None Include="..\AgentBlazor.Components\icon.png" Pack="true" PackagePath="" Link="icon.png" />
+  </ItemGroup>
+
+</Project>

--- a/src/AgentBlazor.EntityFrameworkCore/EntitySchemaBuilder.cs
+++ b/src/AgentBlazor.EntityFrameworkCore/EntitySchemaBuilder.cs
@@ -1,0 +1,244 @@
+using System.Linq.Expressions;
+using AgentBlazor.Core.Data;
+using AgentBlazor.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace AgentBlazor.EntityFrameworkCore;
+
+public static class AgentBlazorEntityFrameworkCoreBuilderExtensions
+{
+    public static AgentBlazorBuilder AddEntitySchema<TContext>(
+        this AgentBlazorBuilder builder,
+        string name,
+        Action<EfDataSchemaBuilder<TContext>> configure)
+        where TContext : DbContext
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        var schemaBuilder = new EfDataSchemaBuilder<TContext>(name);
+        configure(schemaBuilder);
+
+        return builder.AddDataSchema(serviceProvider =>
+            schemaBuilder.Build(serviceProvider));
+    }
+}
+
+public sealed class EfDataSchemaBuilder<TContext>
+    where TContext : DbContext
+{
+    private readonly List<IEfEntitySchemaBuilder<TContext>> _entities = [];
+
+    internal EfDataSchemaBuilder(string name)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        Name = name;
+    }
+
+    public string Name { get; }
+
+    public string? Description { get; private set; }
+
+    public EfDataSchemaBuilder<TContext> WithDescription(string description)
+    {
+        Description = description;
+        return this;
+    }
+
+    public EfDataSchemaBuilder<TContext> Entity<TEntity>(
+        string name,
+        Action<EfEntitySchemaBuilder<TContext, TEntity>> configure)
+        where TEntity : class
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        var entityBuilder = new EfEntitySchemaBuilder<TContext, TEntity>(name);
+        configure(entityBuilder);
+        _entities.Add(entityBuilder);
+        return this;
+    }
+
+    internal AgentDataSchemaSet Build(IServiceProvider serviceProvider)
+    {
+        ArgumentNullException.ThrowIfNull(serviceProvider);
+
+        using var context = CreateContext(serviceProvider);
+        return new AgentDataSchemaSet
+        {
+            Name = Name,
+            Description = Description,
+            Entities = _entities.Select(entity => entity.Build(context.Model)).ToArray()
+        };
+    }
+
+    private static TContext CreateContext(IServiceProvider serviceProvider)
+    {
+        var factory = serviceProvider.GetService<IDbContextFactory<TContext>>();
+        if (factory is not null)
+        {
+            return factory.CreateDbContext();
+        }
+
+        throw new InvalidOperationException(
+            $"AgentBlazor.EntityFrameworkCore requires IDbContextFactory<{typeof(TContext).Name}>. " +
+            $"Register it with services.AddDbContextFactory<{typeof(TContext).Name}>(...).");
+    }
+}
+
+public sealed class EfEntitySchemaBuilder<TContext, TEntity> : IEfEntitySchemaBuilder<TContext>
+    where TContext : DbContext
+    where TEntity : class
+{
+    private readonly List<EfEntityPropertySchemaBuilder<TEntity>> _properties = [];
+
+    internal EfEntitySchemaBuilder(string name)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        Name = name;
+    }
+
+    public string Name { get; }
+
+    public string? Description { get; private set; }
+
+    public EfEntitySchemaBuilder<TContext, TEntity> WithDescription(string description)
+    {
+        Description = description;
+        return this;
+    }
+
+    public EfEntitySchemaBuilder<TContext, TEntity> Property<TProperty>(
+        Expression<Func<TEntity, TProperty>> propertyExpression,
+        string? description = null)
+    {
+        ArgumentNullException.ThrowIfNull(propertyExpression);
+
+        var propertyName = GetPropertyName(propertyExpression);
+        _properties.Add(new EfEntityPropertySchemaBuilder<TEntity>(
+            propertyName,
+            typeof(TProperty),
+            description));
+        return this;
+    }
+
+    AgentEntitySchema IEfEntitySchemaBuilder<TContext>.Build(IModel model)
+    {
+        var entityType = model.FindEntityType(typeof(TEntity));
+        if (entityType is null)
+        {
+            throw new InvalidOperationException(
+                $"Entity type '{typeof(TEntity).FullName}' is not part of DbContext '{typeof(TContext).FullName}'.");
+        }
+
+        return new AgentEntitySchema
+        {
+            Name = Name,
+            ClrTypeName = typeof(TEntity).FullName,
+            Description = Description,
+            Properties = _properties.Select(property => property.Build(entityType)).ToArray()
+        };
+    }
+
+    private static string GetPropertyName<TProperty>(Expression<Func<TEntity, TProperty>> expression)
+    {
+        var body = expression.Body is UnaryExpression unary && unary.NodeType == ExpressionType.Convert
+            ? unary.Operand
+            : expression.Body;
+
+        if (body is MemberExpression member)
+        {
+            return member.Member.Name;
+        }
+
+        throw new ArgumentException(
+            "Entity schema properties must be simple member access expressions such as x => x.Id.",
+            nameof(expression));
+    }
+}
+
+internal interface IEfEntitySchemaBuilder<TContext>
+    where TContext : DbContext
+{
+    AgentEntitySchema Build(IModel model);
+}
+
+internal sealed class EfEntityPropertySchemaBuilder<TEntity>(
+    string propertyName,
+    Type declaredType,
+    string? description)
+    where TEntity : class
+{
+    public AgentEntityPropertySchema Build(IEntityType entityType)
+    {
+        var property = entityType.FindProperty(propertyName);
+        if (property is null)
+        {
+            throw new InvalidOperationException(
+                $"Property '{propertyName}' is not mapped on entity type '{typeof(TEntity).FullName}'.");
+        }
+
+        return new AgentEntityPropertySchema
+        {
+            Name = propertyName,
+            Type = GetTypeName(property.ClrType ?? declaredType),
+            IsNullable = property.IsNullable,
+            IsKey = property.IsPrimaryKey(),
+            Description = description
+        };
+    }
+
+    private static string GetTypeName(Type type)
+    {
+        var target = Nullable.GetUnderlyingType(type) ?? type;
+        if (target == typeof(string))
+        {
+            return "string";
+        }
+
+        if (target == typeof(int))
+        {
+            return "integer";
+        }
+
+        if (target == typeof(long))
+        {
+            return "long";
+        }
+
+        if (target == typeof(decimal))
+        {
+            return "decimal";
+        }
+
+        if (target == typeof(double) || target == typeof(float))
+        {
+            return "number";
+        }
+
+        if (target == typeof(bool))
+        {
+            return "boolean";
+        }
+
+        if (target == typeof(DateTime) || target == typeof(DateTimeOffset))
+        {
+            return "datetime";
+        }
+
+        if (target == typeof(DateOnly))
+        {
+            return "date";
+        }
+
+        if (target.IsEnum)
+        {
+            return $"enum:{target.Name}";
+        }
+
+        return target.Name;
+    }
+}

--- a/src/AgentBlazor.EntityFrameworkCore/README.md
+++ b/src/AgentBlazor.EntityFrameworkCore/README.md
@@ -1,0 +1,25 @@
+# AgentBlazor.EntityFrameworkCore
+
+Optional Entity Framework Core integration for exposing read-safe entity schema to AgentBlazor agents.
+
+This package is schema-only. It does not execute queries, generate LINQ, generate SQL, or grant data mutation capability.
+
+```csharp
+options.ConfigureBuilder(agentBuilder =>
+{
+    agentBuilder.AddEntitySchema<AppDbContext>("support-data", schema =>
+    {
+        schema.Entity<SupportTicket>("support_tickets", entity =>
+        {
+            entity.Property(x => x.Id, "Ticket identifier");
+            entity.Property(x => x.Status, "Current ticket status");
+            entity.Property(x => x.CreatedUtc, "Creation timestamp");
+        });
+    });
+
+    agentBuilder.AddWorkflow<SupportCapabilities>("support-agent", agent =>
+    {
+        agent.WithDataSchemas("support-data");
+    });
+});
+```

--- a/tests/AgentBlazor.Core.Tests/AgentBlazor.Core.Tests.csproj
+++ b/tests/AgentBlazor.Core.Tests/AgentBlazor.Core.Tests.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
@@ -21,6 +22,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\AgentBlazor.Core\AgentBlazor.Core.csproj" />
+    <ProjectReference Include="..\..\src\AgentBlazor.EntityFrameworkCore\AgentBlazor.EntityFrameworkCore.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/AgentBlazor.Core.Tests/EntityFrameworkCoreSchemaTests.cs
+++ b/tests/AgentBlazor.Core.Tests/EntityFrameworkCoreSchemaTests.cs
@@ -1,0 +1,257 @@
+using AgentBlazor.Agents;
+using AgentBlazor.App;
+using AgentBlazor.Attributes;
+using AgentBlazor.Core.Data;
+using AgentBlazor.Core.Runtime.Agents;
+using AgentBlazor.Core.Runtime.Interfaces;
+using AgentBlazor.EntityFrameworkCore;
+using Microsoft.Extensions.AI;
+using AgentBlazor.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace AgentBlazor.Core.Tests;
+
+public class EntityFrameworkCoreSchemaTests
+{
+    [Fact]
+    public void WithDataSchemas_PreservesExplicitAgentOptIn()
+    {
+        var services = new ServiceCollection();
+        services.AddAgentBlazorServices()
+            .AddAgent("support-agent", agent => agent.WithDataSchemas("support-data"))
+            .AddAgent("file-agent");
+
+        using var provider = services.BuildServiceProvider();
+        var registry = provider.GetRequiredService<IAgentRegistry>();
+
+        Assert.True(registry.TryGet("support-agent", out var supportAgent));
+        Assert.Contains("support-data", supportAgent.AllowedDataSchemas);
+
+        Assert.True(registry.TryGet("file-agent", out var fileAgent));
+        Assert.Empty(fileAgent.AllowedDataSchemas);
+    }
+
+    [Fact]
+    public void AddDataSchema_RegistersSchemaInCatalog()
+    {
+        var services = new ServiceCollection();
+        services.AddAgentBlazorServices()
+            .AddDataSchema(new AgentDataSchemaSet
+            {
+                Name = "support-data",
+                Description = "Support ticket data.",
+                Entities =
+                [
+                    new AgentEntitySchema
+                    {
+                        Name = "tickets",
+                        Properties =
+                        [
+                            new AgentEntityPropertySchema
+                            {
+                                Name = "Id",
+                                Type = "string",
+                                IsKey = true
+                            }
+                        ]
+                    }
+                ]
+            });
+
+        using var provider = services.BuildServiceProvider();
+        var catalog = provider.GetRequiredService<IAgentDataSchemaCatalog>();
+
+        Assert.True(catalog.TryGet("support-data", out var schema));
+        Assert.Equal("Support ticket data.", schema.Description);
+        var entity = Assert.Single(schema.Entities);
+        Assert.Equal("tickets", entity.Name);
+        var property = Assert.Single(entity.Properties);
+        Assert.Equal("Id", property.Name);
+        Assert.True(property.IsKey);
+    }
+
+    [Fact]
+    public void AddEntitySchema_ExposesOnlyAllowlistedProperties()
+    {
+        var services = new ServiceCollection();
+        services.AddDbContextFactory<SchemaTestDbContext>(options =>
+            options.UseSqlite("Data Source=:memory:"));
+        services.AddAgentBlazorServices()
+            .AddEntitySchema<SchemaTestDbContext>("support-data", schema =>
+            {
+                schema.WithDescription("Read-safe support ticket shape.");
+                schema.Entity<SupportTicket>("support_tickets", entity =>
+                {
+                    entity.WithDescription("Support tickets visible to the workflow.");
+                    entity.Property(ticket => ticket.Id, "Ticket identifier.");
+                    entity.Property(ticket => ticket.Status, "Current status.");
+                    entity.Property(ticket => ticket.CreatedUtc, "Creation timestamp.");
+                });
+            });
+
+        using var provider = services.BuildServiceProvider();
+        var catalog = provider.GetRequiredService<IAgentDataSchemaCatalog>();
+
+        Assert.True(catalog.TryGet("support-data", out var schema));
+        Assert.Equal("Read-safe support ticket shape.", schema.Description);
+
+        var entitySchema = Assert.Single(schema.Entities);
+        Assert.Equal("support_tickets", entitySchema.Name);
+        Assert.Equal(typeof(SupportTicket).FullName, entitySchema.ClrTypeName);
+        Assert.Equal("Support tickets visible to the workflow.", entitySchema.Description);
+
+        Assert.Collection(
+            entitySchema.Properties,
+            property =>
+            {
+                Assert.Equal("Id", property.Name);
+                Assert.Equal("string", property.Type);
+                Assert.True(property.IsKey);
+                Assert.Equal("Ticket identifier.", property.Description);
+            },
+            property =>
+            {
+                Assert.Equal("Status", property.Name);
+                Assert.Equal("string", property.Type);
+                Assert.False(property.IsKey);
+            },
+            property =>
+            {
+                Assert.Equal("CreatedUtc", property.Name);
+                Assert.Equal("datetime", property.Type);
+                Assert.False(property.IsKey);
+            });
+
+        Assert.DoesNotContain(entitySchema.Properties, property => property.Name == nameof(SupportTicket.CustomerEmail));
+    }
+
+    [Fact]
+    public void AddEntitySchema_RequiresDbContextFactory()
+    {
+        var services = new ServiceCollection();
+        services.AddAgentBlazorServices()
+            .AddEntitySchema<SchemaTestDbContext>("support-data", schema =>
+            {
+                schema.Entity<SupportTicket>("support_tickets", entity =>
+                {
+                    entity.Property(ticket => ticket.Id);
+                });
+            });
+
+        using var provider = services.BuildServiceProvider();
+
+        var error = Assert.Throws<InvalidOperationException>(
+            () => provider.GetRequiredService<IAgentDataSchemaCatalog>());
+        Assert.Contains("requires IDbContextFactory<SchemaTestDbContext>", error.Message);
+    }
+
+    [Fact]
+    public async Task RuntimeAdapter_IncludesOnlyOptedInDataSchemasInInstructions()
+    {
+        var chatClient = new InstructionCapturingChatClient();
+        var services = new ServiceCollection();
+        services.AddSingleton<IChatClient>(chatClient);
+        services.AddAgentBlazorServices()
+            .UseChatClientRuntimeAdapter()
+            .AddDataSchema(new AgentDataSchemaSet
+            {
+                Name = "support-data",
+                Entities =
+                [
+                    new AgentEntitySchema
+                    {
+                        Name = "support_tickets",
+                        Properties =
+                        [
+                            new AgentEntityPropertySchema { Name = "Id", Type = "string", IsKey = true }
+                        ]
+                    }
+                ]
+            })
+            .AddWorkflow<SchemaProbeCapabilities>("support-agent", agent =>
+            {
+                agent.WithDataSchemas("support-data");
+            })
+            .AddWorkflow<SchemaProbeCapabilities>("file-agent");
+
+        await using var provider = services.BuildServiceProvider();
+        var runtime = provider.GetRequiredService<IAgentRuntimeAdapter>();
+
+        _ = await runtime.RunTurnAsync(new AgentTurnRequest("hello", AgentName: "support-agent"));
+        _ = await runtime.RunTurnAsync(new AgentTurnRequest("hello", AgentName: "file-agent"));
+
+        Assert.Contains("support_tickets", chatClient.Instructions[0]);
+        Assert.DoesNotContain("support_tickets", chatClient.Instructions[1] ?? string.Empty, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private sealed class SchemaTestDbContext(DbContextOptions<SchemaTestDbContext> options) : DbContext(options)
+    {
+        public DbSet<SupportTicket> SupportTickets => Set<SupportTicket>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<SupportTicket>(entity =>
+            {
+                entity.HasKey(ticket => ticket.Id);
+                entity.Property(ticket => ticket.Id).IsRequired();
+                entity.Property(ticket => ticket.Status).IsRequired();
+                entity.Property(ticket => ticket.CustomerEmail).IsRequired();
+            });
+        }
+    }
+
+    private sealed class SupportTicket
+    {
+        public string Id { get; set; } = string.Empty;
+
+        public string Status { get; set; } = string.Empty;
+
+        public DateTimeOffset CreatedUtc { get; set; }
+
+        public string CustomerEmail { get; set; } = string.Empty;
+    }
+
+    [AgentCapability("schema_probe")]
+    private sealed class SchemaProbeCapabilities
+    {
+        [AgentAction("Run schema probe")]
+        public CapabilityResult RunProbe() => CapabilityResult.Success("Schema probe completed.");
+    }
+
+    private sealed class InstructionCapturingChatClient : IChatClient
+    {
+        public List<string?> Instructions { get; } = [];
+
+        public Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> messages,
+            ChatOptions? options = null,
+            CancellationToken cancellationToken = default)
+        {
+            _ = messages;
+            _ = cancellationToken;
+            Instructions.Add(options?.Instructions);
+            return Task.FromResult(new ChatResponse(new ChatMessage(ChatRole.Assistant, "ok")));
+        }
+
+        public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IEnumerable<ChatMessage> messages,
+            ChatOptions? options = null,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            var response = await GetResponseAsync(messages, options, cancellationToken);
+            yield return new ChatResponseUpdate(ChatRole.Assistant, response.Text);
+        }
+
+        public object? GetService(Type serviceType, object? serviceKey = null)
+        {
+            _ = serviceType;
+            _ = serviceKey;
+            return null;
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- adds core read-safe data schema abstractions and explicit per-agent schema opt-in
- injects opted-in schema metadata into chat runtime instructions as planning context only
- adds optional AgentBlazor.EntityFrameworkCore package with allowlist-only EF schema extraction
- wires the new package into solution files, local pack smoke definitions, and NuGet publish workflow
- adds a support inbox demo/reference schema without adding query execution

## Testing
- dotnet build src/AgentBlazor.EntityFrameworkCore/AgentBlazor.EntityFrameworkCore.csproj -c Release --no-restore -nologo
- dotnet test tests/AgentBlazor.Core.Tests/AgentBlazor.Core.Tests.csproj -c Release --no-restore -nologo
- dotnet restore demo/AgentBlazor.Demo/AgentBlazor.Demo.csproj --force-evaluate -p:RuntimeIdentifier=linux-x64
- dotnet build demo/AgentBlazor.Demo/AgentBlazor.Demo.csproj -c Release --no-restore -nologo -p:RuntimeIdentifier=linux-x64
- dotnet restore samples/AgentBlazor.Starter/AgentBlazor.Starter.csproj --force-evaluate -p:RuntimeIdentifier=linux-x64
- dotnet build AgentBlazor.slnx -c Release --no-restore -nologo
- dotnet test AgentBlazor.slnx -c Release --no-build -nologo
- dotnet pack src/AgentBlazor.EntityFrameworkCore/AgentBlazor.EntityFrameworkCore.csproj -c Release -nologo /p:PackageVersion=0.1.0-preview.11 /p:RestoreLockedMode=false /p:RestoreForceEvaluate=true

## Notes
- No query execution, LINQ generation, SQL generation, or mutations are included.
- Local PowerShell smoke script was not run because pwsh is not installed in this container.