### PR TITLE
Document EF schema exposure

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,9 +104,20 @@ dotnet run --project samples/AgentBlazor.Starter/AgentBlazor.Starter.csproj
 
 - [Quickstart](docs/quickstart.md)
 - [Recoverable capability errors](docs/capability-errors.md)
+- [Entity Framework Core schema exposure](docs/entity-framework.md)
 - [Beta testing](docs/beta-testing.md)
 - [Starter sample](samples/AgentBlazor.Starter/README.md)
 - [Advanced CLI](docs/advanced/cli.md)
+
+## Optional EF Core Schema Exposure
+
+If your app uses EF Core, install `AgentBlazor.EntityFrameworkCore` to expose selected entity shapes as planning context:
+
+```bash
+dotnet add package AgentBlazor.EntityFrameworkCore --prerelease
+```
+
+This is schema-only. It helps an agent understand safe entity fields, but it does not execute queries, generate LINQ or SQL, scan every `DbSet`, or grant write access. Data access still goes through your typed `[AgentAction]` methods.
 
 ## Beta
 

--- a/docs/entity-framework.md
+++ b/docs/entity-framework.md
@@ -1,0 +1,130 @@
+# Entity Framework Core Schema Exposure
+
+`AgentBlazor.EntityFrameworkCore` lets an AgentBlazor agent see a read-safe description of selected EF Core entities while keeping data access behind your typed workflow actions.
+
+This is schema-only planning context. It does not execute queries, generate LINQ, generate SQL, scan every `DbSet`, or grant write access.
+
+## Install
+
+```bash
+dotnet add package AgentBlazor.EntityFrameworkCore --prerelease
+```
+
+If you pin versions, use the same AgentBlazor version for the runtime and EF package:
+
+```bash
+dotnet add package AgentBlazor --version 0.1.0-preview.11
+dotnet add package AgentBlazor.EntityFrameworkCore --version 0.1.0-preview.11
+```
+
+## DbContext Setup
+
+Use `IDbContextFactory<TContext>`. This follows the Blazor EF Core guidance to create a context per operation instead of sharing one context across interactive UI work.
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+
+builder.Services.AddDbContextFactory<AppDbContext>(options =>
+{
+    options.UseSqlite(builder.Configuration.GetConnectionString("AppDb"));
+});
+```
+
+## Register A Schema
+
+Register only the entities and properties the agent may reason about. Properties are allowlisted; unlisted fields are not exposed.
+
+```csharp
+using AgentBlazor;
+using AgentBlazor.EntityFrameworkCore;
+
+builder.Services.AddAgentBlazor(options =>
+{
+    options.UseOpenAI(
+        apiKey: builder.Configuration["OpenAI:ApiKey"]!,
+        model: builder.Configuration["OpenAI:Model"] ?? "gpt-4o-mini");
+
+    options.ConfigureBuilder(agentBuilder =>
+    {
+        agentBuilder.AddEntitySchema<AppDbContext>("support-data", schema =>
+        {
+            schema.WithDescription("Read-safe support ticket fields.");
+
+            schema.Entity<SupportTicket>("support_tickets", entity =>
+            {
+                entity.WithDescription("Tickets visible to the support workflow.");
+                entity.Property(ticket => ticket.Id, "Ticket identifier such as TCK-1042.");
+                entity.Property(ticket => ticket.Status, "Current ticket status.");
+                entity.Property(ticket => ticket.Priority, "Priority label.");
+                entity.Property(ticket => ticket.CreatedUtc, "Creation timestamp.");
+            });
+        });
+
+        agentBuilder.AddWorkflow<SupportInboxCapabilities>("support-agent", agent =>
+        {
+            agent.WithRoutePrefixes("/support");
+            agent.WithDataSchemas("support-data");
+        });
+    });
+});
+```
+
+## Keep Execution Typed
+
+The schema helps the model understand what concepts exist. Actual reads and writes still go through your `[AgentAction]` methods.
+
+```csharp
+using AgentBlazor.App;
+using AgentBlazor.Attributes;
+using Microsoft.EntityFrameworkCore;
+
+[AgentCapability("support_inbox")]
+public sealed class SupportInboxCapabilities(IDbContextFactory<AppDbContext> dbFactory)
+{
+    [AgentAction("Show open support tickets")]
+    public async Task<CapabilityResult> ShowOpenTicketsAsync(int days = 7)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync();
+
+        var tickets = await db.SupportTickets
+            .AsNoTracking()
+            .Where(ticket => ticket.WaitingOnReply)
+            .OrderByDescending(ticket => ticket.Priority)
+            .Take(20)
+            .Select(ticket => new
+            {
+                ticket.Id,
+                ticket.Status,
+                ticket.Priority
+            })
+            .ToArrayAsync();
+
+        return CapabilityResult
+            .Success($"Found {tickets.Length} open tickets.")
+            .WithOutput("tickets", tickets);
+    }
+}
+```
+
+The action owns tenant filtering, authorization, row limits, projections, and validation. AgentBlazor does not bypass those app-owned controls.
+
+## Safety Rules
+
+- Use explicit property allowlists.
+- Do not expose sensitive fields such as emails, tokens, addresses, notes, secrets, or internal IDs unless they are safe for the model to see.
+- Keep multi-tenancy and row-level security in your app's EF filters or typed workflow methods.
+- Keep result sizes bounded with projection and `Take(...)`.
+- Do not accept model-produced SQL or LINQ as input.
+
+## Current Boundary
+
+v0.2 schema exposure is intentionally narrow:
+
+- Included: schema metadata for planning context.
+- Included: per-agent opt-in with `WithDataSchemas(...)`.
+- Included: EF model validation that exposed properties are mapped.
+- Not included: query execution tools.
+- Not included: component canvas generation from EF results.
+- Not included: dynamic SQL, generated LINQ, or writes.
+
+Constrained query templates and result canvas rendering are future work.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -180,3 +180,4 @@ Say hello
 - [Starter sample](../samples/AgentBlazor.Starter/README.md)
 - [Hosted WebAssembly client](../src/AgentBlazor.Client/PACKAGE_README.md)
 - [Recoverable capability errors](capability-errors.md)
+- [Entity Framework Core schema exposure](entity-framework.md)

--- a/src/AgentBlazor.Components/PACKAGE_README.md
+++ b/src/AgentBlazor.Components/PACKAGE_README.md
@@ -86,4 +86,5 @@ Docs and demo:
 - Structured error reference: https://demo.agentblazor.com/demo/workflows/runtime-probe
 - Quickstart: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/quickstart.md
 - Recoverable capability errors: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/capability-errors.md
+- Optional EF Core schema exposure: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/entity-framework.md
 - Starter sample: https://github.com/ashpeterson/AgentBlazor/tree/master/samples/AgentBlazor.Starter

--- a/src/AgentBlazor.EntityFrameworkCore/README.md
+++ b/src/AgentBlazor.EntityFrameworkCore/README.md
@@ -2,9 +2,28 @@
 
 Optional Entity Framework Core integration for exposing read-safe entity schema to AgentBlazor agents.
 
-This package is schema-only. It does not execute queries, generate LINQ, generate SQL, or grant data mutation capability.
+This package is schema-only. It does not execute queries, generate LINQ, generate SQL, scan every `DbSet`, or grant data mutation capability.
+
+Install:
+
+```bash
+dotnet add package AgentBlazor.EntityFrameworkCore --prerelease
+```
+
+Register your `DbContext` with `IDbContextFactory<TContext>`:
 
 ```csharp
+builder.Services.AddDbContextFactory<AppDbContext>(options =>
+{
+    options.UseSqlite(builder.Configuration.GetConnectionString("AppDb"));
+});
+```
+
+Expose only safe entities and properties:
+
+```csharp
+using AgentBlazor.EntityFrameworkCore;
+
 options.ConfigureBuilder(agentBuilder =>
 {
     agentBuilder.AddEntitySchema<AppDbContext>("support-data", schema =>
@@ -23,3 +42,7 @@ options.ConfigureBuilder(agentBuilder =>
     });
 });
 ```
+
+Execution remains app-owned. Use normal `[AgentAction]` methods with EF projections, row limits, authorization, and tenant filtering. Do not pass model-generated SQL or LINQ into EF.
+
+Full docs: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/entity-framework.md


### PR DESCRIPTION
## Summary
- adds public docs for optional AgentBlazor.EntityFrameworkCore schema exposure
- links EF docs from README, quickstart, and package README
- expands the EF package README with install, IDbContextFactory setup, allowlist registration, and safety boundaries

## Testing
- dotnet pack src/AgentBlazor.EntityFrameworkCore/AgentBlazor.EntityFrameworkCore.csproj -c Release -nologo /p:PackageVersion=0.1.0-preview.11 /p:RestoreLockedMode=false /p:RestoreForceEvaluate=true

## Notes
- docs-only change plus EF package README packaging verification