### PR TITLE
Prepare v0.2 preview release notes

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
 
   <!-- Common package metadata for all AgentBlazor packages -->
   <PropertyGroup>
-    <Version>0.1.0-preview.11</Version>
+    <Version>0.2.0-preview.1</Version>
     <Authors>Ash Peterson</Authors>
     <Company>AgentBlazor</Company>
     <Copyright>Copyright (c) 2026 Ash Peterson</Copyright>
@@ -16,7 +16,7 @@
     <RepositoryType>git</RepositoryType>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <PackageIcon>icon.png</PackageIcon>
-    <PackageReleaseNotes>Install-path fixes: explicit workflow quickstart, clearer OpenAI configuration errors, and chat shell/widget setup corrections.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.2 preview: structured capability error recovery, schema-only EF Core entity exposure, hosted demo observability, and verified package-first quickstart updates.</PackageReleaseNotes>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <Deterministic>true</Deterministic>

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Try the hosted demo:
 ## Install
 
 ```bash
-dotnet add package AgentBlazor --version 0.1.0-preview.11
+dotnet add package AgentBlazor --version 0.2.0-preview.1
 ```
 
 The CLI is optional. Keep it out of the critical path unless you want scaffold help for an existing app.
@@ -103,6 +103,7 @@ dotnet run --project samples/AgentBlazor.Starter/AgentBlazor.Starter.csproj
 ## Docs
 
 - [Quickstart](docs/quickstart.md)
+- [0.2.0 release notes](docs/releases/0.2.0.md)
 - [Recoverable capability errors](docs/capability-errors.md)
 - [Entity Framework Core schema exposure](docs/entity-framework.md)
 - [Beta testing](docs/beta-testing.md)

--- a/demo/AgentBlazor.Demo/Components/Pages/Docs/CliGuide.razor
+++ b/demo/AgentBlazor.Demo/Components/Pages/Docs/CliGuide.razor
@@ -20,8 +20,8 @@
             </div>
         </div>
 
-        <pre class="docs-code"><code>dotnet tool install --global AgentBlazor.Cli --version 0.1.0-preview.11
-dotnet tool update --global AgentBlazor.Cli --version 0.1.0-preview.11</code></pre>
+        <pre class="docs-code"><code>dotnet tool install --global AgentBlazor.Cli --version 0.2.0-preview.1
+dotnet tool update --global AgentBlazor.Cli --version 0.2.0-preview.1</code></pre>
     </section>
 
     <section class="docs-section">

--- a/demo/AgentBlazor.Demo/Components/Pages/Docs/DocsHome.razor
+++ b/demo/AgentBlazor.Demo/Components/Pages/Docs/DocsHome.razor
@@ -40,7 +40,7 @@
             </div>
         </div>
 
-        <pre class="docs-code"><code>dotnet add package AgentBlazor --version 0.1.0-preview.11
+        <pre class="docs-code"><code>dotnet add package AgentBlazor --version 0.2.0-preview.1
 builder.Services.AddAgentBlazor(...)
 app.MapAgentBlazorEndpoints()
 Render one chat surface on one route

--- a/demo/AgentBlazor.Demo/Components/Pages/Docs/GettingStarted.razor
+++ b/demo/AgentBlazor.Demo/Components/Pages/Docs/GettingStarted.razor
@@ -20,7 +20,7 @@
             </div>
         </div>
 
-        <pre class="docs-code"><code>dotnet add ./src/MyBlazorApp/MyBlazorApp.csproj package AgentBlazor --version 0.1.0-preview.11</code></pre>
+        <pre class="docs-code"><code>dotnet add ./src/MyBlazorApp/MyBlazorApp.csproj package AgentBlazor --version 0.2.0-preview.1</code></pre>
     </section>
 
     <section class="docs-section">
@@ -30,7 +30,7 @@
             </div>
         </div>
 
-        <pre class="docs-code"><code>dotnet add ./src/MyBlazorApp/MyBlazorApp.csproj package AgentBlazor --version 0.1.0-preview.11
+        <pre class="docs-code"><code>dotnet add ./src/MyBlazorApp/MyBlazorApp.csproj package AgentBlazor --version 0.2.0-preview.1
 
 builder.Services.AddMudServices();
 builder.Services.AddAgentBlazor(options =&gt; { ... });
@@ -81,7 +81,7 @@ app.MapAgentBlazorEndpoints();</code></pre>
             </div>
         </div>
 
-        <pre class="docs-code"><code>dotnet tool install --global AgentBlazor.Cli --version 0.1.0-preview.11
+        <pre class="docs-code"><code>dotnet tool install --global AgentBlazor.Cli --version 0.2.0-preview.1
 agentblazor init ./MySolution.slnx --host MyBlazorApp
 agentblazor scaffold ./MySolution.slnx --host MyBlazorApp --provider openai --diff
 agentblazor scaffold ./MySolution.slnx --host MyBlazorApp --provider openai --approve
@@ -96,7 +96,7 @@ dotnet build ./MySolution.slnx --no-restore -nologo</code></pre>
             </div>
         </div>
 
-        <pre class="docs-code"><code>dotnet add ./src/MyBlazorApp.Client/MyBlazorApp.Client.csproj package AgentBlazor.Client --version 0.1.0-preview.11
+        <pre class="docs-code"><code>dotnet add ./src/MyBlazorApp.Client/MyBlazorApp.Client.csproj package AgentBlazor.Client --version 0.2.0-preview.1
 
 // Server
 app.MapAgentBlazorEndpoints();

--- a/demo/AgentBlazor.Demo/Components/Pages/Docs/Verification.razor
+++ b/demo/AgentBlazor.Demo/Components/Pages/Docs/Verification.razor
@@ -20,7 +20,7 @@
             </div>
         </div>
 
-        <pre class="docs-code"><code>dotnet add ./src/MyBlazorApp/MyBlazorApp.csproj package AgentBlazor --version 0.1.0-preview.11
+        <pre class="docs-code"><code>dotnet add ./src/MyBlazorApp/MyBlazorApp.csproj package AgentBlazor --version 0.2.0-preview.1
 dotnet build ./MySolution.slnx --nologo
 OpenAI__ApiKey=placeholder-key dotnet run --project ./src/MyBlazorApp/MyBlazorApp.csproj --no-launch-profile --urls http://127.0.0.1:5288
 Open the support route and submit one real prompt</code></pre>
@@ -35,7 +35,7 @@ Open the support route and submit one real prompt</code></pre>
 
         <pre class="docs-code"><code>dotnet new blazor -o FreshAgentBlazor
 cd FreshAgentBlazor
-dotnet add package AgentBlazor --version 0.1.0-preview.11
+dotnet add package AgentBlazor --version 0.2.0-preview.1
 dotnet build FreshAgentBlazor.csproj --nologo</code></pre>
     </section>
 
@@ -46,8 +46,8 @@ dotnet build FreshAgentBlazor.csproj --nologo</code></pre>
             </div>
         </div>
 
-        <pre class="docs-code"><code>dotnet add ./src/MyHostedServer/MyHostedServer.csproj package AgentBlazor --version 0.1.0-preview.11
-dotnet add ./src/MyHostedClient/MyHostedClient.csproj package AgentBlazor.Client --version 0.1.0-preview.11
+        <pre class="docs-code"><code>dotnet add ./src/MyHostedServer/MyHostedServer.csproj package AgentBlazor --version 0.2.0-preview.1
+dotnet add ./src/MyHostedClient/MyHostedClient.csproj package AgentBlazor.Client --version 0.2.0-preview.1
 
 // Server
 app.MapAgentBlazorEndpoints();

--- a/docs/advanced/cli.md
+++ b/docs/advanced/cli.md
@@ -11,7 +11,7 @@ Use it when:
 Current run order:
 
 ```bash
-dotnet tool install --global AgentBlazor.Cli --version 0.1.0-preview.11
+dotnet tool install --global AgentBlazor.Cli --version 0.2.0-preview.1
 agentblazor init ./MySolution.slnx --host MyBlazorApp
 agentblazor scaffold ./MySolution.slnx --host MyBlazorApp --provider openai --diff
 agentblazor scaffold ./MySolution.slnx --host MyBlazorApp --provider openai --approve

--- a/docs/beta-testing.md
+++ b/docs/beta-testing.md
@@ -20,7 +20,7 @@ Use a fresh app first. Do not start with an existing codebase.
 ```bash
 dotnet new blazor -o FreshAgentBlazor
 cd FreshAgentBlazor
-dotnet add package AgentBlazor --version 0.1.0-preview.11
+dotnet add package AgentBlazor --version 0.2.0-preview.1
 ```
 
 Then follow:
@@ -41,7 +41,7 @@ Compare against the hosted support-inbox demo if you want a known-running refere
 
 Please report pass or fail for each of these:
 
-1. `dotnet add package AgentBlazor --version 0.1.0-preview.11`
+1. `dotnet add package AgentBlazor --version 0.2.0-preview.1`
 2. `dotnet build`
 3. app starts with AgentBlazor assets loaded
 4. chat surface opens

--- a/docs/entity-framework.md
+++ b/docs/entity-framework.md
@@ -13,8 +13,8 @@ dotnet add package AgentBlazor.EntityFrameworkCore --prerelease
 If you pin versions, use the same AgentBlazor version for the runtime and EF package:
 
 ```bash
-dotnet add package AgentBlazor --version 0.1.0-preview.11
-dotnet add package AgentBlazor.EntityFrameworkCore --version 0.1.0-preview.11
+dotnet add package AgentBlazor --version 0.2.0-preview.1
+dotnet add package AgentBlazor.EntityFrameworkCore --version 0.2.0-preview.1
 ```
 
 ## DbContext Setup

--- a/docs/internal/beta-tester-runbook.md
+++ b/docs/internal/beta-tester-runbook.md
@@ -80,7 +80,7 @@ For each tester capture:
 If a tester asks what to do, answer with this exact path:
 
 1. create a fresh Blazor app
-2. run `dotnet add package AgentBlazor --version 0.1.0-preview.11`
+2. run `dotnet add package AgentBlazor --version 0.2.0-preview.1`
 3. follow `docs/quickstart.md`
 4. test the support-inbox shape only
 5. submit feedback through one of the issue forms

--- a/docs/internal/launch-content/blog-post.md
+++ b/docs/internal/launch-content/blog-post.md
@@ -37,7 +37,7 @@ What it does not try to do at launch:
 The first install path is now the normal one:
 
 ```bash
-dotnet add package AgentBlazor --version 0.1.0-preview.11
+dotnet add package AgentBlazor --version 0.2.0-preview.1
 ```
 
 Then wire `AddAgentBlazor(...)`, map `MapAgentBlazorEndpoints()`, add one capability class, and mount one chat surface.

--- a/docs/internal/launch-content/reddit-r-dotnet.md
+++ b/docs/internal/launch-content/reddit-r-dotnet.md
@@ -19,7 +19,7 @@ What it is:
 Current public package:
 
 ```bash
-dotnet add package AgentBlazor --version 0.1.0-preview.11
+dotnet add package AgentBlazor --version 0.2.0-preview.1
 ```
 
 Current public demo:

--- a/docs/internal/launch-content/social-thread.md
+++ b/docs/internal/launch-content/social-thread.md
@@ -38,7 +38,7 @@ Post 4:
 Install path:
 
 ```bash
-dotnet add package AgentBlazor --version 0.1.0-preview.11
+dotnet add package AgentBlazor --version 0.2.0-preview.1
 ```
 
 CLI exists, but it is the advanced path, not the headline.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,6 +1,6 @@
 # Quickstart
 
-Get one working AgentBlazor chat widget into a fresh Blazor app. Tested against a clean `dotnet new blazor` project with `AgentBlazor 0.1.0-preview.11`.
+Get one working AgentBlazor chat widget into a fresh Blazor app. Tested against a clean `dotnet new blazor` project with `AgentBlazor 0.2.0-preview.1`.
 
 Hosted demo: https://demo.agentblazor.com/demo/workflows/support-inbox
 
@@ -9,7 +9,7 @@ AgentBlazor does not create a responding agent by default. You must register at 
 ## 1. Install
 
 ```bash
-dotnet add package AgentBlazor --version 0.1.0-preview.11
+dotnet add package AgentBlazor --version 0.2.0-preview.1
 ```
 
 ## 2. Program.cs
@@ -171,12 +171,13 @@ Say hello
 ## Notes
 
 - `MapAgentBlazorEndpoints()` is required. Without it, the widget can render but cannot call the runtime.
-- `AgentBlazorShell` includes the widget in `0.1.0-preview.11`.
+- `AgentBlazorShell` includes the widget in `0.2.0-preview.1`.
 - A registered workflow is required for the chat to respond.
 
 ## Next
 
 - [Hosted demo](https://demo.agentblazor.com/demo/workflows/support-inbox)
+- [0.2.0 release notes](releases/0.2.0.md)
 - [Starter sample](../samples/AgentBlazor.Starter/README.md)
 - [Hosted WebAssembly client](../src/AgentBlazor.Client/PACKAGE_README.md)
 - [Recoverable capability errors](capability-errors.md)

--- a/docs/releases/0.2.0.md
+++ b/docs/releases/0.2.0.md
@@ -1,0 +1,91 @@
+# AgentBlazor 0.2.0 Release Notes
+
+Target package line: `0.2.0-preview.1` leading to `0.2.0`.
+
+AgentBlazor 0.2 focuses on making the package-first path credible: recoverable tool errors, explicit EF Core schema context for planning, a simpler hosted demo, and observable demo traffic/chat usage.
+
+## Highlights
+
+- Structured capability errors: `CapabilityResult` now has explicit recoverable result shapes for missing arguments, invalid arguments, invalid argument shape, and recoverable failures. The reflection binding layer normalizes common binding failures before method invocation, and the chat/runtime path carries summaries, next actions, warnings, and outputs forward so the model can recover instead of spiraling on raw exception text.
+- EF Core schema exposure: the optional `AgentBlazor.EntityFrameworkCore` package exposes selected EF model shapes as planning context with `AddEntitySchema<TContext>(...)` and per-agent opt-in through `WithDataSchemas(...)`. This is read-safe schema metadata only; data access still goes through app-owned `[AgentAction]` methods.
+- Demo and observability: the hosted demo now leads with the support-inbox workflow, includes traffic/chat JSONL logging, protected log/summary endpoints, token and cost fields for chat turns, and filtering so analytics answer whether real people are using the demo instead of showing Blazor transport noise.
+- Install and docs cleanup: the quickstart now documents the required workflow registration, interactive render mode, `AgentBlazorShell`, OpenAI key setup, and package-first setup against a fresh Blazor app. GitHub Packages/PAT setup is no longer the default path.
+
+## Structured Error Recovery
+
+Use structured results when an action cannot complete:
+
+- `CapabilityResult.MissingArgument(...)` when the user must provide a required value.
+- `CapabilityResult.InvalidArguments(...)` when supplied values are logically invalid.
+- `CapabilityResult.InvalidArgumentShape(...)` when the model supplied a value in the wrong shape.
+- `CapabilityResult.RecoverableFailure(...)` for domain validation failures where the model can take a next step.
+
+See [Recoverable capability errors](../capability-errors.md).
+
+## EF Core Schema Exposure
+
+Install the optional package:
+
+```bash
+dotnet add package AgentBlazor.EntityFrameworkCore --version 0.2.0-preview.1
+```
+
+Register only safe entity/property metadata:
+
+```csharp
+agentBuilder.AddEntitySchema<AppDbContext>("support-data", schema =>
+{
+    schema.Entity<SupportTicket>("support_tickets", entity =>
+    {
+        entity.Property(ticket => ticket.Id, "Ticket identifier such as TCK-1042.");
+        entity.Property(ticket => ticket.Status, "Current ticket status.");
+        entity.Property(ticket => ticket.Priority, "Priority label.");
+    });
+});
+
+agentBuilder.AddWorkflow<SupportInboxCapabilities>("support-agent", agent =>
+{
+    agent.WithDataSchemas("support-data");
+});
+```
+
+This does not execute queries, generate LINQ, generate SQL, scan every `DbSet`, expose sensitive fields by default, or grant write access.
+
+See [Entity Framework Core schema exposure](../entity-framework.md).
+
+## Demo And Logging
+
+Hosted demo:
+
+- https://demo.agentblazor.com/demo/workflows/support-inbox
+
+The demo records file-backed JSONL telemetry for:
+
+- page traffic and unique visitor summaries
+- chat request timing and status
+- approval/clarification flags
+- planned/executed action counts
+- prompt/response length
+- token usage and estimated cost when available
+
+The protected `/internal/demo-logs` and `/internal/demo-logs/summary` endpoints are intended for lightweight demo operations without paid analytics infrastructure.
+
+## Install Path
+
+Pinned preview install:
+
+```bash
+dotnet add package AgentBlazor --version 0.2.0-preview.1
+```
+
+Current quickstart:
+
+- [Quickstart](../quickstart.md)
+
+## Known Boundaries
+
+- AgentBlazor is still MudBlazor-first for built-in UI wrappers.
+- EF exposure is schema-only planning context, not a query engine.
+- Query templates and result canvas rendering are future work.
+- The CLI remains an advanced setup path, not the main first-user path.
+- Some older internal planning docs and direct demo routes still exist in the repo while the public surface is being narrowed.

--- a/samples/AgentBlazor.Starter/README.md
+++ b/samples/AgentBlazor.Starter/README.md
@@ -34,5 +34,5 @@ Inside this repo, the starter defaults to local source-project references so the
 To validate the published package path from inside the repo:
 
 ```powershell
-dotnet run --project samples/AgentBlazor.Starter/AgentBlazor.Starter.csproj -p:UseLocalAgentBlazorSource=false -p:AgentBlazorPackageVersion=0.1.0-preview.11
+dotnet run --project samples/AgentBlazor.Starter/AgentBlazor.Starter.csproj -p:UseLocalAgentBlazorSource=false -p:AgentBlazorPackageVersion=0.2.0-preview.1
 ```

--- a/scripts/video/compose-product-videos.cjs
+++ b/scripts/video/compose-product-videos.cjs
@@ -114,7 +114,7 @@ function renderTitleCard(outputPath, config) {
     `drawtext=fontfile=${fontBold}:text='${safeTitle}':x=896:y=208:fontsize=${titleSize}:line_spacing=8:fontcolor=white`,
     `drawtext=fontfile=${fontRegular}:text='${safeBody}':x=896:y=336:fontsize=${bodySize}:fontcolor=white@0.80`,
     `drawtext=fontfile=${fontBold}:text='dotnet new blazor -n FreshAgentBlazor':x=112:y=164:fontsize=22:fontcolor=white@0.82`,
-    `drawtext=fontfile=${fontRegular}:text='dotnet add package AgentBlazor --version 0.1.0-preview.11':x=112:y=208:fontsize=18:fontcolor=white@0.58`,
+    `drawtext=fontfile=${fontRegular}:text='dotnet add package AgentBlazor --version 0.2.0-preview.1':x=112:y=208:fontsize=18:fontcolor=white@0.58`,
     `drawtext=fontfile=${fontRegular}:text='Install. Mount one workflow. Watch the UI move.' :x=112:y=578:fontsize=22:fontcolor=white@0.72`,
     `fade=t=in:st=0:d=0.2,fade=t=out:st=${Math.max(0.1, config.duration - 0.25).toFixed(2)}:d=0.2`
   ].join(",");

--- a/scripts/video/record-cli-install-demo.sh
+++ b/scripts/video/record-cli-install-demo.sh
@@ -51,11 +51,11 @@ run_step "dotnet new blazor -n FreshAgentBlazor" \
 
 cd FreshAgentBlazor
 
-run_step "dotnet add package AgentBlazor --version 0.1.0-preview.11" \
-    dotnet add package AgentBlazor --version 0.1.0-preview.11
+run_step "dotnet add package AgentBlazor --version 0.2.0-preview.1" \
+    dotnet add package AgentBlazor --version 0.2.0-preview.1
 
-run_step "dotnet tool install AgentBlazor.Cli --tool-path ./.tools --version 0.1.0-preview.11" \
-    dotnet tool install AgentBlazor.Cli --tool-path ./.tools --version 0.1.0-preview.11
+run_step "dotnet tool install AgentBlazor.Cli --tool-path ./.tools --version 0.2.0-preview.1" \
+    dotnet tool install AgentBlazor.Cli --tool-path ./.tools --version 0.2.0-preview.1
 
 run_step "./.tools/agentblazor init ./FreshAgentBlazor.csproj --host FreshAgentBlazor" \
     ./.tools/agentblazor init ./FreshAgentBlazor.csproj --host FreshAgentBlazor

--- a/src/AgentBlazor.Cli.Analysis/ExistingAppScaffoldApplier.cs
+++ b/src/AgentBlazor.Cli.Analysis/ExistingAppScaffoldApplier.cs
@@ -301,7 +301,7 @@ public sealed class ExistingAppScaffoldApplier
             .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
             ?.InformationalVersion
             ?? typeof(ExistingAppScaffoldApplier).Assembly.GetName().Version?.ToString()
-            ?? "0.1.0-preview.11";
+            ?? "0.2.0-preview.1";
 
         return version.Split('+', 2)[0];
     }

--- a/src/AgentBlazor.Cli/PACKAGE_README.md
+++ b/src/AgentBlazor.Cli/PACKAGE_README.md
@@ -11,7 +11,7 @@ dotnet tool install --global AgentBlazor.Cli --prerelease
 If you want the exact current preview:
 
 ```bash
-dotnet tool install --global AgentBlazor.Cli --version 0.1.0-preview.11
+dotnet tool install --global AgentBlazor.Cli --version 0.2.0-preview.1
 ```
 
 Example:
@@ -28,3 +28,4 @@ Docs:
 
 - Repository: https://github.com/ashpeterson/AgentBlazor
 - Advanced CLI guide: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/advanced/cli.md
+- 0.2.0 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.0.md

--- a/src/AgentBlazor.Cli/Program.cs
+++ b/src/AgentBlazor.Cli/Program.cs
@@ -7,7 +7,7 @@ var version = typeof(ScaffoldCommand).Assembly
     .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
     ?.InformationalVersion
     ?? typeof(ScaffoldCommand).Assembly.GetName().Version?.ToString()
-    ?? "0.1.0-preview.11";
+    ?? "0.2.0-preview.1";
 version = version.Split('+', 2)[0];
 
 app.Configure(config =>

--- a/src/AgentBlazor.Client/PACKAGE_README.md
+++ b/src/AgentBlazor.Client/PACKAGE_README.md
@@ -11,7 +11,7 @@ dotnet add package AgentBlazor.Client --prerelease
 If you want the exact current preview:
 
 ```bash
-dotnet add package AgentBlazor.Client --version 0.1.0-preview.11
+dotnet add package AgentBlazor.Client --version 0.2.0-preview.1
 ```
 
 Server project:
@@ -35,3 +35,4 @@ Docs:
 
 - Repository: https://github.com/ashpeterson/AgentBlazor
 - Quickstart: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/quickstart.md
+- 0.2.0 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.0.md

--- a/src/AgentBlazor.Components/PACKAGE_README.md
+++ b/src/AgentBlazor.Components/PACKAGE_README.md
@@ -15,7 +15,7 @@ dotnet add package AgentBlazor --prerelease
 Current public releases are prerelease builds. If you prefer a pinned install, use:
 
 ```bash
-dotnet add package AgentBlazor --version 0.1.0-preview.11
+dotnet add package AgentBlazor --version 0.2.0-preview.1
 ```
 
 If `dotnet` still probes an old custom package source on your machine, remove or disable that source before testing the public NuGet install path.
@@ -85,6 +85,7 @@ Docs and demo:
 - Hosted demo: https://demo.agentblazor.com/demo/workflows/support-inbox
 - Structured error reference: https://demo.agentblazor.com/demo/workflows/runtime-probe
 - Quickstart: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/quickstart.md
+- 0.2.0 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.0.md
 - Recoverable capability errors: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/capability-errors.md
 - Optional EF Core schema exposure: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/entity-framework.md
 - Starter sample: https://github.com/ashpeterson/AgentBlazor/tree/master/samples/AgentBlazor.Starter

--- a/tests/AgentBlazor.Cli.Analysis.Tests/ExistingAppScaffoldPlannerTests.cs
+++ b/tests/AgentBlazor.Cli.Analysis.Tests/ExistingAppScaffoldPlannerTests.cs
@@ -151,7 +151,7 @@ public sealed class ExistingAppScaffoldPlannerTests : IDisposable
                     <ImplicitUsings>enable</ImplicitUsings>
                   </PropertyGroup>
                   <ItemGroup>
-                    <PackageReference Include="AgentBlazor" Version="0.1.0-preview.11" />
+                    <PackageReference Include="AgentBlazor" Version="0.2.0-preview.1" />
                   </ItemGroup>
                 </Project>
                 """,
@@ -186,7 +186,7 @@ public sealed class ExistingAppScaffoldPlannerTests : IDisposable
         var report = await new InstallReadinessAnalyzer().AnalyzeAsync(projectPath, hostProjectName: null);
 
         Assert.Contains(plan.Items, item => item.Id == "package-references" && item.Action == ScaffoldPlanAction.Update);
-        Assert.Contains("""<PackageReference Include="AgentBlazor" Version="0.1.0-preview.11" />""", projectText, StringComparison.Ordinal);
+        Assert.Contains("""<PackageReference Include="AgentBlazor" Version="0.2.0-preview.1" />""", projectText, StringComparison.Ordinal);
         Assert.Contains("""<PackageReference Include="MudBlazor" Version="9.0.0" />""", projectText, StringComparison.Ordinal);
         Assert.Contains(report.Checks, check => check.Id == "package-references" && check.Status == InstallReadinessStatus.Pass);
     }
@@ -250,7 +250,7 @@ public sealed class ExistingAppScaffoldPlannerTests : IDisposable
         Assert.Contains("""<PackageReference Include="MudBlazor" />""", projectText, StringComparison.Ordinal);
         Assert.DoesNotContain("PackageReference Include=\"AgentBlazor\" Version=", projectText, StringComparison.Ordinal);
         Assert.DoesNotContain("PackageReference Include=\"MudBlazor\" Version=", projectText, StringComparison.Ordinal);
-        Assert.Contains("""<PackageVersion Include="AgentBlazor" Version="0.1.0-preview.11" />""", centralPackagesText, StringComparison.Ordinal);
+        Assert.Contains("""<PackageVersion Include="AgentBlazor" Version="0.2.0-preview.1" />""", centralPackagesText, StringComparison.Ordinal);
         Assert.Contains("""<PackageVersion Include="MudBlazor" Version="9.0.0" />""", centralPackagesText, StringComparison.Ordinal);
     }
 

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -39,7 +39,7 @@ The external chat surface runner now verifies scaffold idempotency, submitted pr
 
 For external apps that require authentication before the main layout is reachable, set `AGENTBLAZOR_EXTERNAL_LOGIN_PATH`, `AGENTBLAZOR_EXTERNAL_LOGIN_USERNAME`, and `AGENTBLAZOR_EXTERNAL_LOGIN_PASSWORD`. The runner signs in before opening the installed floating widget and before visiting the injected surface harness. Set `AGENTBLAZOR_EXTERNAL_EXPECTED_TEXT` to require a protected-page marker before chat assertions begin; the matrix uses this for the CleanArchitecture `/identity/users` authenticated route.
 
-Current release context: `0.1.0-preview.11` is the current public prerelease. Local e2e runs still require a configured OpenAI, Azure OpenAI, or Ollama provider.
+Current release context: `0.2.0-preview.1` is the current public prerelease. Local e2e runs still require a configured OpenAI, Azure OpenAI, or Ollama provider.
 
 The real-usability runner requires an explicit live provider from environment variables. It intentionally does not treat demo `appsettings.json` sample values as proof that CI can reach a provider, because empty GitHub secrets or missing Ollama services otherwise produce misleading no-provider transcripts instead of a clear preflight failure.
 


### PR DESCRIPTION
## Summary
- bump package metadata and current install docs to 0.2.0-preview.1
- add canonical v0.2 release notes covering structured errors, EF schema exposure, demo logging, and install fixes
- link release notes from README and package READMEs

## Verification
- dotnet build AgentBlazor.slnx -c Release --no-restore -nologo
- dotnet test AgentBlazor.slnx -c Release --no-build -nologo
- dotnet pack src/AgentBlazor.Components/AgentBlazor.Components.csproj -c Release -nologo /p:PackageVersion=0.2.0-preview.1 /p:RestoreLockedMode=false /p:RestoreForceEvaluate=true
- inspected generated nupkg nuspec for version and releaseNotes