### PR TITLE
Add complete v0.2 release worklog

### DIFF
--- a/docs/releases/0.2.0-completed-work.md
+++ b/docs/releases/0.2.0-completed-work.md
@@ -1,0 +1,152 @@
+# AgentBlazor 0.2.0 Completed Work
+
+This is the fuller implementation log behind the 0.2 release notes. It records what changed across the public install path, hosted demo, structured error recovery, EF schema exposure, docs, and release packaging.
+
+Target package line: `0.2.0-preview.1` leading to `0.2.0`.
+
+## Public Install And Documentation
+
+- Moved the public install path to NuGet.org with pinned preview examples now pointing at `0.2.0-preview.1`.
+- Reworked the quickstart around a fresh `dotnet new blazor` app instead of a starter-project file swap.
+- Made the quickstart explicit that AgentBlazor does not create a responding agent by default; users must register at least one workflow or agent.
+- Documented the required interactive render mode setup for the Blazor shell.
+- Documented `AgentBlazorShell` as the simple provider/widget wrapper.
+- Fixed stale OpenAI model examples to use a real model string.
+- Added public docs for recoverable capability errors.
+- Added public docs for EF Core schema exposure.
+- Linked the hosted demo from README and package READMEs.
+- Added `0.2.0` release notes and updated NuGet package release notes metadata.
+
+Relevant PRs: #25, #30, #37, #38, #42, #48, #49.
+
+## Hosted Demo
+
+- Deployed a no-install public demo at `https://demo.agentblazor.com/`.
+- Added hosted demo links to public docs.
+- Shifted the public demo launchpad toward the support-inbox workflow instead of abstract enterprise workflow names.
+- Simplified the demo landing surface so a visitor sees a recognisable workflow first.
+- Added daily cost guard behavior for the hosted demo.
+- Added bot/framework route filtering so analytics do not count Blazor transport or obvious probes as user traffic.
+- Kept OpenAI API keys server-side through app configuration/env.
+- Kept sessions ephemeral; no user accounts or persistent conversations were added.
+
+Relevant PRs: #21, #25, #34, #35, #45.
+
+## Demo Logging And Analytics
+
+- Added structured JSONL chat request logging for demo turns.
+- Logged route, agent, session hash, prompt length, duration, status, response length, approval/clarification flags, planned action count, execution result count, and failed execution count.
+- Added file-backed traffic analytics for page views and unique visitor summaries.
+- Added protected `/internal/demo-logs` access for raw logs.
+- Added protected `/internal/demo-logs/summary` for compact traffic/chat summaries.
+- Added a browser viewer for protected demo logs.
+- Filtered framework routes and bot probes from summary analytics so the top routes reflect actual page traffic.
+- Added token and estimated-cost fields to chat logs where provider usage data is available.
+
+Relevant PRs: #26, #27, #28, #29, #34, #35.
+
+## Chat Surface And Demo Runtime Behavior
+
+- Added the ability to hide verbose execution details in chat surfaces.
+- Defaulted demo-facing execution details away from the primary user chat path so visitors see the conversation first.
+- Enforced route-locked agent resolution to avoid the wrong workflow handling prompts on another route.
+- Hardened queued/generated UI approval behavior so generated UI does not silently invoke approval-gated actions.
+- Rendered structured support reply drafts as first-class demo output instead of leaving users with raw execution metadata.
+- Increased widget usability for the quickstart/demo path and verified the chat shell smoke path.
+
+Relevant PRs: #20, #22, #23, #24, #37.
+
+## Structured Capability Error Recovery
+
+- Added structured `CapabilityResult` helper shapes for recoverable tool failures.
+- Covered missing arguments, invalid arguments, invalid argument shape, and recoverable failures.
+- Hardened reflection binding so common pre-invocation failures return structured capability results instead of raw exceptions.
+- Preserved cancellation behavior while making recoverable binding errors model-readable.
+- Added runtime adapter regressions for structured error propagation.
+- Hardened chat rendering of structured errors.
+- Added a runtime-probe demo path as a reference for structured error behavior.
+- Added recorder/reference artifacts for the structured error demo path.
+- Completed broader structured error regression verification and documented the verification status.
+
+Relevant PRs: #31, #32, #33, #39, #40, #41, #43, #44.
+
+## Entity Framework Core Schema Exposure
+
+- Added core schema abstractions for read-safe data schema metadata.
+- Added an in-memory schema catalog and registration path.
+- Added per-agent schema opt-in with `WithDataSchemas(...)`.
+- Injected opted-in schema metadata into runtime instructions as planning context.
+- Added optional `AgentBlazor.EntityFrameworkCore` package.
+- Added `AddEntitySchema<TContext>(...)` for explicit EF model metadata registration.
+- Required explicit entity/property allowlists.
+- Validated allowlisted properties against EF model metadata.
+- Documented that schema exposure is planning context only, not a query engine.
+- Added support-inbox demo/reference schema.
+- Added tests for EF schema registration and validation.
+- Updated solution, publish workflow, and smoke-test wiring to include the EF package.
+
+Relevant PRs: #46, #47, #48.
+
+## Package And Release Metadata
+
+- Bumped source package metadata to `0.2.0-preview.1`.
+- Updated CLI default/fallback version strings to `0.2.0-preview.1`.
+- Updated tests that assert scaffolded package versions.
+- Updated docs and demo docs that show pinned package/tool install commands.
+- Verified generated `AgentBlazor.0.2.0-preview.1.nupkg` contains the expected version and release notes.
+
+Relevant PR: #49.
+
+## Verification Completed During The Sprint
+
+- Full solution build passed.
+- Full solution test run passed.
+- Main package pack check passed for `0.2.0-preview.1`.
+- Generated NuGet metadata was inspected for version and release notes.
+- CleanTest quickstart verification was run during the install-path cleanup.
+- Hosted demo smoke checks were run after deployment.
+- Structured error demo/reference path was verified and recorded.
+- EF Core schema exposure tests were added and passed.
+
+## Still Open Or Deliberately Deferred
+
+- Issue #1 remains open for the v0.3 continuation: constrained query templates and result canvas rendering.
+- Issue #3 remains open for component-library support beyond MudBlazor.
+- EF schema exposure does not execute queries, generate LINQ, generate SQL, scan every `DbSet`, or grant write access.
+- AgentBlazor remains MudBlazor-first for built-in wrappers.
+- The CLI remains an advanced setup path, not the first-user story.
+- `AgentBlazor.Licensing` still exists in the repo and is not part of this release cleanup.
+- Older internal planning docs and some direct demo routes still exist while the public surface continues to narrow.
+
+## Merged Work Included
+
+- #20 Render structured support reply drafts.
+- #21 Add scalable demo scenario launchpad.
+- #22 Harden runtime queued and generated UI approval semantics.
+- #23 Enforce route-locked agent resolution and hide demo execution details.
+- #24 Allow hiding chat execution details.
+- #25 Add hosted demo links to public docs.
+- #26 Add demo structured request logging.
+- #27 Add demo traffic analytics logs.
+- #28 Filter framework routes from demo traffic analytics.
+- #29 Add browser viewer for demo logs.
+- #30 Start v0.2 week 1 commitments.
+- #31 Add structured capability error recovery.
+- #32 Harden structured error chat rendering.
+- #33 Add structured error runtime adapter regressions.
+- #34 Filter bot probes from demo analytics.
+- #35 Add daily cost guard for hosted demo.
+- #36 Update sprint status and structured error demo reference.
+- #37 Fix quickstart chat shell smoke path.
+- #38 Update sprint status after CleanTest verification.
+- #39 Add structured error runtime probe reference.
+- #40 Add structured error reference recorder.
+- #41 Wait for structured error recorder to settle.
+- #42 Verify structured error docs and package links.
+- #43 Mark structured error demo verification complete.
+- #44 Record broad structured error regression pass.
+- #45 Simplify public demo launchpad.
+- #46 Add schema-only entity exposure plan.
+- #47 Add schema-only EF entity exposure.
+- #48 Document EF schema exposure.
+- #49 Prepare v0.2 preview release notes.

--- a/docs/releases/0.2.0.md
+++ b/docs/releases/0.2.0.md
@@ -4,6 +4,8 @@ Target package line: `0.2.0-preview.1` leading to `0.2.0`.
 
 AgentBlazor 0.2 focuses on making the package-first path credible: recoverable tool errors, explicit EF Core schema context for planning, a simpler hosted demo, and observable demo traffic/chat usage.
 
+For a fuller implementation log, see [0.2.0 completed work](0.2.0-completed-work.md).
+
 ## Highlights
 
 - Structured capability errors: `CapabilityResult` now has explicit recoverable result shapes for missing arguments, invalid arguments, invalid argument shape, and recoverable failures. The reflection binding layer normalizes common binding failures before method invocation, and the chat/runtime path carries summaries, next actions, warnings, and outputs forward so the model can recover instead of spiraling on raw exception text.


### PR DESCRIPTION
## Summary
- add a fuller v0.2 completed-work document covering install/docs, hosted demo, logging, chat/runtime behavior, structured errors, EF schema exposure, and release metadata
- link the worklog from the main v0.2 release notes

## Verification
- git diff --check