### PR TITLE
Fix EF package for v0.2 preview 2

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
 
   <!-- Common package metadata for all AgentBlazor packages -->
   <PropertyGroup>
-    <Version>0.2.0-preview.1</Version>
+    <Version>0.2.0-preview.2</Version>
     <Authors>Ash Peterson</Authors>
     <Company>AgentBlazor</Company>
     <Copyright>Copyright (c) 2026 Ash Peterson</Copyright>

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Try the hosted demo:
 ## Install
 
 ```bash
-dotnet add package AgentBlazor --version 0.2.0-preview.1
+dotnet add package AgentBlazor --version 0.2.0-preview.2
 ```
 
 The CLI is optional. Keep it out of the critical path unless you want scaffold help for an existing app.

--- a/demo/AgentBlazor.Demo/Components/Pages/Docs/CliGuide.razor
+++ b/demo/AgentBlazor.Demo/Components/Pages/Docs/CliGuide.razor
@@ -20,8 +20,8 @@
             </div>
         </div>
 
-        <pre class="docs-code"><code>dotnet tool install --global AgentBlazor.Cli --version 0.2.0-preview.1
-dotnet tool update --global AgentBlazor.Cli --version 0.2.0-preview.1</code></pre>
+        <pre class="docs-code"><code>dotnet tool install --global AgentBlazor.Cli --version 0.2.0-preview.2
+dotnet tool update --global AgentBlazor.Cli --version 0.2.0-preview.2</code></pre>
     </section>
 
     <section class="docs-section">

--- a/demo/AgentBlazor.Demo/Components/Pages/Docs/DocsHome.razor
+++ b/demo/AgentBlazor.Demo/Components/Pages/Docs/DocsHome.razor
@@ -40,7 +40,7 @@
             </div>
         </div>
 
-        <pre class="docs-code"><code>dotnet add package AgentBlazor --version 0.2.0-preview.1
+        <pre class="docs-code"><code>dotnet add package AgentBlazor --version 0.2.0-preview.2
 builder.Services.AddAgentBlazor(...)
 app.MapAgentBlazorEndpoints()
 Render one chat surface on one route

--- a/demo/AgentBlazor.Demo/Components/Pages/Docs/GettingStarted.razor
+++ b/demo/AgentBlazor.Demo/Components/Pages/Docs/GettingStarted.razor
@@ -20,7 +20,7 @@
             </div>
         </div>
 
-        <pre class="docs-code"><code>dotnet add ./src/MyBlazorApp/MyBlazorApp.csproj package AgentBlazor --version 0.2.0-preview.1</code></pre>
+        <pre class="docs-code"><code>dotnet add ./src/MyBlazorApp/MyBlazorApp.csproj package AgentBlazor --version 0.2.0-preview.2</code></pre>
     </section>
 
     <section class="docs-section">
@@ -30,7 +30,7 @@
             </div>
         </div>
 
-        <pre class="docs-code"><code>dotnet add ./src/MyBlazorApp/MyBlazorApp.csproj package AgentBlazor --version 0.2.0-preview.1
+        <pre class="docs-code"><code>dotnet add ./src/MyBlazorApp/MyBlazorApp.csproj package AgentBlazor --version 0.2.0-preview.2
 
 builder.Services.AddMudServices();
 builder.Services.AddAgentBlazor(options =&gt; { ... });
@@ -81,7 +81,7 @@ app.MapAgentBlazorEndpoints();</code></pre>
             </div>
         </div>
 
-        <pre class="docs-code"><code>dotnet tool install --global AgentBlazor.Cli --version 0.2.0-preview.1
+        <pre class="docs-code"><code>dotnet tool install --global AgentBlazor.Cli --version 0.2.0-preview.2
 agentblazor init ./MySolution.slnx --host MyBlazorApp
 agentblazor scaffold ./MySolution.slnx --host MyBlazorApp --provider openai --diff
 agentblazor scaffold ./MySolution.slnx --host MyBlazorApp --provider openai --approve
@@ -96,7 +96,7 @@ dotnet build ./MySolution.slnx --no-restore -nologo</code></pre>
             </div>
         </div>
 
-        <pre class="docs-code"><code>dotnet add ./src/MyBlazorApp.Client/MyBlazorApp.Client.csproj package AgentBlazor.Client --version 0.2.0-preview.1
+        <pre class="docs-code"><code>dotnet add ./src/MyBlazorApp.Client/MyBlazorApp.Client.csproj package AgentBlazor.Client --version 0.2.0-preview.2
 
 // Server
 app.MapAgentBlazorEndpoints();

--- a/demo/AgentBlazor.Demo/Components/Pages/Docs/Verification.razor
+++ b/demo/AgentBlazor.Demo/Components/Pages/Docs/Verification.razor
@@ -20,7 +20,7 @@
             </div>
         </div>
 
-        <pre class="docs-code"><code>dotnet add ./src/MyBlazorApp/MyBlazorApp.csproj package AgentBlazor --version 0.2.0-preview.1
+        <pre class="docs-code"><code>dotnet add ./src/MyBlazorApp/MyBlazorApp.csproj package AgentBlazor --version 0.2.0-preview.2
 dotnet build ./MySolution.slnx --nologo
 OpenAI__ApiKey=placeholder-key dotnet run --project ./src/MyBlazorApp/MyBlazorApp.csproj --no-launch-profile --urls http://127.0.0.1:5288
 Open the support route and submit one real prompt</code></pre>
@@ -35,7 +35,7 @@ Open the support route and submit one real prompt</code></pre>
 
         <pre class="docs-code"><code>dotnet new blazor -o FreshAgentBlazor
 cd FreshAgentBlazor
-dotnet add package AgentBlazor --version 0.2.0-preview.1
+dotnet add package AgentBlazor --version 0.2.0-preview.2
 dotnet build FreshAgentBlazor.csproj --nologo</code></pre>
     </section>
 
@@ -46,8 +46,8 @@ dotnet build FreshAgentBlazor.csproj --nologo</code></pre>
             </div>
         </div>
 
-        <pre class="docs-code"><code>dotnet add ./src/MyHostedServer/MyHostedServer.csproj package AgentBlazor --version 0.2.0-preview.1
-dotnet add ./src/MyHostedClient/MyHostedClient.csproj package AgentBlazor.Client --version 0.2.0-preview.1
+        <pre class="docs-code"><code>dotnet add ./src/MyHostedServer/MyHostedServer.csproj package AgentBlazor --version 0.2.0-preview.2
+dotnet add ./src/MyHostedClient/MyHostedClient.csproj package AgentBlazor.Client --version 0.2.0-preview.2
 
 // Server
 app.MapAgentBlazorEndpoints();

--- a/docs/advanced/cli.md
+++ b/docs/advanced/cli.md
@@ -11,7 +11,7 @@ Use it when:
 Current run order:
 
 ```bash
-dotnet tool install --global AgentBlazor.Cli --version 0.2.0-preview.1
+dotnet tool install --global AgentBlazor.Cli --version 0.2.0-preview.2
 agentblazor init ./MySolution.slnx --host MyBlazorApp
 agentblazor scaffold ./MySolution.slnx --host MyBlazorApp --provider openai --diff
 agentblazor scaffold ./MySolution.slnx --host MyBlazorApp --provider openai --approve

--- a/docs/beta-testing.md
+++ b/docs/beta-testing.md
@@ -20,7 +20,7 @@ Use a fresh app first. Do not start with an existing codebase.
 ```bash
 dotnet new blazor -o FreshAgentBlazor
 cd FreshAgentBlazor
-dotnet add package AgentBlazor --version 0.2.0-preview.1
+dotnet add package AgentBlazor --version 0.2.0-preview.2
 ```
 
 Then follow:
@@ -41,7 +41,7 @@ Compare against the hosted support-inbox demo if you want a known-running refere
 
 Please report pass or fail for each of these:
 
-1. `dotnet add package AgentBlazor --version 0.2.0-preview.1`
+1. `dotnet add package AgentBlazor --version 0.2.0-preview.2`
 2. `dotnet build`
 3. app starts with AgentBlazor assets loaded
 4. chat surface opens

--- a/docs/entity-framework.md
+++ b/docs/entity-framework.md
@@ -13,8 +13,8 @@ dotnet add package AgentBlazor.EntityFrameworkCore --prerelease
 If you pin versions, use the same AgentBlazor version for the runtime and EF package:
 
 ```bash
-dotnet add package AgentBlazor --version 0.2.0-preview.1
-dotnet add package AgentBlazor.EntityFrameworkCore --version 0.2.0-preview.1
+dotnet add package AgentBlazor --version 0.2.0-preview.2
+dotnet add package AgentBlazor.EntityFrameworkCore --version 0.2.0-preview.2
 ```
 
 ## DbContext Setup

--- a/docs/internal/beta-tester-runbook.md
+++ b/docs/internal/beta-tester-runbook.md
@@ -80,7 +80,7 @@ For each tester capture:
 If a tester asks what to do, answer with this exact path:
 
 1. create a fresh Blazor app
-2. run `dotnet add package AgentBlazor --version 0.2.0-preview.1`
+2. run `dotnet add package AgentBlazor --version 0.2.0-preview.2`
 3. follow `docs/quickstart.md`
 4. test the support-inbox shape only
 5. submit feedback through one of the issue forms

--- a/docs/internal/launch-content/blog-post.md
+++ b/docs/internal/launch-content/blog-post.md
@@ -37,7 +37,7 @@ What it does not try to do at launch:
 The first install path is now the normal one:
 
 ```bash
-dotnet add package AgentBlazor --version 0.2.0-preview.1
+dotnet add package AgentBlazor --version 0.2.0-preview.2
 ```
 
 Then wire `AddAgentBlazor(...)`, map `MapAgentBlazorEndpoints()`, add one capability class, and mount one chat surface.

--- a/docs/internal/launch-content/reddit-r-dotnet.md
+++ b/docs/internal/launch-content/reddit-r-dotnet.md
@@ -19,7 +19,7 @@ What it is:
 Current public package:
 
 ```bash
-dotnet add package AgentBlazor --version 0.2.0-preview.1
+dotnet add package AgentBlazor --version 0.2.0-preview.2
 ```
 
 Current public demo:

--- a/docs/internal/launch-content/social-thread.md
+++ b/docs/internal/launch-content/social-thread.md
@@ -38,7 +38,7 @@ Post 4:
 Install path:
 
 ```bash
-dotnet add package AgentBlazor --version 0.2.0-preview.1
+dotnet add package AgentBlazor --version 0.2.0-preview.2
 ```
 
 CLI exists, but it is the advanced path, not the headline.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,6 +1,6 @@
 # Quickstart
 
-Get one working AgentBlazor chat widget into a fresh Blazor app. Tested against a clean `dotnet new blazor` project with `AgentBlazor 0.2.0-preview.1`.
+Get one working AgentBlazor chat widget into a fresh Blazor app. Tested against a clean `dotnet new blazor` project with `AgentBlazor 0.2.0-preview.2`.
 
 Hosted demo: https://demo.agentblazor.com/demo/workflows/support-inbox
 
@@ -9,7 +9,7 @@ AgentBlazor does not create a responding agent by default. You must register at 
 ## 1. Install
 
 ```bash
-dotnet add package AgentBlazor --version 0.2.0-preview.1
+dotnet add package AgentBlazor --version 0.2.0-preview.2
 ```
 
 ## 2. Program.cs
@@ -171,7 +171,7 @@ Say hello
 ## Notes
 
 - `MapAgentBlazorEndpoints()` is required. Without it, the widget can render but cannot call the runtime.
-- `AgentBlazorShell` includes the widget in `0.2.0-preview.1`.
+- `AgentBlazorShell` includes the widget in `0.2.0-preview.2`.
 - A registered workflow is required for the chat to respond.
 
 ## Next

--- a/docs/releases/0.2.0-completed-work.md
+++ b/docs/releases/0.2.0-completed-work.md
@@ -2,11 +2,11 @@
 
 This is the fuller implementation log behind the 0.2 release notes. It records what changed across the public install path, hosted demo, structured error recovery, EF schema exposure, docs, and release packaging.
 
-Target package line: `0.2.0-preview.1` leading to `0.2.0`.
+Target package line: `0.2.0-preview.2` leading to `0.2.0`.
 
 ## Public Install And Documentation
 
-- Moved the public install path to NuGet.org with pinned preview examples now pointing at `0.2.0-preview.1`.
+- Moved the public install path to NuGet.org with pinned preview examples now pointing at `0.2.0-preview.2`.
 - Reworked the quickstart around a fresh `dotnet new blazor` app instead of a starter-project file swap.
 - Made the quickstart explicit that AgentBlazor does not create a responding agent by default; users must register at least one workflow or agent.
 - Documented the required interactive render mode setup for the Blazor shell.
@@ -89,11 +89,11 @@ Relevant PRs: #46, #47, #48.
 
 ## Package And Release Metadata
 
-- Bumped source package metadata to `0.2.0-preview.1`.
-- Updated CLI default/fallback version strings to `0.2.0-preview.1`.
+- Bumped source package metadata to `0.2.0-preview.2`.
+- Updated CLI default/fallback version strings to `0.2.0-preview.2`.
 - Updated tests that assert scaffolded package versions.
 - Updated docs and demo docs that show pinned package/tool install commands.
-- Verified generated `AgentBlazor.0.2.0-preview.1.nupkg` contains the expected version and release notes.
+- Verified generated `AgentBlazor.0.2.0-preview.2.nupkg` contains the expected version and release notes.
 
 Relevant PR: #49.
 
@@ -101,7 +101,7 @@ Relevant PR: #49.
 
 - Full solution build passed.
 - Full solution test run passed.
-- Main package pack check passed for `0.2.0-preview.1`.
+- Main package pack check passed for `0.2.0-preview.2`.
 - Generated NuGet metadata was inspected for version and release notes.
 - CleanTest quickstart verification was run during the install-path cleanup.
 - Hosted demo smoke checks were run after deployment.

--- a/docs/releases/0.2.0.md
+++ b/docs/releases/0.2.0.md
@@ -1,6 +1,6 @@
 # AgentBlazor 0.2.0 Release Notes
 
-Target package line: `0.2.0-preview.1` leading to `0.2.0`.
+Target package line: `0.2.0-preview.2` leading to `0.2.0`.
 
 AgentBlazor 0.2 focuses on making the package-first path credible: recoverable tool errors, explicit EF Core schema context for planning, a simpler hosted demo, and observable demo traffic/chat usage.
 
@@ -29,7 +29,7 @@ See [Recoverable capability errors](../capability-errors.md).
 Install the optional package:
 
 ```bash
-dotnet add package AgentBlazor.EntityFrameworkCore --version 0.2.0-preview.1
+dotnet add package AgentBlazor.EntityFrameworkCore --version 0.2.0-preview.2
 ```
 
 Register only safe entity/property metadata:
@@ -77,7 +77,7 @@ The protected `/internal/demo-logs` and `/internal/demo-logs/summary` endpoints 
 Pinned preview install:
 
 ```bash
-dotnet add package AgentBlazor --version 0.2.0-preview.1
+dotnet add package AgentBlazor --version 0.2.0-preview.2
 ```
 
 Current quickstart:

--- a/samples/AgentBlazor.Starter/README.md
+++ b/samples/AgentBlazor.Starter/README.md
@@ -34,5 +34,5 @@ Inside this repo, the starter defaults to local source-project references so the
 To validate the published package path from inside the repo:
 
 ```powershell
-dotnet run --project samples/AgentBlazor.Starter/AgentBlazor.Starter.csproj -p:UseLocalAgentBlazorSource=false -p:AgentBlazorPackageVersion=0.2.0-preview.1
+dotnet run --project samples/AgentBlazor.Starter/AgentBlazor.Starter.csproj -p:UseLocalAgentBlazorSource=false -p:AgentBlazorPackageVersion=0.2.0-preview.2
 ```

--- a/scripts/video/compose-product-videos.cjs
+++ b/scripts/video/compose-product-videos.cjs
@@ -114,7 +114,7 @@ function renderTitleCard(outputPath, config) {
     `drawtext=fontfile=${fontBold}:text='${safeTitle}':x=896:y=208:fontsize=${titleSize}:line_spacing=8:fontcolor=white`,
     `drawtext=fontfile=${fontRegular}:text='${safeBody}':x=896:y=336:fontsize=${bodySize}:fontcolor=white@0.80`,
     `drawtext=fontfile=${fontBold}:text='dotnet new blazor -n FreshAgentBlazor':x=112:y=164:fontsize=22:fontcolor=white@0.82`,
-    `drawtext=fontfile=${fontRegular}:text='dotnet add package AgentBlazor --version 0.2.0-preview.1':x=112:y=208:fontsize=18:fontcolor=white@0.58`,
+    `drawtext=fontfile=${fontRegular}:text='dotnet add package AgentBlazor --version 0.2.0-preview.2':x=112:y=208:fontsize=18:fontcolor=white@0.58`,
     `drawtext=fontfile=${fontRegular}:text='Install. Mount one workflow. Watch the UI move.' :x=112:y=578:fontsize=22:fontcolor=white@0.72`,
     `fade=t=in:st=0:d=0.2,fade=t=out:st=${Math.max(0.1, config.duration - 0.25).toFixed(2)}:d=0.2`
   ].join(",");

--- a/scripts/video/record-cli-install-demo.sh
+++ b/scripts/video/record-cli-install-demo.sh
@@ -51,11 +51,11 @@ run_step "dotnet new blazor -n FreshAgentBlazor" \
 
 cd FreshAgentBlazor
 
-run_step "dotnet add package AgentBlazor --version 0.2.0-preview.1" \
-    dotnet add package AgentBlazor --version 0.2.0-preview.1
+run_step "dotnet add package AgentBlazor --version 0.2.0-preview.2" \
+    dotnet add package AgentBlazor --version 0.2.0-preview.2
 
-run_step "dotnet tool install AgentBlazor.Cli --tool-path ./.tools --version 0.2.0-preview.1" \
-    dotnet tool install AgentBlazor.Cli --tool-path ./.tools --version 0.2.0-preview.1
+run_step "dotnet tool install AgentBlazor.Cli --tool-path ./.tools --version 0.2.0-preview.2" \
+    dotnet tool install AgentBlazor.Cli --tool-path ./.tools --version 0.2.0-preview.2
 
 run_step "./.tools/agentblazor init ./FreshAgentBlazor.csproj --host FreshAgentBlazor" \
     ./.tools/agentblazor init ./FreshAgentBlazor.csproj --host FreshAgentBlazor

--- a/src/AgentBlazor.Cli.Analysis/ExistingAppScaffoldApplier.cs
+++ b/src/AgentBlazor.Cli.Analysis/ExistingAppScaffoldApplier.cs
@@ -301,7 +301,7 @@ public sealed class ExistingAppScaffoldApplier
             .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
             ?.InformationalVersion
             ?? typeof(ExistingAppScaffoldApplier).Assembly.GetName().Version?.ToString()
-            ?? "0.2.0-preview.1";
+            ?? "0.2.0-preview.2";
 
         return version.Split('+', 2)[0];
     }

--- a/src/AgentBlazor.Cli/PACKAGE_README.md
+++ b/src/AgentBlazor.Cli/PACKAGE_README.md
@@ -11,7 +11,7 @@ dotnet tool install --global AgentBlazor.Cli --prerelease
 If you want the exact current preview:
 
 ```bash
-dotnet tool install --global AgentBlazor.Cli --version 0.2.0-preview.1
+dotnet tool install --global AgentBlazor.Cli --version 0.2.0-preview.2
 ```
 
 Example:

--- a/src/AgentBlazor.Cli/Program.cs
+++ b/src/AgentBlazor.Cli/Program.cs
@@ -7,7 +7,7 @@ var version = typeof(ScaffoldCommand).Assembly
     .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
     ?.InformationalVersion
     ?? typeof(ScaffoldCommand).Assembly.GetName().Version?.ToString()
-    ?? "0.2.0-preview.1";
+    ?? "0.2.0-preview.2";
 version = version.Split('+', 2)[0];
 
 app.Configure(config =>

--- a/src/AgentBlazor.Client/PACKAGE_README.md
+++ b/src/AgentBlazor.Client/PACKAGE_README.md
@@ -11,7 +11,7 @@ dotnet add package AgentBlazor.Client --prerelease
 If you want the exact current preview:
 
 ```bash
-dotnet add package AgentBlazor.Client --version 0.2.0-preview.1
+dotnet add package AgentBlazor.Client --version 0.2.0-preview.2
 ```
 
 Server project:

--- a/src/AgentBlazor.Components/PACKAGE_README.md
+++ b/src/AgentBlazor.Components/PACKAGE_README.md
@@ -15,7 +15,7 @@ dotnet add package AgentBlazor --prerelease
 Current public releases are prerelease builds. If you prefer a pinned install, use:
 
 ```bash
-dotnet add package AgentBlazor --version 0.2.0-preview.1
+dotnet add package AgentBlazor --version 0.2.0-preview.2
 ```
 
 If `dotnet` still probes an old custom package source on your machine, remove or disable that source before testing the public NuGet install path.

--- a/src/AgentBlazor.EntityFrameworkCore/AgentBlazor.EntityFrameworkCore.csproj
+++ b/src/AgentBlazor.EntityFrameworkCore/AgentBlazor.EntityFrameworkCore.csproj
@@ -9,10 +9,11 @@
     <PackageTags>blazor;aspnetcore;ai;agents;entity-framework;efcore;schema</PackageTags>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>false</IncludeSymbols>
+    <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);IncludeProjectReferenceBuildOutputs</TargetsForTfmSpecificBuildOutput>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AgentBlazor.Core\AgentBlazor.Core.csproj" />
+    <ProjectReference Include="..\AgentBlazor.Core\AgentBlazor.Core.csproj" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>
@@ -23,5 +24,11 @@
     <None Include="README.md" Pack="true" PackagePath="\" />
     <None Include="..\AgentBlazor.Components\icon.png" Pack="true" PackagePath="" Link="icon.png" />
   </ItemGroup>
+
+  <Target Name="IncludeProjectReferenceBuildOutputs" DependsOnTargets="ResolveReferences">
+    <ItemGroup>
+      <BuildOutputInPackage Include="@(ReferenceCopyLocalPaths->WithMetadataValue('ReferenceSourceTarget', 'ProjectReference'))" />
+    </ItemGroup>
+  </Target>
 
 </Project>

--- a/tests/AgentBlazor.Cli.Analysis.Tests/ExistingAppScaffoldPlannerTests.cs
+++ b/tests/AgentBlazor.Cli.Analysis.Tests/ExistingAppScaffoldPlannerTests.cs
@@ -151,7 +151,7 @@ public sealed class ExistingAppScaffoldPlannerTests : IDisposable
                     <ImplicitUsings>enable</ImplicitUsings>
                   </PropertyGroup>
                   <ItemGroup>
-                    <PackageReference Include="AgentBlazor" Version="0.2.0-preview.1" />
+                    <PackageReference Include="AgentBlazor" Version="0.2.0-preview.2" />
                   </ItemGroup>
                 </Project>
                 """,
@@ -186,7 +186,7 @@ public sealed class ExistingAppScaffoldPlannerTests : IDisposable
         var report = await new InstallReadinessAnalyzer().AnalyzeAsync(projectPath, hostProjectName: null);
 
         Assert.Contains(plan.Items, item => item.Id == "package-references" && item.Action == ScaffoldPlanAction.Update);
-        Assert.Contains("""<PackageReference Include="AgentBlazor" Version="0.2.0-preview.1" />""", projectText, StringComparison.Ordinal);
+        Assert.Contains("""<PackageReference Include="AgentBlazor" Version="0.2.0-preview.2" />""", projectText, StringComparison.Ordinal);
         Assert.Contains("""<PackageReference Include="MudBlazor" Version="9.0.0" />""", projectText, StringComparison.Ordinal);
         Assert.Contains(report.Checks, check => check.Id == "package-references" && check.Status == InstallReadinessStatus.Pass);
     }
@@ -250,7 +250,7 @@ public sealed class ExistingAppScaffoldPlannerTests : IDisposable
         Assert.Contains("""<PackageReference Include="MudBlazor" />""", projectText, StringComparison.Ordinal);
         Assert.DoesNotContain("PackageReference Include=\"AgentBlazor\" Version=", projectText, StringComparison.Ordinal);
         Assert.DoesNotContain("PackageReference Include=\"MudBlazor\" Version=", projectText, StringComparison.Ordinal);
-        Assert.Contains("""<PackageVersion Include="AgentBlazor" Version="0.2.0-preview.1" />""", centralPackagesText, StringComparison.Ordinal);
+        Assert.Contains("""<PackageVersion Include="AgentBlazor" Version="0.2.0-preview.2" />""", centralPackagesText, StringComparison.Ordinal);
         Assert.Contains("""<PackageVersion Include="MudBlazor" Version="9.0.0" />""", centralPackagesText, StringComparison.Ordinal);
     }
 

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -39,7 +39,7 @@ The external chat surface runner now verifies scaffold idempotency, submitted pr
 
 For external apps that require authentication before the main layout is reachable, set `AGENTBLAZOR_EXTERNAL_LOGIN_PATH`, `AGENTBLAZOR_EXTERNAL_LOGIN_USERNAME`, and `AGENTBLAZOR_EXTERNAL_LOGIN_PASSWORD`. The runner signs in before opening the installed floating widget and before visiting the injected surface harness. Set `AGENTBLAZOR_EXTERNAL_EXPECTED_TEXT` to require a protected-page marker before chat assertions begin; the matrix uses this for the CleanArchitecture `/identity/users` authenticated route.
 
-Current release context: `0.2.0-preview.1` is the current public prerelease. Local e2e runs still require a configured OpenAI, Azure OpenAI, or Ollama provider.
+Current release context: `0.2.0-preview.2` is the current public prerelease. Local e2e runs still require a configured OpenAI, Azure OpenAI, or Ollama provider.
 
 The real-usability runner requires an explicit live provider from environment variables. It intentionally does not treat demo `appsettings.json` sample values as proof that CI can reach a provider, because empty GitHub secrets or missing Ollama services otherwise produce misleading no-provider transcripts instead of a clear preflight failure.
 


### PR DESCRIPTION
## Summary
- bump current preview references to 0.2.0-preview.2 because 0.2.0-preview.1 is immutable on NuGet
- fix AgentBlazor.EntityFrameworkCore packaging so it bundles internal AgentBlazor assemblies instead of depending on unpublished AgentBlazor.Core
- keep public docs and tests aligned to preview.2

## Verification
- dotnet pack src/AgentBlazor.EntityFrameworkCore/AgentBlazor.EntityFrameworkCore.csproj -c Release -nologo /p:PackageVersion=0.2.0-preview.2 /p:RestoreLockedMode=false /p:RestoreForceEvaluate=true
- inspected EF nupkg nuspec: no AgentBlazor.Core dependency
- inspected EF nupkg lib files: includes AgentBlazor.Core.dll and AgentBlazor.Licensing.dll
- dotnet build AgentBlazor.slnx -c Release --no-restore -nologo
- dotnet test AgentBlazor.slnx -c Release --no-build -nologo