### PR TITLE
Document v0.2 preview 2 NuGet guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Try the hosted demo:
 dotnet add package AgentBlazor --version 0.2.0-preview.2
 ```
 
+Use `0.2.0-preview.2` or later. `0.2.0-preview.1` was superseded after publish because the optional EF package referenced an unpublished internal package.
+
 The CLI is optional. Keep it out of the critical path unless you want scaffold help for an existing app.
 
 ## Dependency Stability
@@ -115,7 +117,7 @@ dotnet run --project samples/AgentBlazor.Starter/AgentBlazor.Starter.csproj
 If your app uses EF Core, install `AgentBlazor.EntityFrameworkCore` to expose selected entity shapes as planning context:
 
 ```bash
-dotnet add package AgentBlazor.EntityFrameworkCore --prerelease
+dotnet add package AgentBlazor.EntityFrameworkCore --version 0.2.0-preview.2
 ```
 
 This is schema-only. It helps an agent understand safe entity fields, but it does not execute queries, generate LINQ or SQL, scan every `DbSet`, or grant write access. Data access still goes through your typed `[AgentAction]` methods.

--- a/docs/entity-framework.md
+++ b/docs/entity-framework.md
@@ -17,6 +17,8 @@ dotnet add package AgentBlazor --version 0.2.0-preview.2
 dotnet add package AgentBlazor.EntityFrameworkCore --version 0.2.0-preview.2
 ```
 
+Use `0.2.0-preview.2` or later. `0.2.0-preview.1` was superseded after publish because this optional package referenced an unpublished internal package.
+
 ## DbContext Setup
 
 Use `IDbContextFactory<TContext>`. This follows the Blazor EF Core guidance to create a context per operation instead of sharing one context across interactive UI work.

--- a/docs/releases/0.2.0-completed-work.md
+++ b/docs/releases/0.2.0-completed-work.md
@@ -4,6 +4,8 @@ This is the fuller implementation log behind the 0.2 release notes. It records w
 
 Target package line: `0.2.0-preview.2` leading to `0.2.0`.
 
+Published package note: `0.2.0-preview.1` was superseded by `0.2.0-preview.2` after public-feed smoke testing exposed that `AgentBlazor.EntityFrameworkCore` depended on unpublished `AgentBlazor.Core` package metadata. Preview 2 fixes the EF package by bundling the required internal assemblies and is the version to test.
+
 ## Public Install And Documentation
 
 - Moved the public install path to NuGet.org with pinned preview examples now pointing at `0.2.0-preview.2`.
@@ -16,8 +18,9 @@ Target package line: `0.2.0-preview.2` leading to `0.2.0`.
 - Added public docs for EF Core schema exposure.
 - Linked the hosted demo from README and package READMEs.
 - Added `0.2.0` release notes and updated NuGet package release notes metadata.
+- Superseded `0.2.0-preview.1` with `0.2.0-preview.2` after public NuGet smoke testing caught the EF packaging issue.
 
-Relevant PRs: #25, #30, #37, #38, #42, #48, #49.
+Relevant PRs: #25, #30, #37, #38, #42, #48, #49, #51.
 
 ## Hosted Demo
 
@@ -84,8 +87,9 @@ Relevant PRs: #31, #32, #33, #39, #40, #41, #43, #44.
 - Added support-inbox demo/reference schema.
 - Added tests for EF schema registration and validation.
 - Updated solution, publish workflow, and smoke-test wiring to include the EF package.
+- Fixed the published EF package shape so it no longer restores an unpublished `AgentBlazor.Core` package from NuGet.
 
-Relevant PRs: #46, #47, #48.
+Relevant PRs: #46, #47, #48, #51.
 
 ## Package And Release Metadata
 
@@ -94,8 +98,10 @@ Relevant PRs: #46, #47, #48.
 - Updated tests that assert scaffolded package versions.
 - Updated docs and demo docs that show pinned package/tool install commands.
 - Verified generated `AgentBlazor.0.2.0-preview.2.nupkg` contains the expected version and release notes.
+- Verified `AgentBlazor.EntityFrameworkCore.0.2.0-preview.2.nupkg` has no NuGet dependency on `AgentBlazor.Core` and includes the required internal assemblies.
+- Verified a fresh Blazor app installs `AgentBlazor` and `AgentBlazor.EntityFrameworkCore` `0.2.0-preview.2` from public NuGet and builds.
 
-Relevant PR: #49.
+Relevant PRs: #49, #51.
 
 ## Verification Completed During The Sprint
 
@@ -107,6 +113,7 @@ Relevant PR: #49.
 - Hosted demo smoke checks were run after deployment.
 - Structured error demo/reference path was verified and recorded.
 - EF Core schema exposure tests were added and passed.
+- Public NuGet smoke passed for `AgentBlazor` plus `AgentBlazor.EntityFrameworkCore` `0.2.0-preview.2` in a fresh Blazor app.
 
 ## Still Open Or Deliberately Deferred
 
@@ -150,3 +157,5 @@ Relevant PR: #49.
 - #47 Add schema-only EF entity exposure.
 - #48 Document EF schema exposure.
 - #49 Prepare v0.2 preview release notes.
+- #50 Add complete v0.2 release worklog.
+- #51 Fix EF package for v0.2 preview 2.

--- a/docs/releases/0.2.0.md
+++ b/docs/releases/0.2.0.md
@@ -4,6 +4,8 @@ Target package line: `0.2.0-preview.2` leading to `0.2.0`.
 
 AgentBlazor 0.2 focuses on making the package-first path credible: recoverable tool errors, explicit EF Core schema context for planning, a simpler hosted demo, and observable demo traffic/chat usage.
 
+Use `0.2.0-preview.2` for testing. `0.2.0-preview.1` was published first, but was superseded after the optional `AgentBlazor.EntityFrameworkCore` package was found to depend on unpublished internal `AgentBlazor.Core` package metadata. `0.2.0-preview.2` bundles the required internal assemblies and passed a fresh public NuGet install/build smoke.
+
 For a fuller implementation log, see [0.2.0 completed work](0.2.0-completed-work.md).
 
 ## Highlights
@@ -78,6 +80,12 @@ Pinned preview install:
 
 ```bash
 dotnet add package AgentBlazor --version 0.2.0-preview.2
+```
+
+Optional EF schema package:
+
+```bash
+dotnet add package AgentBlazor.EntityFrameworkCore --version 0.2.0-preview.2
 ```
 
 Current quickstart:

--- a/src/AgentBlazor.Components/PACKAGE_README.md
+++ b/src/AgentBlazor.Components/PACKAGE_README.md
@@ -18,6 +18,8 @@ Current public releases are prerelease builds. If you prefer a pinned install, u
 dotnet add package AgentBlazor --version 0.2.0-preview.2
 ```
 
+Use `0.2.0-preview.2` or later. `0.2.0-preview.1` was superseded after publish because the optional EF package referenced an unpublished internal package.
+
 If `dotnet` still probes an old custom package source on your machine, remove or disable that source before testing the public NuGet install path.
 
 Minimal setup:

--- a/src/AgentBlazor.EntityFrameworkCore/README.md
+++ b/src/AgentBlazor.EntityFrameworkCore/README.md
@@ -10,6 +10,14 @@ Install:
 dotnet add package AgentBlazor.EntityFrameworkCore --prerelease
 ```
 
+Pinned preview:
+
+```bash
+dotnet add package AgentBlazor.EntityFrameworkCore --version 0.2.0-preview.2
+```
+
+Use `0.2.0-preview.2` or later. `0.2.0-preview.1` was superseded after publish because this optional package referenced an unpublished internal package.
+
 Register your `DbContext` with `IDbContextFactory<TContext>`:
 
 ```csharp


### PR DESCRIPTION
## Summary
- document that 0.2.0-preview.2 is the version to test
- explain why 0.2.0-preview.1 was superseded after the EF package smoke found the unpublished internal package dependency
- add pinned EF package install guidance to README, EF docs, package README, and release notes

## Verification
- git diff --check
- rg checked public docs for preview guidance