### PR TITLE
Add v0.2 release test plan

### DIFF
--- a/docs/beta-testing.md
+++ b/docs/beta-testing.md
@@ -27,6 +27,8 @@ Then follow:
 
 - [Quickstart](quickstart.md)
 
+For a fuller release validation pass that includes EF Core schema exposure, structured errors, hosted demo checks, and package smoke tests, use the [0.2.0 release test plan](releases/0.2.0-test-plan.md).
+
 Use the support-inbox shape only:
 
 - one workflow

--- a/docs/releases/0.2.0-test-plan.md
+++ b/docs/releases/0.2.0-test-plan.md
@@ -1,0 +1,441 @@
+# AgentBlazor 0.2.0 Release Test Plan
+
+Target package line: `0.2.0-preview.2` leading to `0.2.0`.
+
+Use this plan to validate the release from a clean consumer app, not from project references. The goal is to prove that a new Blazor developer can install AgentBlazor from NuGet, wire one workflow, see the chat widget, use EF Core schema exposure, and observe structured error recovery.
+
+## Release Gate
+
+The release is not ready for `0.2.0` stable until these checks pass:
+
+- Fresh Blazor app installs `AgentBlazor 0.2.0-preview.2` from NuGet.org.
+- Fresh Blazor app builds and starts after following the quickstart.
+- Chat widget renders, opens, and lists the registered workflow.
+- With a real OpenAI key, `Say hello` produces the expected workflow result.
+- EF schema package installs from NuGet.org and builds in the same app.
+- EF schema registration is explicit, allowlisted, and does not require unpublished packages.
+- Structured error workflow returns recoverable `CapabilityResult` output for invalid/missing input.
+- Hosted demo still loads and support-inbox prompts work.
+- `0.2.0-preview.1` is unlisted on NuGet.org.
+
+## Test Environment
+
+Run these tests outside the repo checkout.
+
+Required:
+
+- .NET SDK from `global.json` or newer compatible preview SDK.
+- NuGet.org available.
+- No repo-local package source.
+- OpenAI API key for the end-to-end chat response checks.
+
+Recommended isolation:
+
+```bash
+export TEST_ROOT="/tmp/agentblazor-release-020-$(date -u +%Y%m%d%H%M%S)"
+export NUGET_PACKAGES="$TEST_ROOT/nuget-packages"
+mkdir -p "$TEST_ROOT"
+cd "$TEST_ROOT"
+dotnet nuget locals http-cache --clear
+```
+
+If your machine has old custom package sources, use an isolated `NuGet.Config`:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>
+```
+
+## 1. NuGet Package Availability
+
+Verify all current packages are indexed:
+
+```bash
+for p in agentblazor agentblazor.client agentblazor.entityframeworkcore agentblazor.cli; do
+  echo "== $p =="
+  curl -fsSL "https://api.nuget.org/v3-flatcontainer/$p/index.json" | grep '0.2.0-preview.2'
+done
+```
+
+Pass:
+
+- All four package IDs show `0.2.0-preview.2`.
+- `0.2.0-preview.1` is unlisted in the NuGet.org UI.
+
+Note: the flat-container API may still show unlisted versions. Use the NuGet.org package page or registration `listed` flag to verify unlisting.
+
+## 2. Fresh Blazor Quickstart
+
+Create a new app:
+
+```bash
+dotnet new blazor -n AgentBlazorReleaseSmoke
+cd AgentBlazorReleaseSmoke
+dotnet add package AgentBlazor --version 0.2.0-preview.2 --source https://api.nuget.org/v3/index.json
+```
+
+Apply the current [quickstart](../quickstart.md):
+
+- update `Program.cs`
+- add `@using AgentBlazor.Components`
+- update `Components/App.razor`
+- wrap layout content with `AgentBlazorShell`
+- add `Workflows/HelloWorkflow.cs`
+- configure OpenAI key and model with user secrets
+
+Use user secrets:
+
+```bash
+dotnet user-secrets init
+dotnet user-secrets set "OpenAI:ApiKey" "$OPENAI_API_KEY"
+dotnet user-secrets set "OpenAI:Model" "gpt-4o-mini"
+```
+
+Build:
+
+```bash
+dotnet build -nologo
+```
+
+Run:
+
+```bash
+dotnet run --urls http://127.0.0.1:5128
+```
+
+Browser checks:
+
+- home page loads
+- AgentBlazor CSS and JS are present in page source
+- MudBlazor CSS and JS are present in page source
+- floating chat widget appears
+- clicking the widget opens the chat surface
+- agent dropdown contains `hello`
+- message input is visible
+- send button enables after typing
+
+Prompt:
+
+```text
+Say hello
+```
+
+Pass:
+
+- the app does not crash
+- the chat returns `Hello from AgentBlazor.`
+- no raw exception text is shown
+- no setup step requires GitHub Packages or a PAT
+
+Fail:
+
+- package restore uses a repo-local source
+- widget renders but cannot open
+- `MapAgentBlazorEndpoints()` is missing from docs or required wiring
+- chat has no registered agent after following the quickstart
+- OpenAI key errors are unclear or do not name the missing configuration key
+
+## 3. EF Core Schema Exposure
+
+Install the optional package into the same fresh app:
+
+```bash
+dotnet add package AgentBlazor.EntityFrameworkCore --version 0.2.0-preview.2 --source https://api.nuget.org/v3/index.json
+dotnet add package Microsoft.EntityFrameworkCore.Sqlite
+```
+
+Create a minimal EF model:
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+
+namespace AgentBlazorReleaseSmoke.Data;
+
+public sealed class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(options)
+{
+    public DbSet<SupportTicket> SupportTickets => Set<SupportTicket>();
+}
+
+public sealed class SupportTicket
+{
+    public int Id { get; set; }
+    public string TicketId { get; set; } = "";
+    public string Status { get; set; } = "";
+    public string Priority { get; set; } = "";
+    public DateTime CreatedUtc { get; set; }
+    public bool WaitingOnReply { get; set; }
+}
+```
+
+Register EF and schema metadata:
+
+```csharp
+using AgentBlazor.EntityFrameworkCore;
+using AgentBlazorReleaseSmoke.Data;
+using Microsoft.EntityFrameworkCore;
+
+builder.Services.AddDbContextFactory<AppDbContext>(options =>
+{
+    options.UseSqlite("Data Source=:memory:");
+});
+
+builder.Services.AddAgentBlazor(options =>
+{
+    options.UseOpenAI(
+        apiKey: builder.Configuration["OpenAI:ApiKey"]!,
+        model: builder.Configuration["OpenAI:Model"] ?? "gpt-4o-mini");
+
+    options.ConfigureBuilder(agentBuilder =>
+    {
+        agentBuilder.AddEntitySchema<AppDbContext>("support-data", schema =>
+        {
+            schema.WithDescription("Read-safe support ticket fields.");
+            schema.Entity<SupportTicket>("support_tickets", entity =>
+            {
+                entity.Property(ticket => ticket.TicketId, "Ticket identifier such as TCK-1042.");
+                entity.Property(ticket => ticket.Status, "Current ticket status.");
+                entity.Property(ticket => ticket.Priority, "Priority label.");
+                entity.Property(ticket => ticket.CreatedUtc, "Creation timestamp.");
+                entity.Property(ticket => ticket.WaitingOnReply, "Whether the ticket is waiting on a support reply.");
+            });
+        });
+
+        agentBuilder.AddWorkflow<HelloWorkflow>("hello", agent =>
+        {
+            agent.WithDataSchemas("support-data");
+        });
+    });
+});
+```
+
+Build:
+
+```bash
+dotnet build -nologo
+```
+
+Pass:
+
+- `AgentBlazor.EntityFrameworkCore` restores from NuGet.org.
+- restore does not try to resolve `AgentBlazor.Core` from NuGet.org.
+- build succeeds.
+- schema registration requires explicit entity/property allowlists.
+
+Negative checks:
+
+- register a property that is not mapped by EF and confirm startup/build path reports a clear validation failure when schema creation runs.
+- remove `IDbContextFactory<AppDbContext>` and confirm the error names the missing factory registration.
+
+## 4. Structured Error Recovery
+
+Add a workflow with explicit structured errors:
+
+```csharp
+using AgentBlazor.App;
+using AgentBlazor.Attributes;
+
+namespace AgentBlazorReleaseSmoke.Workflows;
+
+[AgentCapability("release_probe")]
+public sealed class ReleaseProbeWorkflow
+{
+    [AgentAction("Find orders in a date range")]
+    public Task<CapabilityResult> FindOrdersAsync(DateOnly startDate, DateOnly endDate)
+    {
+        if (endDate < startDate)
+        {
+            return Task.FromResult(
+                CapabilityResult
+                    .InvalidArguments("The end date must be on or after the start date.")
+                    .WithOutput("errorCode", "invalid_date_range")
+                    .WithOutput("parameterName", "endDate")
+                    .WithOutput("expectedShape", "date on or after startDate")
+                    .WithNextAction("Retry with an endDate that is on or after startDate."));
+        }
+
+        return Task.FromResult(CapabilityResult.Success("Found matching orders."));
+    }
+
+    [AgentAction("Draft a reply for a ticket")]
+    public Task<CapabilityResult> DraftReplyAsync(string ticketId)
+    {
+        if (string.IsNullOrWhiteSpace(ticketId))
+        {
+            return Task.FromResult(
+                CapabilityResult.MissingArgument(
+                    parameterName: "ticketId",
+                    expectedShape: "a ticket ID such as TCK-1042",
+                    actionId: "release_probe.draft_reply"));
+        }
+
+        return Task.FromResult(CapabilityResult.Success($"Prepared draft for {ticketId}."));
+    }
+}
+```
+
+Register it:
+
+```csharp
+agentBuilder.AddWorkflow<ReleaseProbeWorkflow>("release-probe");
+```
+
+Prompts:
+
+```text
+Find orders from tomorrow to yesterday
+```
+
+```text
+Draft a reply but I do not know the ticket number
+```
+
+Pass:
+
+- invalid date range returns a recoverable failure, not raw exception text
+- response includes a clear next action
+- missing ticket ID asks for clarification
+- chat output contains useful structured details when execution details are enabled
+- model does not repeatedly call the same failing action without new input
+
+## 5. Binding-Layer Error Recovery
+
+Use the hosted runtime-probe demo or a local equivalent:
+
+```text
+Run the structured error date range probe
+```
+
+Pass:
+
+- missing required argument is normalized before method invocation
+- output includes `parameterName`, `expectedShape`, and a recovery hint
+- no raw `TargetInvocationException`, binder stack trace, or JSON conversion exception is shown to the user
+
+## 6. Hosted Demo Smoke
+
+Open:
+
+- https://demo.agentblazor.com/demo/workflows/support-inbox
+
+Prompts:
+
+```text
+Show open tickets from this week
+Explain why they need attention
+Draft a reply for ticket TCK-1042
+Approved
+```
+
+Pass:
+
+- support inbox route loads
+- chat widget opens
+- prompts use `Support Inbox Agent`
+- approval is requested once for the draft action
+- after approval, draft output references `TCK-1042`
+- no unrelated workflow handles the support-inbox prompt
+- no generated UI action silently invokes approval-gated actions
+- verbose plan/execution details stay hidden unless intentionally enabled
+
+## 7. Demo Logging And Analytics
+
+Use the protected log token and check:
+
+```bash
+TOKEN="$(cat artifacts/demo-log-access-token.txt)"
+curl -H "X-Demo-Log-Token: $TOKEN" "https://demo.agentblazor.com/internal/demo-logs/summary"
+curl -H "X-Demo-Log-Token: $TOKEN" "https://demo.agentblazor.com/internal/demo-logs?lines=50"
+```
+
+Pass:
+
+- summary endpoint returns JSON
+- page views increment after visiting the demo
+- chat turns increment after sending prompts
+- top routes show user-facing routes, not `/_blazor` or static asset noise
+- chat log rows include route, agent, duration, status, prompt length, response length, action counts, and token/cost fields when available
+- invalid token is rejected
+
+## 8. CLI Package Smoke
+
+The CLI targets `net8.0`, so the machine must have .NET 8 runtime installed.
+
+```bash
+TOOL_ROOT="$TEST_ROOT/tool"
+mkdir -p "$TOOL_ROOT"
+dotnet tool install AgentBlazor.Cli --tool-path "$TOOL_ROOT" --version 0.2.0-preview.2 --add-source https://api.nuget.org/v3/index.json
+"$TOOL_ROOT/agentblazor" --version
+```
+
+Pass:
+
+- tool installs from NuGet.org
+- `agentblazor --version` reports `0.2.0-preview.2`
+
+Known environment failure:
+
+- if only .NET 10 runtime is installed, the tool install can succeed but execution fails asking for `Microsoft.NETCore.App 8.0.0`
+
+## 9. Hosted WebAssembly Client Package Smoke
+
+Create a hosted WebAssembly Blazor app or use the existing hosted WebAssembly validation script.
+
+Minimum checks:
+
+```bash
+dotnet add package AgentBlazor.Client --version 0.2.0-preview.2 --source https://api.nuget.org/v3/index.json
+```
+
+Pass:
+
+- package restores from NuGet.org
+- remote widget/surface/panel/bar components compile
+- server maps `MapAgentBlazorRemoteChat()`
+- browser client can submit a prompt through the remote endpoint
+
+## 10. Stable Release Readiness
+
+Before cutting `0.2.0` stable:
+
+- `0.2.0-preview.1` is unlisted.
+- `0.2.0-preview.2` package pages and GitHub docs point to preview 2.
+- quickstart passes with a real OpenAI key.
+- EF schema package passes fresh-app install/build.
+- structured error prompt path passes locally or on hosted runtime probe.
+- hosted demo support-inbox smoke passes.
+- demo logs show test traffic and chat turns.
+- known advisory warnings are recorded and accepted or fixed.
+- release notes and completed-work docs are current.
+
+## Report Template
+
+Use this format for each test run:
+
+```text
+Date:
+Tester:
+OS:
+.NET SDK:
+Package version:
+NuGet source:
+OpenAI model:
+
+Fresh quickstart: pass/fail
+EF schema exposure: pass/fail
+Structured errors: pass/fail
+Hosted demo: pass/fail
+Demo logs: pass/fail
+CLI: pass/fail/not run
+Hosted WASM client: pass/fail/not run
+
+Failures:
+- command:
+- expected:
+- actual:
+- screenshot/log:
+```

--- a/docs/releases/0.2.0.md
+++ b/docs/releases/0.2.0.md
@@ -8,6 +8,8 @@ Use `0.2.0-preview.2` for testing. `0.2.0-preview.1` was published first, but wa
 
 For a fuller implementation log, see [0.2.0 completed work](0.2.0-completed-work.md).
 
+For release verification, see [0.2.0 release test plan](0.2.0-test-plan.md).
+
 ## Highlights
 
 - Structured capability errors: `CapabilityResult` now has explicit recoverable result shapes for missing arguments, invalid arguments, invalid argument shape, and recoverable failures. The reflection binding layer normalizes common binding failures before method invocation, and the chat/runtime path carries summaries, next actions, warnings, and outputs forward so the model can recover instead of spiraling on raw exception text.


### PR DESCRIPTION
## Summary
- add a full v0.2 release test plan starting from a fresh Blazor app and public NuGet packages
- cover quickstart install, EF Core schema exposure, structured errors, hosted demo, logging, CLI, hosted WASM, and stable-release gates
- link the plan from release notes and beta testing docs

## Verification
- git diff --check