### PR TITLE
Clarify structured error release test prompts

### DIFF
--- a/docs/releases/0.2.0-test-plan.md
+++ b/docs/releases/0.2.0-test-plan.md
@@ -284,11 +284,13 @@ Register it:
 agentBuilder.AddWorkflow<ReleaseProbeWorkflow>("release-probe");
 ```
 
-Prompts:
+Invalid argument prompt:
 
 ```text
-Find orders from tomorrow to yesterday
+Use the Find orders in a date range action with startDate 2026-05-19 and endDate 2026-05-18. Do not ask for clarification; call the action with those exact values.
 ```
+
+Missing argument prompt:
 
 ```text
 Draft a reply but I do not know the ticket number
@@ -297,10 +299,17 @@ Draft a reply but I do not know the ticket number
 Pass:
 
 - invalid date range returns a recoverable failure, not raw exception text
+- invalid date range includes `errorCode=invalid_date_range`
 - response includes a clear next action
 - missing ticket ID asks for clarification
 - chat output contains useful structured details when execution details are enabled
 - model does not repeatedly call the same failing action without new input
+
+If the natural-language prompt `Find orders from tomorrow to yesterday` returns
+`Required parameter 'startDate' is missing`, that is the binding-layer recovery
+path in section 5. It means the model did not bind the relative dates into tool
+arguments. Retry this section with the explicit date prompt above to verify the
+in-method invalid-argument path.
 
 ## 5. Binding-Layer Error Recovery
 
@@ -315,6 +324,7 @@ Pass:
 - missing required argument is normalized before method invocation
 - output includes `parameterName`, `expectedShape`, and a recovery hint
 - no raw `TargetInvocationException`, binder stack trace, or JSON conversion exception is shown to the user
+- the prompt `Find orders from tomorrow to yesterday` may land here if the model does not bind `startDate` and `endDate`; that is acceptable if the chat asks for clarification instead of crashing
 
 ## 6. Hosted Demo Smoke
 


### PR DESCRIPTION
## Summary
- split the release test plan into explicit invalid-argument and missing-argument prompts
- document that natural-language relative dates can hit binding-layer missing-argument recovery
- add the expected invalid_date_range marker for the in-method structured error check

## Testing
- git diff --check