### PR TITLE
Project date parameters as tool-friendly schemas

### DIFF
--- a/src/AgentBlazor.Core/App/ReflectionAgentCapabilityRegistry.cs
+++ b/src/AgentBlazor.Core/App/ReflectionAgentCapabilityRegistry.cs
@@ -440,14 +440,33 @@ internal sealed class ReflectionAgentCapabilityRegistry(IEnumerable<Type> capabi
 
     private static object BuildParameterSchema(ParameterInfo parameter, AgentParamAttribute? attribute)
     {
+        var parameterType = Nullable.GetUnderlyingType(parameter.ParameterType) ?? parameter.ParameterType;
         var schema = new Dictionary<string, object?>
         {
             ["type"] = GetJsonSchemaType(parameter.ParameterType)
         };
 
+        var format = GetJsonSchemaFormat(parameterType);
+        if (!string.IsNullOrWhiteSpace(format))
+        {
+            schema["format"] = format;
+        }
+
         if (!string.IsNullOrWhiteSpace(attribute?.Description))
         {
             schema["description"] = attribute.Description;
+        }
+        else if (parameterType == typeof(DateOnly))
+        {
+            schema["description"] = "Date in yyyy-MM-dd format.";
+        }
+        else if (parameterType == typeof(TimeOnly))
+        {
+            schema["description"] = "Time in HH:mm:ss format.";
+        }
+        else if (parameterType == typeof(DateTime) || parameterType == typeof(DateTimeOffset))
+        {
+            schema["description"] = "Date and time in ISO 8601 format.";
         }
 
         var allowedValues = GetAllowedValues(parameter, attribute);
@@ -546,6 +565,15 @@ internal sealed class ReflectionAgentCapabilityRegistry(IEnumerable<Type> capabi
             return "string";
         }
 
+        if (underlyingType == typeof(DateOnly) ||
+            underlyingType == typeof(TimeOnly) ||
+            underlyingType == typeof(DateTime) ||
+            underlyingType == typeof(DateTimeOffset) ||
+            underlyingType == typeof(Guid))
+        {
+            return "string";
+        }
+
         if (underlyingType == typeof(bool))
         {
             return "boolean";
@@ -571,6 +599,32 @@ internal sealed class ReflectionAgentCapabilityRegistry(IEnumerable<Type> capabi
         }
 
         return "object";
+    }
+
+    private static string? GetJsonSchemaFormat(Type type)
+    {
+        var underlyingType = Nullable.GetUnderlyingType(type) ?? type;
+        if (underlyingType == typeof(DateOnly))
+        {
+            return "date";
+        }
+
+        if (underlyingType == typeof(TimeOnly))
+        {
+            return "time";
+        }
+
+        if (underlyingType == typeof(DateTime) || underlyingType == typeof(DateTimeOffset))
+        {
+            return "date-time";
+        }
+
+        if (underlyingType == typeof(Guid))
+        {
+            return "uuid";
+        }
+
+        return null;
     }
 
     private static string GetJsonSchemaType(Type type)
@@ -685,6 +739,26 @@ internal sealed class ReflectionAgentCapabilityRegistry(IEnumerable<Type> capabi
         if (underlyingType.IsEnum)
         {
             return $"one of: {string.Join(", ", Enum.GetNames(underlyingType))}";
+        }
+
+        if (underlyingType == typeof(DateOnly))
+        {
+            return "a date in yyyy-MM-dd format";
+        }
+
+        if (underlyingType == typeof(TimeOnly))
+        {
+            return "a time in HH:mm:ss format";
+        }
+
+        if (underlyingType == typeof(DateTime) || underlyingType == typeof(DateTimeOffset))
+        {
+            return "a date-time in ISO 8601 format";
+        }
+
+        if (underlyingType == typeof(Guid))
+        {
+            return "a UUID string";
         }
 
         return GetJsonSchemaType(underlyingType) switch

--- a/src/AgentBlazor.Core/Runtime/Discovery/AgentActionDiscovery.cs
+++ b/src/AgentBlazor.Core/Runtime/Discovery/AgentActionDiscovery.cs
@@ -394,6 +394,11 @@ public static class AgentActionDiscovery
             _ when underlying == typeof(float) => "number",
             _ when underlying == typeof(decimal) => "number",
             _ when underlying == typeof(bool) => "boolean",
+            _ when underlying == typeof(DateOnly) => "date",
+            _ when underlying == typeof(TimeOnly) => "time",
+            _ when underlying == typeof(DateTime) => "date-time",
+            _ when underlying == typeof(DateTimeOffset) => "date-time",
+            _ when underlying == typeof(Guid) => "uuid",
             _ when underlying.IsEnum => "string",
             _ => "any"
         };

--- a/tests/AgentBlazor.Core.Tests/AgentCapabilityRegistryTests.cs
+++ b/tests/AgentBlazor.Core.Tests/AgentCapabilityRegistryTests.cs
@@ -3,6 +3,7 @@ using AgentBlazor.Attributes;
 using AgentBlazor.Core.Runtime.Agents;
 using AgentBlazor.Services;
 using Microsoft.Extensions.DependencyInjection;
+using System.Text.Json;
 
 namespace AgentBlazor.Core.Tests;
 
@@ -153,6 +154,67 @@ public class AgentCapabilityRegistryTests
         Assert.Equal("object", result.Outputs["actualShape"]);
         Assert.Contains("days", result.Summary, StringComparison.OrdinalIgnoreCase);
         Assert.Contains(result.NextActions, action => action.Contains("days", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void GetCapabilities_ProjectsDateOnlyParametersAsDateStrings()
+    {
+        var services = new ServiceCollection();
+        services.AddAgentBlazorServices()
+            .AddCapability<DateRangeCapabilities>();
+
+        using var provider = services.BuildServiceProvider();
+        var registry = provider.GetRequiredService<IAgentCapabilityRegistry>();
+
+        var capability = Assert.Single(registry.GetCapabilities(provider));
+        var action = Assert.Single(capability.Actions);
+
+        Assert.Collection(
+            action.Parameters,
+            start =>
+            {
+                Assert.Equal("startDate", start.Name);
+                Assert.Equal("string", start.Type);
+                Assert.True(start.Required);
+            },
+            end =>
+            {
+                Assert.Equal("endDate", end.Name);
+                Assert.Equal("string", end.Type);
+                Assert.True(end.Required);
+            });
+
+        using var schema = JsonDocument.Parse(action.InputSchema);
+        var properties = schema.RootElement.GetProperty("properties");
+        Assert.Equal("string", properties.GetProperty("startDate").GetProperty("type").GetString());
+        Assert.Equal("date", properties.GetProperty("startDate").GetProperty("format").GetString());
+        Assert.Equal("string", properties.GetProperty("endDate").GetProperty("type").GetString());
+        Assert.Equal("date", properties.GetProperty("endDate").GetProperty("format").GetString());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_BindsDateOnlyArgumentsFromIsoDateStrings()
+    {
+        var services = new ServiceCollection();
+        services.AddAgentBlazorServices()
+            .AddCapability<DateRangeCapabilities>();
+
+        await using var provider = services.BuildServiceProvider();
+        var registry = provider.GetRequiredService<IAgentCapabilityRegistry>();
+
+        var result = await registry.ExecuteAsync(
+            "date_range.find_orders",
+            new Dictionary<string, object?>
+            {
+                ["startDate"] = "2026-05-19",
+                ["endDate"] = "2026-05-18"
+            },
+            provider);
+
+        Assert.False(result.Succeeded);
+        Assert.Equal("invalid_date_range", result.Outputs["errorCode"]);
+        Assert.Equal(new DateOnly(2026, 5, 19), result.Outputs["startDate"]);
+        Assert.Equal(new DateOnly(2026, 5, 18), result.Outputs["endDate"]);
     }
 
     [Fact]
@@ -403,6 +465,25 @@ public class AgentCapabilityRegistryTests
         {
             recorder.LastSessionId = sessionId;
             return CapabilityResult.Success($"Captured {sessionId}.");
+        }
+    }
+
+    [AgentCapability("date_range", Name = "Date Range", Category = "Workflow")]
+    public sealed class DateRangeCapabilities
+    {
+        [AgentAction("Find orders in a date range", ActionId = "find_orders")]
+        public CapabilityResult FindOrders(DateOnly startDate, DateOnly endDate)
+        {
+            if (endDate < startDate)
+            {
+                return CapabilityResult
+                    .InvalidArguments("The end date must be on or after the start date.")
+                    .WithOutput("errorCode", "invalid_date_range")
+                    .WithOutput("startDate", startDate)
+                    .WithOutput("endDate", endDate);
+            }
+
+            return CapabilityResult.Success("Found matching orders.");
         }
     }
 


### PR DESCRIPTION
## Summary
- project DateOnly, TimeOnly, DateTime, DateTimeOffset, and Guid as string schemas with useful formats instead of opaque objects
- improve expected-shape messages for date-like and UUID parameters
- keep component action discovery labels aligned with these primitive-like types
- add registry coverage for DateOnly schema projection and ISO date-string binding

## Testing
- dotnet test tests/AgentBlazor.Core.Tests/AgentBlazor.Core.Tests.csproj --filter AgentCapabilityRegistryTests
- dotnet test AgentBlazor.sln --no-restore