### PR TITLE
Update docs for preview 3 release

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
 
   <!-- Common package metadata for all AgentBlazor packages -->
   <PropertyGroup>
-    <Version>0.2.0-preview.2</Version>
+    <Version>0.2.0-preview.3</Version>
     <Authors>Ash Peterson</Authors>
     <Company>AgentBlazor</Company>
     <Copyright>Copyright (c) 2026 Ash Peterson</Copyright>
@@ -16,7 +16,7 @@
     <RepositoryType>git</RepositoryType>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <PackageIcon>icon.png</PackageIcon>
-    <PackageReleaseNotes>v0.2 preview: structured capability error recovery, schema-only EF Core entity exposure, hosted demo observability, and verified package-first quickstart updates.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.2 preview: structured capability error recovery, schema-only EF Core entity exposure, hosted demo observability, verified package-first quickstart updates, and tool-friendly schemas for date-like workflow parameters.</PackageReleaseNotes>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <Deterministic>true</Deterministic>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AgentBlazor
 
-Last updated: 2026-04-29
+Last updated: 2026-05-19
 
 Add an agent chat surface and deterministic app actions to a Blazor app.
 
@@ -13,10 +13,10 @@ Try the hosted demo:
 ## Install
 
 ```bash
-dotnet add package AgentBlazor --version 0.2.0-preview.2
+dotnet add package AgentBlazor --version 0.2.0-preview.3
 ```
 
-Use `0.2.0-preview.2` or later. `0.2.0-preview.1` was superseded after publish because the optional EF package referenced an unpublished internal package.
+Use `0.2.0-preview.3` or later. `0.2.0-preview.1` was superseded after publish because the optional EF package referenced an unpublished internal package; `0.2.0-preview.3` also fixes date-like workflow parameters so `DateOnly`, `TimeOnly`, `DateTime`, `DateTimeOffset`, and `Guid` project as tool-friendly string schemas.
 
 The CLI is optional. Keep it out of the critical path unless you want scaffold help for an existing app.
 
@@ -117,7 +117,7 @@ dotnet run --project samples/AgentBlazor.Starter/AgentBlazor.Starter.csproj
 If your app uses EF Core, install `AgentBlazor.EntityFrameworkCore` to expose selected entity shapes as planning context:
 
 ```bash
-dotnet add package AgentBlazor.EntityFrameworkCore --version 0.2.0-preview.2
+dotnet add package AgentBlazor.EntityFrameworkCore --version 0.2.0-preview.3
 ```
 
 This is schema-only. It helps an agent understand safe entity fields, but it does not execute queries, generate LINQ or SQL, scan every `DbSet`, or grant write access. Data access still goes through your typed `[AgentAction]` methods.

--- a/docs/advanced/cli.md
+++ b/docs/advanced/cli.md
@@ -11,7 +11,7 @@ Use it when:
 Current run order:
 
 ```bash
-dotnet tool install --global AgentBlazor.Cli --version 0.2.0-preview.2
+dotnet tool install --global AgentBlazor.Cli --version 0.2.0-preview.3
 agentblazor init ./MySolution.slnx --host MyBlazorApp
 agentblazor scaffold ./MySolution.slnx --host MyBlazorApp --provider openai --diff
 agentblazor scaffold ./MySolution.slnx --host MyBlazorApp --provider openai --approve

--- a/docs/beta-testing.md
+++ b/docs/beta-testing.md
@@ -20,7 +20,7 @@ Use a fresh app first. Do not start with an existing codebase.
 ```bash
 dotnet new blazor -o FreshAgentBlazor
 cd FreshAgentBlazor
-dotnet add package AgentBlazor --version 0.2.0-preview.2
+dotnet add package AgentBlazor --version 0.2.0-preview.3
 ```
 
 Then follow:
@@ -43,7 +43,7 @@ Compare against the hosted support-inbox demo if you want a known-running refere
 
 Please report pass or fail for each of these:
 
-1. `dotnet add package AgentBlazor --version 0.2.0-preview.2`
+1. `dotnet add package AgentBlazor --version 0.2.0-preview.3`
 2. `dotnet build`
 3. app starts with AgentBlazor assets loaded
 4. chat surface opens

--- a/docs/capability-errors.md
+++ b/docs/capability-errors.md
@@ -85,6 +85,8 @@ The reflection registry rejects the call before invoking the method because the 
 
 For in-method validation, the same runtime-probe capability returns `errorCode=invalid_date_range` when `endDate` is earlier than `startDate`. Use that shape when your method body can validate supplied arguments but the requested operation is not valid.
 
+In `0.2.0-preview.3` and later, date-like action parameters are projected as string schemas with useful formats. For example, `DateOnly startDate` is exposed to the model as a `string` with `format: date`, so prompts that provide explicit `yyyy-MM-dd` values can bind into the action body instead of failing as missing arguments.
+
 ## Runtime Wrapping
 
 The reflection registry wraps common binding failures before the method runs:

--- a/docs/entity-framework.md
+++ b/docs/entity-framework.md
@@ -13,11 +13,11 @@ dotnet add package AgentBlazor.EntityFrameworkCore --prerelease
 If you pin versions, use the same AgentBlazor version for the runtime and EF package:
 
 ```bash
-dotnet add package AgentBlazor --version 0.2.0-preview.2
-dotnet add package AgentBlazor.EntityFrameworkCore --version 0.2.0-preview.2
+dotnet add package AgentBlazor --version 0.2.0-preview.3
+dotnet add package AgentBlazor.EntityFrameworkCore --version 0.2.0-preview.3
 ```
 
-Use `0.2.0-preview.2` or later. `0.2.0-preview.1` was superseded after publish because this optional package referenced an unpublished internal package.
+Use `0.2.0-preview.3` or later. `0.2.0-preview.1` was superseded after publish because this optional package referenced an unpublished internal package; `0.2.0-preview.3` also fixes date-like workflow parameters so they project as tool-friendly string schemas.
 
 ## DbContext Setup
 

--- a/docs/internal/beta-tester-runbook.md
+++ b/docs/internal/beta-tester-runbook.md
@@ -80,7 +80,7 @@ For each tester capture:
 If a tester asks what to do, answer with this exact path:
 
 1. create a fresh Blazor app
-2. run `dotnet add package AgentBlazor --version 0.2.0-preview.2`
+2. run `dotnet add package AgentBlazor --version 0.2.0-preview.3`
 3. follow `docs/quickstart.md`
 4. test the support-inbox shape only
 5. submit feedback through one of the issue forms

--- a/docs/internal/launch-content/blog-post.md
+++ b/docs/internal/launch-content/blog-post.md
@@ -37,7 +37,7 @@ What it does not try to do at launch:
 The first install path is now the normal one:
 
 ```bash
-dotnet add package AgentBlazor --version 0.2.0-preview.2
+dotnet add package AgentBlazor --version 0.2.0-preview.3
 ```
 
 Then wire `AddAgentBlazor(...)`, map `MapAgentBlazorEndpoints()`, add one capability class, and mount one chat surface.

--- a/docs/internal/launch-content/reddit-r-dotnet.md
+++ b/docs/internal/launch-content/reddit-r-dotnet.md
@@ -19,7 +19,7 @@ What it is:
 Current public package:
 
 ```bash
-dotnet add package AgentBlazor --version 0.2.0-preview.2
+dotnet add package AgentBlazor --version 0.2.0-preview.3
 ```
 
 Current public demo:

--- a/docs/internal/launch-content/social-thread.md
+++ b/docs/internal/launch-content/social-thread.md
@@ -38,7 +38,7 @@ Post 4:
 Install path:
 
 ```bash
-dotnet add package AgentBlazor --version 0.2.0-preview.2
+dotnet add package AgentBlazor --version 0.2.0-preview.3
 ```
 
 CLI exists, but it is the advanced path, not the headline.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,6 +1,6 @@
 # Quickstart
 
-Get one working AgentBlazor chat widget into a fresh Blazor app. Tested against a clean `dotnet new blazor` project with `AgentBlazor 0.2.0-preview.2`.
+Get one working AgentBlazor chat widget into a fresh Blazor app. Tested against a clean `dotnet new blazor` project with `AgentBlazor 0.2.0-preview.3`.
 
 Hosted demo: https://demo.agentblazor.com/demo/workflows/support-inbox
 
@@ -9,7 +9,7 @@ AgentBlazor does not create a responding agent by default. You must register at 
 ## 1. Install
 
 ```bash
-dotnet add package AgentBlazor --version 0.2.0-preview.2
+dotnet add package AgentBlazor --version 0.2.0-preview.3
 ```
 
 ## 2. Program.cs
@@ -171,7 +171,7 @@ Say hello
 ## Notes
 
 - `MapAgentBlazorEndpoints()` is required. Without it, the widget can render but cannot call the runtime.
-- `AgentBlazorShell` includes the widget in `0.2.0-preview.2`.
+- `AgentBlazorShell` includes the widget in `0.2.0-preview.3`.
 - A registered workflow is required for the chat to respond.
 
 ## Next

--- a/docs/releases/0.2.0-completed-work.md
+++ b/docs/releases/0.2.0-completed-work.md
@@ -2,13 +2,13 @@
 
 This is the fuller implementation log behind the 0.2 release notes. It records what changed across the public install path, hosted demo, structured error recovery, EF schema exposure, docs, and release packaging.
 
-Target package line: `0.2.0-preview.2` leading to `0.2.0`.
+Target package line: `0.2.0-preview.3` leading to `0.2.0`.
 
-Published package note: `0.2.0-preview.1` was superseded by `0.2.0-preview.2` after public-feed smoke testing exposed that `AgentBlazor.EntityFrameworkCore` depended on unpublished `AgentBlazor.Core` package metadata. Preview 2 fixes the EF package by bundling the required internal assemblies and is the version to test.
+Published package note: `0.2.0-preview.1` was superseded after public-feed smoke testing exposed that `AgentBlazor.EntityFrameworkCore` depended on unpublished `AgentBlazor.Core` package metadata. `0.2.0-preview.2` fixed the EF package by bundling the required internal assemblies. `0.2.0-preview.3` is the current version to test because it also fixes date-like workflow parameter schemas.
 
 ## Public Install And Documentation
 
-- Moved the public install path to NuGet.org with pinned preview examples now pointing at `0.2.0-preview.2`.
+- Moved the public install path to NuGet.org with pinned preview examples now pointing at `0.2.0-preview.3`.
 - Reworked the quickstart around a fresh `dotnet new blazor` app instead of a starter-project file swap.
 - Made the quickstart explicit that AgentBlazor does not create a responding agent by default; users must register at least one workflow or agent.
 - Documented the required interactive render mode setup for the Blazor shell.
@@ -19,6 +19,7 @@ Published package note: `0.2.0-preview.1` was superseded by `0.2.0-preview.2` af
 - Linked the hosted demo from README and package READMEs.
 - Added `0.2.0` release notes and updated NuGet package release notes metadata.
 - Superseded `0.2.0-preview.1` with `0.2.0-preview.2` after public NuGet smoke testing caught the EF packaging issue.
+- Superseded `0.2.0-preview.2` with `0.2.0-preview.3` after release testing exposed that date-like workflow parameters were projected as opaque objects instead of tool-friendly string schemas.
 
 Relevant PRs: #25, #30, #37, #38, #42, #48, #49, #51.
 
@@ -64,6 +65,7 @@ Relevant PRs: #20, #22, #23, #24, #37.
 - Added structured `CapabilityResult` helper shapes for recoverable tool failures.
 - Covered missing arguments, invalid arguments, invalid argument shape, and recoverable failures.
 - Hardened reflection binding so common pre-invocation failures return structured capability results instead of raw exceptions.
+- Projected date-like workflow parameters as tool-friendly schemas so `DateOnly`, `TimeOnly`, `DateTime`, `DateTimeOffset`, and `Guid` bind more reliably from model tool calls.
 - Preserved cancellation behavior while making recoverable binding errors model-readable.
 - Added runtime adapter regressions for structured error propagation.
 - Hardened chat rendering of structured errors.
@@ -93,13 +95,14 @@ Relevant PRs: #46, #47, #48, #51.
 
 ## Package And Release Metadata
 
-- Bumped source package metadata to `0.2.0-preview.2`.
-- Updated CLI default/fallback version strings to `0.2.0-preview.2`.
+- Bumped source package metadata to `0.2.0-preview.3`.
+- Updated CLI default/fallback version strings to `0.2.0-preview.3`.
 - Updated tests that assert scaffolded package versions.
 - Updated docs and demo docs that show pinned package/tool install commands.
-- Verified generated `AgentBlazor.0.2.0-preview.2.nupkg` contains the expected version and release notes.
-- Verified `AgentBlazor.EntityFrameworkCore.0.2.0-preview.2.nupkg` has no NuGet dependency on `AgentBlazor.Core` and includes the required internal assemblies.
-- Verified a fresh Blazor app installs `AgentBlazor` and `AgentBlazor.EntityFrameworkCore` `0.2.0-preview.2` from public NuGet and builds.
+- Verified generated `AgentBlazor.0.2.0-preview.3.nupkg` contains the expected version and release notes.
+- Verified `AgentBlazor.EntityFrameworkCore.0.2.0-preview.3.nupkg` has no NuGet dependency on `AgentBlazor.Core` and includes the required internal assemblies.
+- Verified a fresh Blazor app installs `AgentBlazor` and `AgentBlazor.EntityFrameworkCore` `0.2.0-preview.3` from public NuGet and builds.
+- Verified the published `AgentBlazor 0.2.0-preview.3` package projects `DateOnly` parameters as `string` with `format: date`, and ISO date strings bind through to in-method validation.
 
 Relevant PRs: #49, #51.
 
@@ -107,13 +110,14 @@ Relevant PRs: #49, #51.
 
 - Full solution build passed.
 - Full solution test run passed.
-- Main package pack check passed for `0.2.0-preview.2`.
+- Main package pack check passed for `0.2.0-preview.3`.
 - Generated NuGet metadata was inspected for version and release notes.
 - CleanTest quickstart verification was run during the install-path cleanup.
 - Hosted demo smoke checks were run after deployment.
 - Structured error demo/reference path was verified and recorded.
 - EF Core schema exposure tests were added and passed.
-- Public NuGet smoke passed for `AgentBlazor` plus `AgentBlazor.EntityFrameworkCore` `0.2.0-preview.2` in a fresh Blazor app.
+- Public NuGet smoke passed for `AgentBlazor` plus `AgentBlazor.EntityFrameworkCore` `0.2.0-preview.3` in a fresh Blazor app.
+- Public NuGet schema probe passed for the `DateOnly` tool-schema fix in `0.2.0-preview.3`.
 
 ## Still Open Or Deliberately Deferred
 
@@ -159,3 +163,4 @@ Relevant PRs: #49, #51.
 - #49 Prepare v0.2 preview release notes.
 - #50 Add complete v0.2 release worklog.
 - #51 Fix EF package for v0.2 preview 2.
+- #56 Project date parameters as tool-friendly schemas.

--- a/docs/releases/0.2.0-test-plan.md
+++ b/docs/releases/0.2.0-test-plan.md
@@ -1,6 +1,6 @@
 # AgentBlazor 0.2.0 Release Test Plan
 
-Target package line: `0.2.0-preview.2` leading to `0.2.0`.
+Target package line: `0.2.0-preview.3` leading to `0.2.0`.
 
 Use this plan to validate the release from a clean consumer app, not from project references. The goal is to prove that a new Blazor developer can install AgentBlazor from NuGet, wire one workflow, see the chat widget, use EF Core schema exposure, and observe structured error recovery.
 
@@ -8,7 +8,7 @@ Use this plan to validate the release from a clean consumer app, not from projec
 
 The release is not ready for `0.2.0` stable until these checks pass:
 
-- Fresh Blazor app installs `AgentBlazor 0.2.0-preview.2` from NuGet.org.
+- Fresh Blazor app installs `AgentBlazor 0.2.0-preview.3` from NuGet.org.
 - Fresh Blazor app builds and starts after following the quickstart.
 - Chat widget renders, opens, and lists the registered workflow.
 - With a real OpenAI key, `Say hello` produces the expected workflow result.
@@ -58,13 +58,13 @@ Verify all current packages are indexed:
 ```bash
 for p in agentblazor agentblazor.client agentblazor.entityframeworkcore agentblazor.cli; do
   echo "== $p =="
-  curl -fsSL "https://api.nuget.org/v3-flatcontainer/$p/index.json" | grep '0.2.0-preview.2'
+  curl -fsSL "https://api.nuget.org/v3-flatcontainer/$p/index.json" | grep '0.2.0-preview.3'
 done
 ```
 
 Pass:
 
-- All four package IDs show `0.2.0-preview.2`.
+- All four package IDs show `0.2.0-preview.3`.
 - `0.2.0-preview.1` is unlisted in the NuGet.org UI.
 
 Note: the flat-container API may still show unlisted versions. Use the NuGet.org package page or registration `listed` flag to verify unlisting.
@@ -76,7 +76,7 @@ Create a new app:
 ```bash
 dotnet new blazor -n AgentBlazorReleaseSmoke
 cd AgentBlazorReleaseSmoke
-dotnet add package AgentBlazor --version 0.2.0-preview.2 --source https://api.nuget.org/v3/index.json
+dotnet add package AgentBlazor --version 0.2.0-preview.3 --source https://api.nuget.org/v3/index.json
 ```
 
 Apply the current [quickstart](../quickstart.md):
@@ -145,7 +145,7 @@ Fail:
 Install the optional package into the same fresh app:
 
 ```bash
-dotnet add package AgentBlazor.EntityFrameworkCore --version 0.2.0-preview.2 --source https://api.nuget.org/v3/index.json
+dotnet add package AgentBlazor.EntityFrameworkCore --version 0.2.0-preview.3 --source https://api.nuget.org/v3/index.json
 dotnet add package Microsoft.EntityFrameworkCore.Sqlite
 ```
 
@@ -378,14 +378,14 @@ The CLI targets `net8.0`, so the machine must have .NET 8 runtime installed.
 ```bash
 TOOL_ROOT="$TEST_ROOT/tool"
 mkdir -p "$TOOL_ROOT"
-dotnet tool install AgentBlazor.Cli --tool-path "$TOOL_ROOT" --version 0.2.0-preview.2 --add-source https://api.nuget.org/v3/index.json
+dotnet tool install AgentBlazor.Cli --tool-path "$TOOL_ROOT" --version 0.2.0-preview.3 --add-source https://api.nuget.org/v3/index.json
 "$TOOL_ROOT/agentblazor" --version
 ```
 
 Pass:
 
 - tool installs from NuGet.org
-- `agentblazor --version` reports `0.2.0-preview.2`
+- `agentblazor --version` reports `0.2.0-preview.3`
 
 Known environment failure:
 
@@ -398,7 +398,7 @@ Create a hosted WebAssembly Blazor app or use the existing hosted WebAssembly va
 Minimum checks:
 
 ```bash
-dotnet add package AgentBlazor.Client --version 0.2.0-preview.2 --source https://api.nuget.org/v3/index.json
+dotnet add package AgentBlazor.Client --version 0.2.0-preview.3 --source https://api.nuget.org/v3/index.json
 ```
 
 Pass:
@@ -413,7 +413,7 @@ Pass:
 Before cutting `0.2.0` stable:
 
 - `0.2.0-preview.1` is unlisted.
-- `0.2.0-preview.2` package pages and GitHub docs point to preview 2.
+- `0.2.0-preview.3` package pages and GitHub docs point to preview 3.
 - quickstart passes with a real OpenAI key.
 - EF schema package passes fresh-app install/build.
 - structured error prompt path passes locally or on hosted runtime probe.

--- a/docs/releases/0.2.0.md
+++ b/docs/releases/0.2.0.md
@@ -1,10 +1,10 @@
 # AgentBlazor 0.2.0 Release Notes
 
-Target package line: `0.2.0-preview.2` leading to `0.2.0`.
+Target package line: `0.2.0-preview.3` leading to `0.2.0`.
 
 AgentBlazor 0.2 focuses on making the package-first path credible: recoverable tool errors, explicit EF Core schema context for planning, a simpler hosted demo, and observable demo traffic/chat usage.
 
-Use `0.2.0-preview.2` for testing. `0.2.0-preview.1` was published first, but was superseded after the optional `AgentBlazor.EntityFrameworkCore` package was found to depend on unpublished internal `AgentBlazor.Core` package metadata. `0.2.0-preview.2` bundles the required internal assemblies and passed a fresh public NuGet install/build smoke.
+Use `0.2.0-preview.3` for testing. `0.2.0-preview.1` was published first, but was superseded after the optional `AgentBlazor.EntityFrameworkCore` package was found to depend on unpublished internal `AgentBlazor.Core` package metadata. `0.2.0-preview.2` fixed that package shape; `0.2.0-preview.3` adds the date-parameter schema fix and passed a fresh public NuGet install/build smoke.
 
 For a fuller implementation log, see [0.2.0 completed work](0.2.0-completed-work.md).
 
@@ -13,6 +13,7 @@ For release verification, see [0.2.0 release test plan](0.2.0-test-plan.md).
 ## Highlights
 
 - Structured capability errors: `CapabilityResult` now has explicit recoverable result shapes for missing arguments, invalid arguments, invalid argument shape, and recoverable failures. The reflection binding layer normalizes common binding failures before method invocation, and the chat/runtime path carries summaries, next actions, warnings, and outputs forward so the model can recover instead of spiraling on raw exception text.
+- Tool-friendly parameter schemas: date-like workflow parameters now project as string schemas with useful formats, so `DateOnly`, `TimeOnly`, `DateTime`, `DateTimeOffset`, and `Guid` are easier for the model to call correctly.
 - EF Core schema exposure: the optional `AgentBlazor.EntityFrameworkCore` package exposes selected EF model shapes as planning context with `AddEntitySchema<TContext>(...)` and per-agent opt-in through `WithDataSchemas(...)`. This is read-safe schema metadata only; data access still goes through app-owned `[AgentAction]` methods.
 - Demo and observability: the hosted demo now leads with the support-inbox workflow, includes traffic/chat JSONL logging, protected log/summary endpoints, token and cost fields for chat turns, and filtering so analytics answer whether real people are using the demo instead of showing Blazor transport noise.
 - Install and docs cleanup: the quickstart now documents the required workflow registration, interactive render mode, `AgentBlazorShell`, OpenAI key setup, and package-first setup against a fresh Blazor app. GitHub Packages/PAT setup is no longer the default path.
@@ -33,7 +34,7 @@ See [Recoverable capability errors](../capability-errors.md).
 Install the optional package:
 
 ```bash
-dotnet add package AgentBlazor.EntityFrameworkCore --version 0.2.0-preview.2
+dotnet add package AgentBlazor.EntityFrameworkCore --version 0.2.0-preview.3
 ```
 
 Register only safe entity/property metadata:
@@ -81,13 +82,13 @@ The protected `/internal/demo-logs` and `/internal/demo-logs/summary` endpoints 
 Pinned preview install:
 
 ```bash
-dotnet add package AgentBlazor --version 0.2.0-preview.2
+dotnet add package AgentBlazor --version 0.2.0-preview.3
 ```
 
 Optional EF schema package:
 
 ```bash
-dotnet add package AgentBlazor.EntityFrameworkCore --version 0.2.0-preview.2
+dotnet add package AgentBlazor.EntityFrameworkCore --version 0.2.0-preview.3
 ```
 
 Current quickstart:

--- a/samples/AgentBlazor.Starter/README.md
+++ b/samples/AgentBlazor.Starter/README.md
@@ -34,5 +34,5 @@ Inside this repo, the starter defaults to local source-project references so the
 To validate the published package path from inside the repo:
 
 ```powershell
-dotnet run --project samples/AgentBlazor.Starter/AgentBlazor.Starter.csproj -p:UseLocalAgentBlazorSource=false -p:AgentBlazorPackageVersion=0.2.0-preview.2
+dotnet run --project samples/AgentBlazor.Starter/AgentBlazor.Starter.csproj -p:UseLocalAgentBlazorSource=false -p:AgentBlazorPackageVersion=0.2.0-preview.3
 ```

--- a/src/AgentBlazor.Cli.Analysis/ExistingAppScaffoldApplier.cs
+++ b/src/AgentBlazor.Cli.Analysis/ExistingAppScaffoldApplier.cs
@@ -301,7 +301,7 @@ public sealed class ExistingAppScaffoldApplier
             .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
             ?.InformationalVersion
             ?? typeof(ExistingAppScaffoldApplier).Assembly.GetName().Version?.ToString()
-            ?? "0.2.0-preview.2";
+            ?? "0.2.0-preview.3";
 
         return version.Split('+', 2)[0];
     }

--- a/src/AgentBlazor.Cli/PACKAGE_README.md
+++ b/src/AgentBlazor.Cli/PACKAGE_README.md
@@ -11,7 +11,7 @@ dotnet tool install --global AgentBlazor.Cli --prerelease
 If you want the exact current preview:
 
 ```bash
-dotnet tool install --global AgentBlazor.Cli --version 0.2.0-preview.2
+dotnet tool install --global AgentBlazor.Cli --version 0.2.0-preview.3
 ```
 
 Example:

--- a/src/AgentBlazor.Cli/Program.cs
+++ b/src/AgentBlazor.Cli/Program.cs
@@ -7,7 +7,7 @@ var version = typeof(ScaffoldCommand).Assembly
     .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
     ?.InformationalVersion
     ?? typeof(ScaffoldCommand).Assembly.GetName().Version?.ToString()
-    ?? "0.2.0-preview.2";
+    ?? "0.2.0-preview.3";
 version = version.Split('+', 2)[0];
 
 app.Configure(config =>

--- a/src/AgentBlazor.Client/PACKAGE_README.md
+++ b/src/AgentBlazor.Client/PACKAGE_README.md
@@ -11,7 +11,7 @@ dotnet add package AgentBlazor.Client --prerelease
 If you want the exact current preview:
 
 ```bash
-dotnet add package AgentBlazor.Client --version 0.2.0-preview.2
+dotnet add package AgentBlazor.Client --version 0.2.0-preview.3
 ```
 
 Server project:

--- a/src/AgentBlazor.Components/PACKAGE_README.md
+++ b/src/AgentBlazor.Components/PACKAGE_README.md
@@ -15,10 +15,10 @@ dotnet add package AgentBlazor --prerelease
 Current public releases are prerelease builds. If you prefer a pinned install, use:
 
 ```bash
-dotnet add package AgentBlazor --version 0.2.0-preview.2
+dotnet add package AgentBlazor --version 0.2.0-preview.3
 ```
 
-Use `0.2.0-preview.2` or later. `0.2.0-preview.1` was superseded after publish because the optional EF package referenced an unpublished internal package.
+Use `0.2.0-preview.3` or later. `0.2.0-preview.1` was superseded after publish because the optional EF package referenced an unpublished internal package; `0.2.0-preview.3` also fixes date-like workflow parameters so they project as tool-friendly string schemas.
 
 If `dotnet` still probes an old custom package source on your machine, remove or disable that source before testing the public NuGet install path.
 

--- a/src/AgentBlazor.EntityFrameworkCore/README.md
+++ b/src/AgentBlazor.EntityFrameworkCore/README.md
@@ -13,10 +13,10 @@ dotnet add package AgentBlazor.EntityFrameworkCore --prerelease
 Pinned preview:
 
 ```bash
-dotnet add package AgentBlazor.EntityFrameworkCore --version 0.2.0-preview.2
+dotnet add package AgentBlazor.EntityFrameworkCore --version 0.2.0-preview.3
 ```
 
-Use `0.2.0-preview.2` or later. `0.2.0-preview.1` was superseded after publish because this optional package referenced an unpublished internal package.
+Use `0.2.0-preview.3` or later. `0.2.0-preview.1` was superseded after publish because this optional package referenced an unpublished internal package; `0.2.0-preview.3` also fixes date-like workflow parameters so they project as tool-friendly string schemas.
 
 Register your `DbContext` with `IDbContextFactory<TContext>`:
 

--- a/tests/AgentBlazor.Cli.Analysis.Tests/ExistingAppScaffoldPlannerTests.cs
+++ b/tests/AgentBlazor.Cli.Analysis.Tests/ExistingAppScaffoldPlannerTests.cs
@@ -151,7 +151,7 @@ public sealed class ExistingAppScaffoldPlannerTests : IDisposable
                     <ImplicitUsings>enable</ImplicitUsings>
                   </PropertyGroup>
                   <ItemGroup>
-                    <PackageReference Include="AgentBlazor" Version="0.2.0-preview.2" />
+                    <PackageReference Include="AgentBlazor" Version="0.2.0-preview.3" />
                   </ItemGroup>
                 </Project>
                 """,
@@ -186,7 +186,7 @@ public sealed class ExistingAppScaffoldPlannerTests : IDisposable
         var report = await new InstallReadinessAnalyzer().AnalyzeAsync(projectPath, hostProjectName: null);
 
         Assert.Contains(plan.Items, item => item.Id == "package-references" && item.Action == ScaffoldPlanAction.Update);
-        Assert.Contains("""<PackageReference Include="AgentBlazor" Version="0.2.0-preview.2" />""", projectText, StringComparison.Ordinal);
+        Assert.Contains("""<PackageReference Include="AgentBlazor" Version="0.2.0-preview.3" />""", projectText, StringComparison.Ordinal);
         Assert.Contains("""<PackageReference Include="MudBlazor" Version="9.0.0" />""", projectText, StringComparison.Ordinal);
         Assert.Contains(report.Checks, check => check.Id == "package-references" && check.Status == InstallReadinessStatus.Pass);
     }
@@ -250,7 +250,7 @@ public sealed class ExistingAppScaffoldPlannerTests : IDisposable
         Assert.Contains("""<PackageReference Include="MudBlazor" />""", projectText, StringComparison.Ordinal);
         Assert.DoesNotContain("PackageReference Include=\"AgentBlazor\" Version=", projectText, StringComparison.Ordinal);
         Assert.DoesNotContain("PackageReference Include=\"MudBlazor\" Version=", projectText, StringComparison.Ordinal);
-        Assert.Contains("""<PackageVersion Include="AgentBlazor" Version="0.2.0-preview.2" />""", centralPackagesText, StringComparison.Ordinal);
+        Assert.Contains("""<PackageVersion Include="AgentBlazor" Version="0.2.0-preview.3" />""", centralPackagesText, StringComparison.Ordinal);
         Assert.Contains("""<PackageVersion Include="MudBlazor" Version="9.0.0" />""", centralPackagesText, StringComparison.Ordinal);
     }
 

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -39,7 +39,7 @@ The external chat surface runner now verifies scaffold idempotency, submitted pr
 
 For external apps that require authentication before the main layout is reachable, set `AGENTBLAZOR_EXTERNAL_LOGIN_PATH`, `AGENTBLAZOR_EXTERNAL_LOGIN_USERNAME`, and `AGENTBLAZOR_EXTERNAL_LOGIN_PASSWORD`. The runner signs in before opening the installed floating widget and before visiting the injected surface harness. Set `AGENTBLAZOR_EXTERNAL_EXPECTED_TEXT` to require a protected-page marker before chat assertions begin; the matrix uses this for the CleanArchitecture `/identity/users` authenticated route.
 
-Current release context: `0.2.0-preview.2` is the current public prerelease. Local e2e runs still require a configured OpenAI, Azure OpenAI, or Ollama provider.
+Current release context: `0.2.0-preview.3` is the current public prerelease. Local e2e runs still require a configured OpenAI, Azure OpenAI, or Ollama provider.
 
 The real-usability runner requires an explicit live provider from environment variables. It intentionally does not treat demo `appsettings.json` sample values as proof that CI can reach a provider, because empty GitHub secrets or missing Ollama services otherwise produce misleading no-provider transcripts instead of a clear preflight failure.
 


### PR DESCRIPTION
## Summary
- update public install docs, package READMEs, release notes, test plan, and beta/internal launch docs to 0.2.0-preview.3
- document that preview.3 includes the date-like workflow parameter schema fix
- bump source package metadata and CLI/scaffold fallback versions to preview.3
- update scaffold planner tests that assert the default package version

## Testing
- dotnet build AgentBlazor.slnx -c Release --no-restore -nologo
- dotnet test tests/AgentBlazor.Cli.Analysis.Tests/AgentBlazor.Cli.Analysis.Tests.csproj -c Release --no-restore --filter ExistingAppScaffoldPlannerTests