### PR TITLE
Fix quickstart AgentBlazor imports

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -55,12 +55,15 @@ app.Run();
 ## 3. Components/_Imports.razor
 
 ```razor
+@using AgentBlazor
 @using AgentBlazor.Components
 ```
 
 ## 4. Components/App.razor
 
 ```razor
+@using AgentBlazor
+
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -91,6 +94,8 @@ app.Run();
 Wrap your existing layout content:
 
 ```razor
+@using AgentBlazor.Components
+
 @inherits LayoutComponentBase
 
 <AgentBlazorShell>

--- a/src/AgentBlazor.Cli.Analysis/ExistingAppScaffoldApplier.cs
+++ b/src/AgentBlazor.Cli.Analysis/ExistingAppScaffoldApplier.cs
@@ -432,6 +432,7 @@ public sealed class ExistingAppScaffoldApplier
         var updated = original;
 
         updated = EnsureLine(updated, "@using static Microsoft.AspNetCore.Components.Web.RenderMode");
+        updated = EnsureLine(updated, "@using AgentBlazor");
         updated = EnsureLine(updated, "@using AgentBlazor.Components");
 
         AddTextChange(
@@ -744,6 +745,7 @@ builder.Services.AddAgentBlazor(options =>
         var original = exists ? await File.ReadAllTextAsync(importsPath, ct).ConfigureAwait(false) : string.Empty;
         var updated = original;
 
+        updated = EnsureLine(updated, "@using AgentBlazor");
         updated = EnsureLine(updated, "@using AgentBlazor.Components");
 
         AddTextChange(

--- a/src/AgentBlazor.Components/PACKAGE_README.md
+++ b/src/AgentBlazor.Components/PACKAGE_README.md
@@ -74,6 +74,7 @@ public sealed class SupportInboxCapabilities
 ```
 
 ```razor
+@using AgentBlazor
 @using AgentBlazor.Components
 
 <AgentBlazorShell>

--- a/tests/AgentBlazor.Cli.Analysis.Tests/ExistingAppScaffoldPlannerTests.cs
+++ b/tests/AgentBlazor.Cli.Analysis.Tests/ExistingAppScaffoldPlannerTests.cs
@@ -450,6 +450,8 @@ public sealed class ExistingAppScaffoldPlannerTests : IDisposable
         var importsChange = Assert.Single(preview.Changes, change => change.Path.EndsWith(Path.Combine("Components", "_Imports.razor"), StringComparison.Ordinal));
         var layoutChange = Assert.Single(preview.Changes, change => change.Path.EndsWith(Path.Combine("Components", "Layout", "MainLayout.razor"), StringComparison.Ordinal));
         Assert.Contains("@using static Microsoft.AspNetCore.Components.Web.RenderMode", importsChange.UpdatedContent, StringComparison.Ordinal);
+        Assert.Contains("@using AgentBlazor", importsChange.UpdatedContent, StringComparison.Ordinal);
+        Assert.Contains("@using AgentBlazor.Components", importsChange.UpdatedContent, StringComparison.Ordinal);
         Assert.DoesNotContain("@using MudBlazor", importsChange.UpdatedContent, StringComparison.Ordinal);
         Assert.Contains("@using MudBlazor", layoutChange.UpdatedContent, StringComparison.Ordinal);
         Assert.Contains("""<AgentChatWidget @rendermode="InteractiveServer" Title="Assistant" />""", layoutChange.UpdatedContent, StringComparison.Ordinal);


### PR DESCRIPTION
## Summary
- add explicit AgentBlazor namespace imports to the quickstart snippets
- include AgentBlazor namespace in component package README shell snippet
- update CLI scaffold imports so generated apps can resolve AgentBlazorAssetPaths and AgentBlazor components

## Verification
- dotnet test tests/AgentBlazor.Cli.Analysis.Tests/AgentBlazor.Cli.Analysis.Tests.csproj -c Release --filter ExistingAppScaffoldPlannerTests