### PR TITLE
Update hosted demo docs to preview 3

### DIFF
--- a/demo/AgentBlazor.Demo/Components/Pages/Docs/CliGuide.razor
+++ b/demo/AgentBlazor.Demo/Components/Pages/Docs/CliGuide.razor
@@ -20,8 +20,8 @@
             </div>
         </div>
 
-        <pre class="docs-code"><code>dotnet tool install --global AgentBlazor.Cli --version 0.2.0-preview.2
-dotnet tool update --global AgentBlazor.Cli --version 0.2.0-preview.2</code></pre>
+        <pre class="docs-code"><code>dotnet tool install --global AgentBlazor.Cli --version 0.2.0-preview.3
+dotnet tool update --global AgentBlazor.Cli --version 0.2.0-preview.3</code></pre>
     </section>
 
     <section class="docs-section">

--- a/demo/AgentBlazor.Demo/Components/Pages/Docs/DocsHome.razor
+++ b/demo/AgentBlazor.Demo/Components/Pages/Docs/DocsHome.razor
@@ -40,7 +40,7 @@
             </div>
         </div>
 
-        <pre class="docs-code"><code>dotnet add package AgentBlazor --version 0.2.0-preview.2
+        <pre class="docs-code"><code>dotnet add package AgentBlazor --version 0.2.0-preview.3
 builder.Services.AddAgentBlazor(...)
 app.MapAgentBlazorEndpoints()
 Render one chat surface on one route

--- a/demo/AgentBlazor.Demo/Components/Pages/Docs/GettingStarted.razor
+++ b/demo/AgentBlazor.Demo/Components/Pages/Docs/GettingStarted.razor
@@ -20,7 +20,7 @@
             </div>
         </div>
 
-        <pre class="docs-code"><code>dotnet add ./src/MyBlazorApp/MyBlazorApp.csproj package AgentBlazor --version 0.2.0-preview.2</code></pre>
+        <pre class="docs-code"><code>dotnet add ./src/MyBlazorApp/MyBlazorApp.csproj package AgentBlazor --version 0.2.0-preview.3</code></pre>
     </section>
 
     <section class="docs-section">
@@ -30,7 +30,7 @@
             </div>
         </div>
 
-        <pre class="docs-code"><code>dotnet add ./src/MyBlazorApp/MyBlazorApp.csproj package AgentBlazor --version 0.2.0-preview.2
+        <pre class="docs-code"><code>dotnet add ./src/MyBlazorApp/MyBlazorApp.csproj package AgentBlazor --version 0.2.0-preview.3
 
 builder.Services.AddMudServices();
 builder.Services.AddAgentBlazor(options =&gt; { ... });
@@ -81,7 +81,7 @@ app.MapAgentBlazorEndpoints();</code></pre>
             </div>
         </div>
 
-        <pre class="docs-code"><code>dotnet tool install --global AgentBlazor.Cli --version 0.2.0-preview.2
+        <pre class="docs-code"><code>dotnet tool install --global AgentBlazor.Cli --version 0.2.0-preview.3
 agentblazor init ./MySolution.slnx --host MyBlazorApp
 agentblazor scaffold ./MySolution.slnx --host MyBlazorApp --provider openai --diff
 agentblazor scaffold ./MySolution.slnx --host MyBlazorApp --provider openai --approve
@@ -96,7 +96,7 @@ dotnet build ./MySolution.slnx --no-restore -nologo</code></pre>
             </div>
         </div>
 
-        <pre class="docs-code"><code>dotnet add ./src/MyBlazorApp.Client/MyBlazorApp.Client.csproj package AgentBlazor.Client --version 0.2.0-preview.2
+        <pre class="docs-code"><code>dotnet add ./src/MyBlazorApp.Client/MyBlazorApp.Client.csproj package AgentBlazor.Client --version 0.2.0-preview.3
 
 // Server
 app.MapAgentBlazorEndpoints();

--- a/demo/AgentBlazor.Demo/Components/Pages/Docs/Verification.razor
+++ b/demo/AgentBlazor.Demo/Components/Pages/Docs/Verification.razor
@@ -20,7 +20,7 @@
             </div>
         </div>
 
-        <pre class="docs-code"><code>dotnet add ./src/MyBlazorApp/MyBlazorApp.csproj package AgentBlazor --version 0.2.0-preview.2
+        <pre class="docs-code"><code>dotnet add ./src/MyBlazorApp/MyBlazorApp.csproj package AgentBlazor --version 0.2.0-preview.3
 dotnet build ./MySolution.slnx --nologo
 OpenAI__ApiKey=placeholder-key dotnet run --project ./src/MyBlazorApp/MyBlazorApp.csproj --no-launch-profile --urls http://127.0.0.1:5288
 Open the support route and submit one real prompt</code></pre>
@@ -35,7 +35,7 @@ Open the support route and submit one real prompt</code></pre>
 
         <pre class="docs-code"><code>dotnet new blazor -o FreshAgentBlazor
 cd FreshAgentBlazor
-dotnet add package AgentBlazor --version 0.2.0-preview.2
+dotnet add package AgentBlazor --version 0.2.0-preview.3
 dotnet build FreshAgentBlazor.csproj --nologo</code></pre>
     </section>
 
@@ -46,8 +46,8 @@ dotnet build FreshAgentBlazor.csproj --nologo</code></pre>
             </div>
         </div>
 
-        <pre class="docs-code"><code>dotnet add ./src/MyHostedServer/MyHostedServer.csproj package AgentBlazor --version 0.2.0-preview.2
-dotnet add ./src/MyHostedClient/MyHostedClient.csproj package AgentBlazor.Client --version 0.2.0-preview.2
+        <pre class="docs-code"><code>dotnet add ./src/MyHostedServer/MyHostedServer.csproj package AgentBlazor --version 0.2.0-preview.3
+dotnet add ./src/MyHostedClient/MyHostedClient.csproj package AgentBlazor.Client --version 0.2.0-preview.3
 
 // Server
 app.MapAgentBlazorEndpoints();


### PR DESCRIPTION
## Summary
- update hosted demo docs from 0.2.0-preview.2 to 0.2.0-preview.3
- keep Getting Started, Verification, Docs home, and CLI examples aligned with the latest published preview

## Verification
- rg -n "0\.1\.0-preview\.11|0\.2\.0-preview\.2|preview\.2" demo/AgentBlazor.Demo/Components/Pages/Docs -S
- dotnet build demo/AgentBlazor.Demo/AgentBlazor.Demo.csproj -c Release --nologo *(blocked locally: package source mapping excludes /usr/lib/dotnet/library-packs for Microsoft.NETCore.App.Host.ubuntu.24.04-x64; CI container build will verify)*