### PR TITLE
Prepare stable 0.2.0 release

### DIFF
--- a/.github/ISSUE_TEMPLATE/install-friction.yml
+++ b/.github/ISSUE_TEMPLATE/install-friction.yml
@@ -8,7 +8,7 @@ body:
     id: command
     attributes:
       label: Command that failed
-      placeholder: dotnet add package AgentBlazor --version 0.1.0-preview.11
+      placeholder: dotnet add package AgentBlazor
     validations:
       required: true
   - type: input

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Local Package Smoke Test
         shell: pwsh
         run: |
-          ./scripts/smoke-test-local-package.ps1 -PackageVersion 0.1.0-preview.11
+          ./scripts/smoke-test-local-package.ps1 -PackageVersion 0.2.0
 
       - name: Restore Demo For E2E
         run: >

--- a/.github/workflows/publish-nuget-org.yml
+++ b/.github/workflows/publish-nuget-org.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       package_version:
-        description: "Package version to publish (example: 0.1.0-preview.11 or 0.1.0)"
+        description: "Package version to publish (example: 0.2.0-preview.N or 0.2.0)"
         required: true
         type: string
 
@@ -36,7 +36,7 @@ jobs:
         run: |
           $version = "${{ inputs.package_version }}"
           if ($version -notmatch '^\d+\.\d+\.\d+([-.].+)?$') {
-            throw "package_version must be a valid SemVer string such as 0.1.0-preview.11 or 0.1.0"
+            throw "package_version must be a valid SemVer string such as 0.2.0-preview.N or 0.2.0"
           }
 
       - name: Validate Central Package Pinning

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
 
   <!-- Common package metadata for all AgentBlazor packages -->
   <PropertyGroup>
-    <Version>0.2.0-preview.3</Version>
+    <Version>0.2.0</Version>
     <Authors>Ash Peterson</Authors>
     <Company>AgentBlazor</Company>
     <Copyright>Copyright (c) 2026 Ash Peterson</Copyright>
@@ -16,7 +16,7 @@
     <RepositoryType>git</RepositoryType>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <PackageIcon>icon.png</PackageIcon>
-    <PackageReleaseNotes>v0.2 preview: structured capability error recovery, schema-only EF Core entity exposure, hosted demo observability, verified package-first quickstart updates, and tool-friendly schemas for date-like workflow parameters.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.2: structured capability error recovery, schema-only EF Core entity exposure, hosted demo observability, verified package-first quickstart updates, and tool-friendly schemas for date-like workflow parameters.</PackageReleaseNotes>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <Deterministic>true</Deterministic>

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ Try the hosted demo:
 ## Install
 
 ```bash
-dotnet add package AgentBlazor --version 0.2.0-preview.3
+dotnet add package AgentBlazor
 ```
 
-Use `0.2.0-preview.3` or later. `0.2.0-preview.1` was superseded after publish because the optional EF package referenced an unpublished internal package; `0.2.0-preview.3` also fixes date-like workflow parameters so `DateOnly`, `TimeOnly`, `DateTime`, `DateTimeOffset`, and `Guid` project as tool-friendly string schemas.
+Use `0.2.0` or later. This release includes the corrected EF package shape and tool-friendly schemas for `DateOnly`, `TimeOnly`, `DateTime`, `DateTimeOffset`, and `Guid` workflow parameters.
 
 The CLI is optional. Keep it out of the critical path unless you want scaffold help for an existing app.
 
@@ -117,7 +117,7 @@ dotnet run --project samples/AgentBlazor.Starter/AgentBlazor.Starter.csproj
 If your app uses EF Core, install `AgentBlazor.EntityFrameworkCore` to expose selected entity shapes as planning context:
 
 ```bash
-dotnet add package AgentBlazor.EntityFrameworkCore --version 0.2.0-preview.3
+dotnet add package AgentBlazor.EntityFrameworkCore
 ```
 
 This is schema-only. It helps an agent understand safe entity fields, but it does not execute queries, generate LINQ or SQL, scan every `DbSet`, or grant write access. Data access still goes through your typed `[AgentAction]` methods.

--- a/demo/AgentBlazor.Demo/Components/Pages/Docs/CliGuide.razor
+++ b/demo/AgentBlazor.Demo/Components/Pages/Docs/CliGuide.razor
@@ -20,8 +20,8 @@
             </div>
         </div>
 
-        <pre class="docs-code"><code>dotnet tool install --global AgentBlazor.Cli --version 0.2.0-preview.3
-dotnet tool update --global AgentBlazor.Cli --version 0.2.0-preview.3</code></pre>
+        <pre class="docs-code"><code>dotnet tool install --global AgentBlazor.Cli
+dotnet tool update --global AgentBlazor.Cli</code></pre>
     </section>
 
     <section class="docs-section">

--- a/demo/AgentBlazor.Demo/Components/Pages/Docs/DocsHome.razor
+++ b/demo/AgentBlazor.Demo/Components/Pages/Docs/DocsHome.razor
@@ -40,7 +40,7 @@
             </div>
         </div>
 
-        <pre class="docs-code"><code>dotnet add package AgentBlazor --version 0.2.0-preview.3
+        <pre class="docs-code"><code>dotnet add package AgentBlazor
 builder.Services.AddAgentBlazor(...)
 app.MapAgentBlazorEndpoints()
 Render one chat surface on one route

--- a/demo/AgentBlazor.Demo/Components/Pages/Docs/GettingStarted.razor
+++ b/demo/AgentBlazor.Demo/Components/Pages/Docs/GettingStarted.razor
@@ -20,7 +20,7 @@
             </div>
         </div>
 
-        <pre class="docs-code"><code>dotnet add ./src/MyBlazorApp/MyBlazorApp.csproj package AgentBlazor --version 0.2.0-preview.3</code></pre>
+        <pre class="docs-code"><code>dotnet add ./src/MyBlazorApp/MyBlazorApp.csproj package AgentBlazor --version 0.2.0</code></pre>
     </section>
 
     <section class="docs-section">
@@ -30,7 +30,7 @@
             </div>
         </div>
 
-        <pre class="docs-code"><code>dotnet add ./src/MyBlazorApp/MyBlazorApp.csproj package AgentBlazor --version 0.2.0-preview.3
+        <pre class="docs-code"><code>dotnet add ./src/MyBlazorApp/MyBlazorApp.csproj package AgentBlazor --version 0.2.0
 
 builder.Services.AddMudServices();
 builder.Services.AddAgentBlazor(options =&gt; { ... });
@@ -81,7 +81,7 @@ app.MapAgentBlazorEndpoints();</code></pre>
             </div>
         </div>
 
-        <pre class="docs-code"><code>dotnet tool install --global AgentBlazor.Cli --version 0.2.0-preview.3
+        <pre class="docs-code"><code>dotnet tool install --global AgentBlazor.Cli
 agentblazor init ./MySolution.slnx --host MyBlazorApp
 agentblazor scaffold ./MySolution.slnx --host MyBlazorApp --provider openai --diff
 agentblazor scaffold ./MySolution.slnx --host MyBlazorApp --provider openai --approve
@@ -96,7 +96,7 @@ dotnet build ./MySolution.slnx --no-restore -nologo</code></pre>
             </div>
         </div>
 
-        <pre class="docs-code"><code>dotnet add ./src/MyBlazorApp.Client/MyBlazorApp.Client.csproj package AgentBlazor.Client --version 0.2.0-preview.3
+        <pre class="docs-code"><code>dotnet add ./src/MyBlazorApp.Client/MyBlazorApp.Client.csproj package AgentBlazor.Client
 
 // Server
 app.MapAgentBlazorEndpoints();

--- a/demo/AgentBlazor.Demo/Components/Pages/Docs/Verification.razor
+++ b/demo/AgentBlazor.Demo/Components/Pages/Docs/Verification.razor
@@ -20,7 +20,7 @@
             </div>
         </div>
 
-        <pre class="docs-code"><code>dotnet add ./src/MyBlazorApp/MyBlazorApp.csproj package AgentBlazor --version 0.2.0-preview.3
+        <pre class="docs-code"><code>dotnet add ./src/MyBlazorApp/MyBlazorApp.csproj package AgentBlazor --version 0.2.0
 dotnet build ./MySolution.slnx --nologo
 OpenAI__ApiKey=placeholder-key dotnet run --project ./src/MyBlazorApp/MyBlazorApp.csproj --no-launch-profile --urls http://127.0.0.1:5288
 Open the support route and submit one real prompt</code></pre>
@@ -35,7 +35,7 @@ Open the support route and submit one real prompt</code></pre>
 
         <pre class="docs-code"><code>dotnet new blazor -o FreshAgentBlazor
 cd FreshAgentBlazor
-dotnet add package AgentBlazor --version 0.2.0-preview.3
+dotnet add package AgentBlazor
 dotnet build FreshAgentBlazor.csproj --nologo</code></pre>
     </section>
 
@@ -46,8 +46,8 @@ dotnet build FreshAgentBlazor.csproj --nologo</code></pre>
             </div>
         </div>
 
-        <pre class="docs-code"><code>dotnet add ./src/MyHostedServer/MyHostedServer.csproj package AgentBlazor --version 0.2.0-preview.3
-dotnet add ./src/MyHostedClient/MyHostedClient.csproj package AgentBlazor.Client --version 0.2.0-preview.3
+        <pre class="docs-code"><code>dotnet add ./src/MyHostedServer/MyHostedServer.csproj package AgentBlazor --version 0.2.0
+dotnet add ./src/MyHostedClient/MyHostedClient.csproj package AgentBlazor.Client
 
 // Server
 app.MapAgentBlazorEndpoints();

--- a/demo/AgentBlazor.Demo/Components/Pages/Home.razor
+++ b/demo/AgentBlazor.Demo/Components/Pages/Home.razor
@@ -19,7 +19,7 @@
             <ol class="landing-page__quickstart-steps">
                 <li>
                     <span>1</span>
-                    <code>dotnet add package AgentBlazor --prerelease</code>
+                    <code>dotnet add package AgentBlazor</code>
                 </li>
                 <li>
                     <span>2</span>

--- a/docs/advanced/cli.md
+++ b/docs/advanced/cli.md
@@ -11,7 +11,7 @@ Use it when:
 Current run order:
 
 ```bash
-dotnet tool install --global AgentBlazor.Cli --version 0.2.0-preview.3
+dotnet tool install --global AgentBlazor.Cli
 agentblazor init ./MySolution.slnx --host MyBlazorApp
 agentblazor scaffold ./MySolution.slnx --host MyBlazorApp --provider openai --diff
 agentblazor scaffold ./MySolution.slnx --host MyBlazorApp --provider openai --approve

--- a/docs/beta-testing.md
+++ b/docs/beta-testing.md
@@ -20,7 +20,7 @@ Use a fresh app first. Do not start with an existing codebase.
 ```bash
 dotnet new blazor -o FreshAgentBlazor
 cd FreshAgentBlazor
-dotnet add package AgentBlazor --version 0.2.0-preview.3
+dotnet add package AgentBlazor
 ```
 
 Then follow:
@@ -43,7 +43,7 @@ Compare against the hosted support-inbox demo if you want a known-running refere
 
 Please report pass or fail for each of these:
 
-1. `dotnet add package AgentBlazor --version 0.2.0-preview.3`
+1. `dotnet add package AgentBlazor`
 2. `dotnet build`
 3. app starts with AgentBlazor assets loaded
 4. chat surface opens

--- a/docs/capability-errors.md
+++ b/docs/capability-errors.md
@@ -85,7 +85,7 @@ The reflection registry rejects the call before invoking the method because the 
 
 For in-method validation, the same runtime-probe capability returns `errorCode=invalid_date_range` when `endDate` is earlier than `startDate`. Use that shape when your method body can validate supplied arguments but the requested operation is not valid.
 
-In `0.2.0-preview.3` and later, date-like action parameters are projected as string schemas with useful formats. For example, `DateOnly startDate` is exposed to the model as a `string` with `format: date`, so prompts that provide explicit `yyyy-MM-dd` values can bind into the action body instead of failing as missing arguments.
+In `0.2.0` and later, date-like action parameters are projected as string schemas with useful formats. For example, `DateOnly startDate` is exposed to the model as a `string` with `format: date`, so prompts that provide explicit `yyyy-MM-dd` values can bind into the action body instead of failing as missing arguments.
 
 ## Runtime Wrapping
 

--- a/docs/entity-framework.md
+++ b/docs/entity-framework.md
@@ -7,17 +7,17 @@ This is schema-only planning context. It does not execute queries, generate LINQ
 ## Install
 
 ```bash
-dotnet add package AgentBlazor.EntityFrameworkCore --prerelease
+dotnet add package AgentBlazor.EntityFrameworkCore
 ```
 
 If you pin versions, use the same AgentBlazor version for the runtime and EF package:
 
 ```bash
-dotnet add package AgentBlazor --version 0.2.0-preview.3
-dotnet add package AgentBlazor.EntityFrameworkCore --version 0.2.0-preview.3
+dotnet add package AgentBlazor
+dotnet add package AgentBlazor.EntityFrameworkCore
 ```
 
-Use `0.2.0-preview.3` or later. `0.2.0-preview.1` was superseded after publish because this optional package referenced an unpublished internal package; `0.2.0-preview.3` also fixes date-like workflow parameters so they project as tool-friendly string schemas.
+Use `0.2.0` or later. This release includes the corrected EF package shape and tool-friendly schemas for date-like workflow parameters.
 
 ## DbContext Setup
 

--- a/docs/internal/beta-tester-runbook.md
+++ b/docs/internal/beta-tester-runbook.md
@@ -80,7 +80,7 @@ For each tester capture:
 If a tester asks what to do, answer with this exact path:
 
 1. create a fresh Blazor app
-2. run `dotnet add package AgentBlazor --version 0.2.0-preview.3`
+2. run `dotnet add package AgentBlazor --version 0.2.0`
 3. follow `docs/quickstart.md`
 4. test the support-inbox shape only
 5. submit feedback through one of the issue forms

--- a/docs/internal/launch-content/blog-post.md
+++ b/docs/internal/launch-content/blog-post.md
@@ -37,7 +37,7 @@ What it does not try to do at launch:
 The first install path is now the normal one:
 
 ```bash
-dotnet add package AgentBlazor --version 0.2.0-preview.3
+dotnet add package AgentBlazor --version 0.2.0
 ```
 
 Then wire `AddAgentBlazor(...)`, map `MapAgentBlazorEndpoints()`, add one capability class, and mount one chat surface.

--- a/docs/internal/launch-content/reddit-r-dotnet.md
+++ b/docs/internal/launch-content/reddit-r-dotnet.md
@@ -19,7 +19,7 @@ What it is:
 Current public package:
 
 ```bash
-dotnet add package AgentBlazor --version 0.2.0-preview.3
+dotnet add package AgentBlazor --version 0.2.0
 ```
 
 Current public demo:

--- a/docs/internal/launch-content/social-thread.md
+++ b/docs/internal/launch-content/social-thread.md
@@ -38,7 +38,7 @@ Post 4:
 Install path:
 
 ```bash
-dotnet add package AgentBlazor --version 0.2.0-preview.3
+dotnet add package AgentBlazor --version 0.2.0
 ```
 
 CLI exists, but it is the advanced path, not the headline.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,6 +1,6 @@
 # Quickstart
 
-Get one working AgentBlazor chat widget into a fresh Blazor app. Tested against a clean `dotnet new blazor` project with `AgentBlazor 0.2.0-preview.3`.
+Get one working AgentBlazor chat widget into a fresh Blazor app. Tested against a clean `dotnet new blazor` project with `AgentBlazor 0.2.0`.
 
 Hosted demo: https://demo.agentblazor.com/demo/workflows/support-inbox
 
@@ -9,7 +9,7 @@ AgentBlazor does not create a responding agent by default. You must register at 
 ## 1. Install
 
 ```bash
-dotnet add package AgentBlazor --version 0.2.0-preview.3
+dotnet add package AgentBlazor
 ```
 
 ## 2. Program.cs
@@ -176,7 +176,7 @@ Say hello
 ## Notes
 
 - `MapAgentBlazorEndpoints()` is required. Without it, the widget can render but cannot call the runtime.
-- `AgentBlazorShell` includes the widget in `0.2.0-preview.3`.
+- `AgentBlazorShell` includes the widget in `0.2.0`.
 - A registered workflow is required for the chat to respond.
 
 ## Next

--- a/docs/releases/0.2.0-test-plan.md
+++ b/docs/releases/0.2.0-test-plan.md
@@ -1,6 +1,6 @@
 # AgentBlazor 0.2.0 Release Test Plan
 
-Target package line: `0.2.0-preview.3` leading to `0.2.0`.
+Target package line: `0.2.0` stable.
 
 Use this plan to validate the release from a clean consumer app, not from project references. The goal is to prove that a new Blazor developer can install AgentBlazor from NuGet, wire one workflow, see the chat widget, use EF Core schema exposure, and observe structured error recovery.
 
@@ -8,7 +8,7 @@ Use this plan to validate the release from a clean consumer app, not from projec
 
 The release is not ready for `0.2.0` stable until these checks pass:
 
-- Fresh Blazor app installs `AgentBlazor 0.2.0-preview.3` from NuGet.org.
+- Fresh Blazor app installs `AgentBlazor 0.2.0` from NuGet.org.
 - Fresh Blazor app builds and starts after following the quickstart.
 - Chat widget renders, opens, and lists the registered workflow.
 - With a real OpenAI key, `Say hello` produces the expected workflow result.
@@ -16,7 +16,7 @@ The release is not ready for `0.2.0` stable until these checks pass:
 - EF schema registration is explicit, allowlisted, and does not require unpublished packages.
 - Structured error workflow returns recoverable `CapabilityResult` output for invalid/missing input.
 - Hosted demo still loads and support-inbox prompts work.
-- `0.2.0-preview.1` is unlisted on NuGet.org.
+- older preview packages are unlisted on NuGet.org.
 
 ## Test Environment
 
@@ -58,14 +58,14 @@ Verify all current packages are indexed:
 ```bash
 for p in agentblazor agentblazor.client agentblazor.entityframeworkcore agentblazor.cli; do
   echo "== $p =="
-  curl -fsSL "https://api.nuget.org/v3-flatcontainer/$p/index.json" | grep '0.2.0-preview.3'
+  curl -fsSL "https://api.nuget.org/v3-flatcontainer/$p/index.json" | grep '0.2.0'
 done
 ```
 
 Pass:
 
-- All four package IDs show `0.2.0-preview.3`.
-- `0.2.0-preview.1` is unlisted in the NuGet.org UI.
+- All four package IDs show `0.2.0`.
+- older preview packages are unlisted in the NuGet.org UI.
 
 Note: the flat-container API may still show unlisted versions. Use the NuGet.org package page or registration `listed` flag to verify unlisting.
 
@@ -76,7 +76,7 @@ Create a new app:
 ```bash
 dotnet new blazor -n AgentBlazorReleaseSmoke
 cd AgentBlazorReleaseSmoke
-dotnet add package AgentBlazor --version 0.2.0-preview.3 --source https://api.nuget.org/v3/index.json
+dotnet add package AgentBlazor --version 0.2.0 --source https://api.nuget.org/v3/index.json
 ```
 
 Apply the current [quickstart](../quickstart.md):
@@ -145,7 +145,7 @@ Fail:
 Install the optional package into the same fresh app:
 
 ```bash
-dotnet add package AgentBlazor.EntityFrameworkCore --version 0.2.0-preview.3 --source https://api.nuget.org/v3/index.json
+dotnet add package AgentBlazor.EntityFrameworkCore --version 0.2.0 --source https://api.nuget.org/v3/index.json
 dotnet add package Microsoft.EntityFrameworkCore.Sqlite
 ```
 
@@ -378,14 +378,14 @@ The CLI targets `net8.0`, so the machine must have .NET 8 runtime installed.
 ```bash
 TOOL_ROOT="$TEST_ROOT/tool"
 mkdir -p "$TOOL_ROOT"
-dotnet tool install AgentBlazor.Cli --tool-path "$TOOL_ROOT" --version 0.2.0-preview.3 --add-source https://api.nuget.org/v3/index.json
+dotnet tool install AgentBlazor.Cli --tool-path "$TOOL_ROOT" --version 0.2.0 --add-source https://api.nuget.org/v3/index.json
 "$TOOL_ROOT/agentblazor" --version
 ```
 
 Pass:
 
 - tool installs from NuGet.org
-- `agentblazor --version` reports `0.2.0-preview.3`
+- `agentblazor --version` reports `0.2.0`
 
 Known environment failure:
 
@@ -398,7 +398,7 @@ Create a hosted WebAssembly Blazor app or use the existing hosted WebAssembly va
 Minimum checks:
 
 ```bash
-dotnet add package AgentBlazor.Client --version 0.2.0-preview.3 --source https://api.nuget.org/v3/index.json
+dotnet add package AgentBlazor.Client --version 0.2.0 --source https://api.nuget.org/v3/index.json
 ```
 
 Pass:
@@ -412,8 +412,8 @@ Pass:
 
 Before cutting `0.2.0` stable:
 
-- `0.2.0-preview.1` is unlisted.
-- `0.2.0-preview.3` package pages and GitHub docs point to preview 3.
+- older preview packages are unlisted.
+- `0.2.0` package pages and GitHub docs point to stable 0.2.0.
 - quickstart passes with a real OpenAI key.
 - EF schema package passes fresh-app install/build.
 - structured error prompt path passes locally or on hosted runtime probe.

--- a/docs/releases/0.2.0.md
+++ b/docs/releases/0.2.0.md
@@ -1,10 +1,10 @@
 # AgentBlazor 0.2.0 Release Notes
 
-Target package line: `0.2.0-preview.3` leading to `0.2.0`.
+Target package line: `0.2.0` stable.
 
 AgentBlazor 0.2 focuses on making the package-first path credible: recoverable tool errors, explicit EF Core schema context for planning, a simpler hosted demo, and observable demo traffic/chat usage.
 
-Use `0.2.0-preview.3` for testing. `0.2.0-preview.1` was published first, but was superseded after the optional `AgentBlazor.EntityFrameworkCore` package was found to depend on unpublished internal `AgentBlazor.Core` package metadata. `0.2.0-preview.2` fixed that package shape; `0.2.0-preview.3` adds the date-parameter schema fix and passed a fresh public NuGet install/build smoke.
+`0.2.0` is the first stable release. Earlier preview builds were superseded during package validation; `0.2.0` includes the corrected EF package shape, tool-friendly date parameter schemas, and the fresh public NuGet install/build smoke fixes.
 
 For a fuller implementation log, see [0.2.0 completed work](0.2.0-completed-work.md).
 
@@ -34,7 +34,7 @@ See [Recoverable capability errors](../capability-errors.md).
 Install the optional package:
 
 ```bash
-dotnet add package AgentBlazor.EntityFrameworkCore --version 0.2.0-preview.3
+dotnet add package AgentBlazor.EntityFrameworkCore --version 0.2.0
 ```
 
 Register only safe entity/property metadata:
@@ -79,16 +79,16 @@ The protected `/internal/demo-logs` and `/internal/demo-logs/summary` endpoints 
 
 ## Install Path
 
-Pinned preview install:
+Pinned stable install:
 
 ```bash
-dotnet add package AgentBlazor --version 0.2.0-preview.3
+dotnet add package AgentBlazor --version 0.2.0
 ```
 
 Optional EF schema package:
 
 ```bash
-dotnet add package AgentBlazor.EntityFrameworkCore --version 0.2.0-preview.3
+dotnet add package AgentBlazor.EntityFrameworkCore --version 0.2.0
 ```
 
 Current quickstart:

--- a/samples/AgentBlazor.Starter/README.md
+++ b/samples/AgentBlazor.Starter/README.md
@@ -34,5 +34,5 @@ Inside this repo, the starter defaults to local source-project references so the
 To validate the published package path from inside the repo:
 
 ```powershell
-dotnet run --project samples/AgentBlazor.Starter/AgentBlazor.Starter.csproj -p:UseLocalAgentBlazorSource=false -p:AgentBlazorPackageVersion=0.2.0-preview.3
+dotnet run --project samples/AgentBlazor.Starter/AgentBlazor.Starter.csproj -p:UseLocalAgentBlazorSource=false -p:AgentBlazorPackageVersion=0.2.0
 ```

--- a/src/AgentBlazor.Cli.Analysis/ExistingAppScaffoldApplier.cs
+++ b/src/AgentBlazor.Cli.Analysis/ExistingAppScaffoldApplier.cs
@@ -301,7 +301,7 @@ public sealed class ExistingAppScaffoldApplier
             .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
             ?.InformationalVersion
             ?? typeof(ExistingAppScaffoldApplier).Assembly.GetName().Version?.ToString()
-            ?? "0.2.0-preview.3";
+            ?? "0.2.0";
 
         return version.Split('+', 2)[0];
     }

--- a/src/AgentBlazor.Cli/PACKAGE_README.md
+++ b/src/AgentBlazor.Cli/PACKAGE_README.md
@@ -5,13 +5,13 @@ Advanced scaffold and validation tool for wiring AgentBlazor into existing Blazo
 Install:
 
 ```bash
-dotnet tool install --global AgentBlazor.Cli --prerelease
+dotnet tool install --global AgentBlazor.Cli
 ```
 
-If you want the exact current preview:
+If you prefer a pinned install:
 
 ```bash
-dotnet tool install --global AgentBlazor.Cli --version 0.2.0-preview.3
+dotnet tool install --global AgentBlazor.Cli --version 0.2.0
 ```
 
 Example:

--- a/src/AgentBlazor.Cli/Program.cs
+++ b/src/AgentBlazor.Cli/Program.cs
@@ -7,7 +7,7 @@ var version = typeof(ScaffoldCommand).Assembly
     .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
     ?.InformationalVersion
     ?? typeof(ScaffoldCommand).Assembly.GetName().Version?.ToString()
-    ?? "0.2.0-preview.3";
+    ?? "0.2.0";
 version = version.Split('+', 2)[0];
 
 app.Configure(config =>

--- a/src/AgentBlazor.Client/PACKAGE_README.md
+++ b/src/AgentBlazor.Client/PACKAGE_README.md
@@ -5,13 +5,13 @@ Browser-safe AgentBlazor chat components for Blazor WebAssembly and hosted WebAs
 Install:
 
 ```bash
-dotnet add package AgentBlazor.Client --prerelease
+dotnet add package AgentBlazor.Client
 ```
 
-If you want the exact current preview:
+If you prefer a pinned install:
 
 ```bash
-dotnet add package AgentBlazor.Client --version 0.2.0-preview.3
+dotnet add package AgentBlazor.Client --version 0.2.0
 ```
 
 Server project:

--- a/src/AgentBlazor.Components/PACKAGE_README.md
+++ b/src/AgentBlazor.Components/PACKAGE_README.md
@@ -9,16 +9,16 @@ Hosted demo:
 Install:
 
 ```bash
-dotnet add package AgentBlazor --prerelease
+dotnet add package AgentBlazor
 ```
 
-Current public releases are prerelease builds. If you prefer a pinned install, use:
+If you prefer a pinned install, use:
 
 ```bash
-dotnet add package AgentBlazor --version 0.2.0-preview.3
+dotnet add package AgentBlazor --version 0.2.0
 ```
 
-Use `0.2.0-preview.3` or later. `0.2.0-preview.1` was superseded after publish because the optional EF package referenced an unpublished internal package; `0.2.0-preview.3` also fixes date-like workflow parameters so they project as tool-friendly string schemas.
+Use `0.2.0` or later. This release includes the corrected EF package shape and tool-friendly schemas for date-like workflow parameters.
 
 If `dotnet` still probes an old custom package source on your machine, remove or disable that source before testing the public NuGet install path.
 

--- a/src/AgentBlazor.EntityFrameworkCore/README.md
+++ b/src/AgentBlazor.EntityFrameworkCore/README.md
@@ -7,16 +7,16 @@ This package is schema-only. It does not execute queries, generate LINQ, generat
 Install:
 
 ```bash
-dotnet add package AgentBlazor.EntityFrameworkCore --prerelease
+dotnet add package AgentBlazor.EntityFrameworkCore
 ```
 
-Pinned preview:
+Pinned install:
 
 ```bash
-dotnet add package AgentBlazor.EntityFrameworkCore --version 0.2.0-preview.3
+dotnet add package AgentBlazor.EntityFrameworkCore --version 0.2.0
 ```
 
-Use `0.2.0-preview.3` or later. `0.2.0-preview.1` was superseded after publish because this optional package referenced an unpublished internal package; `0.2.0-preview.3` also fixes date-like workflow parameters so they project as tool-friendly string schemas.
+Use `0.2.0` or later. This release includes the corrected EF package shape and tool-friendly schemas for date-like workflow parameters.
 
 Register your `DbContext` with `IDbContextFactory<TContext>`:
 

--- a/tests/AgentBlazor.Cli.Analysis.Tests/ExistingAppScaffoldPlannerTests.cs
+++ b/tests/AgentBlazor.Cli.Analysis.Tests/ExistingAppScaffoldPlannerTests.cs
@@ -151,7 +151,7 @@ public sealed class ExistingAppScaffoldPlannerTests : IDisposable
                     <ImplicitUsings>enable</ImplicitUsings>
                   </PropertyGroup>
                   <ItemGroup>
-                    <PackageReference Include="AgentBlazor" Version="0.2.0-preview.3" />
+                    <PackageReference Include="AgentBlazor" Version="0.2.0" />
                   </ItemGroup>
                 </Project>
                 """,
@@ -186,7 +186,7 @@ public sealed class ExistingAppScaffoldPlannerTests : IDisposable
         var report = await new InstallReadinessAnalyzer().AnalyzeAsync(projectPath, hostProjectName: null);
 
         Assert.Contains(plan.Items, item => item.Id == "package-references" && item.Action == ScaffoldPlanAction.Update);
-        Assert.Contains("""<PackageReference Include="AgentBlazor" Version="0.2.0-preview.3" />""", projectText, StringComparison.Ordinal);
+        Assert.Contains("""<PackageReference Include="AgentBlazor" Version="0.2.0" />""", projectText, StringComparison.Ordinal);
         Assert.Contains("""<PackageReference Include="MudBlazor" Version="9.0.0" />""", projectText, StringComparison.Ordinal);
         Assert.Contains(report.Checks, check => check.Id == "package-references" && check.Status == InstallReadinessStatus.Pass);
     }
@@ -250,7 +250,7 @@ public sealed class ExistingAppScaffoldPlannerTests : IDisposable
         Assert.Contains("""<PackageReference Include="MudBlazor" />""", projectText, StringComparison.Ordinal);
         Assert.DoesNotContain("PackageReference Include=\"AgentBlazor\" Version=", projectText, StringComparison.Ordinal);
         Assert.DoesNotContain("PackageReference Include=\"MudBlazor\" Version=", projectText, StringComparison.Ordinal);
-        Assert.Contains("""<PackageVersion Include="AgentBlazor" Version="0.2.0-preview.3" />""", centralPackagesText, StringComparison.Ordinal);
+        Assert.Contains("""<PackageVersion Include="AgentBlazor" Version="0.2.0" />""", centralPackagesText, StringComparison.Ordinal);
         Assert.Contains("""<PackageVersion Include="MudBlazor" Version="9.0.0" />""", centralPackagesText, StringComparison.Ordinal);
     }
 

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -39,7 +39,7 @@ The external chat surface runner now verifies scaffold idempotency, submitted pr
 
 For external apps that require authentication before the main layout is reachable, set `AGENTBLAZOR_EXTERNAL_LOGIN_PATH`, `AGENTBLAZOR_EXTERNAL_LOGIN_USERNAME`, and `AGENTBLAZOR_EXTERNAL_LOGIN_PASSWORD`. The runner signs in before opening the installed floating widget and before visiting the injected surface harness. Set `AGENTBLAZOR_EXTERNAL_EXPECTED_TEXT` to require a protected-page marker before chat assertions begin; the matrix uses this for the CleanArchitecture `/identity/users` authenticated route.
 
-Current release context: `0.2.0-preview.3` is the current public prerelease. Local e2e runs still require a configured OpenAI, Azure OpenAI, or Ollama provider.
+Current release context: `0.2.0` is the current public stable release. Local e2e runs still require a configured OpenAI, Azure OpenAI, or Ollama provider.
 
 The real-usability runner requires an explicit live provider from environment variables. It intentionally does not treat demo `appsettings.json` sample values as proof that CI can reach a provider, because empty GitHub secrets or missing Ollama services otherwise produce misleading no-provider transcripts instead of a clear preflight failure.
 

--- a/tests/e2e/specs/home.spec.cjs
+++ b/tests/e2e/specs/home.spec.cjs
@@ -10,7 +10,7 @@ test.describe("Landing page", () => {
     await expect(page.locator("#hero").getByRole("link", { name: "Docs" })).toBeVisible();
     await expect(page.locator("#hero").getByRole("link", { name: "Live demo" })).toBeVisible();
     await expect(page.locator(".landing-page__quickstart")).toContainText("Quickstart");
-    await expect(page.locator(".landing-page__quickstart")).toContainText("dotnet add package AgentBlazor --prerelease");
+    await expect(page.locator(".landing-page__quickstart")).toContainText("dotnet add package AgentBlazor");
     await expect(page.locator(".landing-page__quickstart")).toContainText("AgentChatWidget");
     await expect(page.locator(".landing-page__hero-meta").getByRole("link", { name: "Read quickstart" })).toBeVisible();
     await expect(page.locator(".landing-page__hero-meta").getByRole("link", { name: "Try live demo" })).toBeVisible();


### PR DESCRIPTION
## Summary

Prepares the stable `0.2.0` release across package metadata, public docs, package READMEs, release notes, CLI scaffold defaults, and tests.

## Verification

- `dotnet test tests/AgentBlazor.Cli.Analysis.Tests/AgentBlazor.Cli.Analysis.Tests.csproj -c Release --filter ExistingAppScaffoldPlannerTests --nologo`
- `cd tests/e2e && npx playwright test specs/home.spec.cjs --config=playwright.config.cjs --reporter=list`
- `dotnet pack` completed for `AgentBlazor`, `AgentBlazor.Client`, `AgentBlazor.EntityFrameworkCore`, and `AgentBlazor.Cli` with `PackageVersion=0.2.0`
- Fresh Blazor local-feed smoke installed `AgentBlazor --version 0.2.0` and built
- Fresh Blazor local-feed smoke using unpinned `dotnet add package AgentBlazor --source <feed>` resolved `0.2.0` and built

## Notes

- Local PowerShell smoke script was not run in this environment because `pwsh` is unavailable; the publish workflow still runs the scripted smoke.
- Stable `0.2.0` still depends on preview Microsoft Agents hosting packages, which is documented in the README dependency section.
- Pack/build emits advisory warnings for transitive dependencies; these are warnings, not package blockers.
