### PR TITLE
Fix mobile chat input stability

### DIFF
--- a/src/AgentBlazor.Components/Chat/AgentChatBar.razor
+++ b/src/AgentBlazor.Components/Chat/AgentChatBar.razor
@@ -10,6 +10,7 @@
 @using AgentBlazor.Execution
 @using AgentBlazor.Options
 @using Microsoft.Extensions.Options
+@using Microsoft.JSInterop
 @implements IDisposable
 @using MudBlazor
 @inject IAgentRuntimeAdapter RuntimeAdapter
@@ -22,6 +23,7 @@
 @inject IOptions<AgentBlazorOptions> AgentBlazorOptionsAccessor
 @inject IServiceProvider ServiceProvider
 @inject IAgentExecutionScopeAccessor ExecutionScopeAccessor
+@inject IJSRuntime JSRuntime
 
 <div class="ab-chat-bar @(HasConversation ? "ab-chat-bar--has-conversation" : "ab-chat-bar--idle") @(Theme?.CssClass) @(Theme?.GetFeatureClasses()) @CssClass"
      data-theme="@(Theme?.DataTheme)"
@@ -36,19 +38,19 @@
             <MudIcon Icon="@Icon" Class="ab-chat-bar__icon" />
         }
         <input type="text"
+               id="@InputId"
                class="ab-chat-bar__input"
                placeholder="@Placeholder"
                aria-label="Message input"
                data-testid="agent-chat-bar-input"
-               @bind="_prompt"
-               @bind:event="oninput"
+               @oninput="HandlePromptInput"
                @onkeydown="HandleKeyDown"
                disabled="@_isBusy" />
         <button class="ab-chat-bar__send"
                 type="button"
                 aria-label="Send message"
                 data-testid="agent-chat-bar-send"
-                @onclick="SendAsync"
+                @onclick="SendFromButtonAsync"
                 disabled="@(_isBusy || string.IsNullOrWhiteSpace(_prompt))">
             @if (_isBusy)
             {
@@ -182,6 +184,7 @@
         new(StringComparer.OrdinalIgnoreCase);
     private string? _historyHydratedForSession;
     private bool? _lastConversationState;
+    private string InputId => $"ab-chat-bar-input-{_instanceId}";
 
     /// <summary>
     /// Placeholder text for the input field.
@@ -327,19 +330,33 @@
         }
     }
 
+    private void HandlePromptInput(ChangeEventArgs args)
+    {
+        _prompt = args.Value?.ToString() ?? string.Empty;
+    }
+
+    private Task SendFromButtonAsync()
+        => SendAsync();
+
     private async Task SendPromptAsync(string prompt)
     {
         _prompt = prompt;
-        await SendAsync();
+        await SetPromptElementValueAsync(prompt);
+        await SendAsync(readPromptElement: false);
     }
 
-    private async Task SendAsync()
+    private async Task SendAsync(bool readPromptElement = true)
     {
+        if (readPromptElement)
+        {
+            _prompt = await ReadPromptElementValueAsync(_prompt);
+        }
+
         if (string.IsNullOrWhiteSpace(_prompt) || _isBusy)
             return;
 
         var message = _prompt.Trim();
-        _prompt = string.Empty;
+        await ClearPromptAsync();
         _isBusy = true;
         _streamingResponseText = string.Empty;
         _streamingAgentName = null;
@@ -415,7 +432,7 @@
     public async Task SendMessageAsync(string message)
     {
         _prompt = message;
-        await SendAsync();
+        await SendAsync(readPromptElement: false);
     }
 
     /// <summary>
@@ -423,8 +440,43 @@
     /// </summary>
     public Task InjectAsync(string prompt)
     {
-        _prompt = prompt;
-        return InvokeAsync(StateHasChanged);
+        return InvokeAsync(async () =>
+        {
+            _prompt = prompt;
+            await SetPromptElementValueAsync(prompt);
+            StateHasChanged();
+        });
+    }
+
+    private async Task ClearPromptAsync()
+    {
+        _prompt = string.Empty;
+        await SetPromptElementValueAsync(string.Empty);
+    }
+
+    private async Task SetPromptElementValueAsync(string value)
+    {
+        try
+        {
+            await JSRuntime.InvokeVoidAsync("AgentBlazor.chat.setInputValue", InputId, value);
+        }
+        catch
+        {
+            // JS may be unavailable during prerender or component tests; the server-side prompt remains authoritative.
+        }
+    }
+
+    private async Task<string> ReadPromptElementValueAsync(string fallback)
+    {
+        try
+        {
+            return await JSRuntime.InvokeAsync<string>("AgentBlazor.chat.getInputValue", InputId);
+        }
+        catch
+        {
+            // JS may be unavailable during prerender or component tests; use the latest server-side input event value.
+            return fallback;
+        }
     }
 
     /// <summary>

--- a/src/AgentBlazor.Components/Chat/AgentChatSurface.razor
+++ b/src/AgentBlazor.Components/Chat/AgentChatSurface.razor
@@ -240,8 +240,7 @@
                         <input id="@ClarificationInputId"
                                type="text"
                                class="ab-chat-surface__input"
-                               @bind="_clarificationResponse"
-                               @bind:event="oninput"
+                               @oninput="HandleClarificationInput"
                                placeholder="Type your answer..."
                                disabled="@_isBusy"
                                @onkeydown="HandleClarificationKeyDown" />
@@ -410,7 +409,6 @@
             <textarea id="@PromptId"
                       class="ab-chat-surface__input"
                       rows="3"
-                      value="@_prompt"
                       @oninput="HandlePromptInput"
                       @onkeydown="HandlePromptKeyDown"
                       placeholder="@Placeholder"
@@ -795,6 +793,7 @@
         if (_isBusy)
             return;
 
+        _prompt = await ReadPromptElementValueAsync(_prompt);
         var message = _prompt.Trim();
         if (message.Length == 0)
             return;
@@ -810,9 +809,7 @@
 
         if (TryHandleAgentListCommand(message))
         {
-            _prompt = string.Empty;
-            _showSlashMenu = false;
-            _suggestions = [];
+            await ClearPromptAsync();
             _scrollRequested = true;
             StateHasChanged();
             return;
@@ -820,9 +817,7 @@
 
         if (TryHandleHandoffHistoryCommand(message))
         {
-            _prompt = string.Empty;
-            _showSlashMenu = false;
-            _suggestions = [];
+            await ClearPromptAsync();
             _scrollRequested = true;
             StateHasChanged();
             return;
@@ -830,9 +825,7 @@
 
         if (TryHandleHandoffPolicyCommand(message))
         {
-            _prompt = string.Empty;
-            _showSlashMenu = false;
-            _suggestions = [];
+            await ClearPromptAsync();
             _scrollRequested = true;
             StateHasChanged();
             return;
@@ -840,9 +833,7 @@
 
         if (await TryHandleHandoffDecisionCommandAsync(message))
         {
-            _prompt = string.Empty;
-            _showSlashMenu = false;
-            _suggestions = [];
+            await ClearPromptAsync();
             _scrollRequested = true;
             StateHasChanged();
             return;
@@ -850,18 +841,14 @@
 
         if (await TryHandleAgentHandoffCommandAsync(message))
         {
-            _prompt = string.Empty;
-            _showSlashMenu = false;
-            _suggestions = [];
+            await ClearPromptAsync();
             _scrollRequested = true;
             StateHasChanged();
             return;
         }
 
         _timeline.Add(ChatTimelineItem.User(message));
-        _suggestions = [];
-        _prompt = string.Empty;
-        _showSlashMenu = false;
+        await ClearPromptAsync();
         _pendingClarification = null;
         _pendingApprovals.Clear();
         _clarificationResponse = string.Empty;
@@ -906,15 +893,20 @@
     /// <summary>Populates the chat input with <paramref name="text"/> without submitting.</summary>
     public Task SetInputAsync(string text)
     {
-        _prompt = text;
-        _suggestions = [];
-        return InvokeAsync(StateHasChanged);
+        return InvokeAsync(async () =>
+        {
+            _prompt = text;
+            _suggestions = [];
+            await SetPromptElementValueAsync(text);
+            StateHasChanged();
+        });
     }
 
-    private void AcceptSuggestion(string text)
+    private async Task AcceptSuggestion(string text)
     {
         _prompt = text;
         _suggestions = [];
+        await SetPromptElementValueAsync(text);
         StateHasChanged();
     }
 
@@ -2328,10 +2320,16 @@
         }
     }
 
-    private void AcceptSlashItem(SlashItem item)
+    private void HandleClarificationInput(ChangeEventArgs args)
+    {
+        _clarificationResponse = args.Value?.ToString() ?? string.Empty;
+    }
+
+    private async Task AcceptSlashItem(SlashItem item)
     {
         _prompt = item.InsertText;
         _showSlashMenu = false;
+        await SetPromptElementValueAsync(item.InsertText);
         StateHasChanged();
     }
 
@@ -2913,7 +2911,44 @@
     /// <summary>Pre-fills the prompt input with the given text.</summary>
     public Task InjectAsync(string prompt)
     {
-        _prompt = prompt;
-        return InvokeAsync(StateHasChanged);
+        return InvokeAsync(async () =>
+        {
+            _prompt = prompt;
+            await SetPromptElementValueAsync(prompt);
+            StateHasChanged();
+        });
+    }
+
+    private async Task ClearPromptAsync()
+    {
+        _prompt = string.Empty;
+        _showSlashMenu = false;
+        _suggestions = [];
+        await SetPromptElementValueAsync(string.Empty);
+    }
+
+    private async Task SetPromptElementValueAsync(string value)
+    {
+        try
+        {
+            await JSRuntime.InvokeVoidAsync("AgentBlazor.chat.setInputValue", PromptId, value);
+        }
+        catch
+        {
+            // JS may be unavailable during prerender or component tests; the server-side prompt remains authoritative.
+        }
+    }
+
+    private async Task<string> ReadPromptElementValueAsync(string fallback)
+    {
+        try
+        {
+            return await JSRuntime.InvokeAsync<string>("AgentBlazor.chat.getInputValue", PromptId);
+        }
+        catch
+        {
+            // JS may be unavailable during prerender or component tests; use the latest server-side input event value.
+            return fallback;
+        }
     }
 }

--- a/src/AgentBlazor.Components/wwwroot/AgentBlazor.min.js
+++ b/src/AgentBlazor.Components/wwwroot/AgentBlazor.min.js
@@ -33,6 +33,16 @@ window.AgentBlazor = window.AgentBlazor || {
         textarea.removeEventListener('keydown', textarea._abChatEnterHandler);
         textarea._abChatEnterHandler = null;
       }
+    },
+    setInputValue: function (elementId, value) {
+      var input = document.getElementById(elementId);
+      if (!input) return;
+      input.value = value || '';
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    },
+    getInputValue: function (elementId) {
+      var input = document.getElementById(elementId);
+      return input ? input.value || '' : '';
     }
   },
   internal: {

--- a/tests/AgentBlazor.Components.Tests/AgentChatAutomationSelectorTests.cs
+++ b/tests/AgentBlazor.Components.Tests/AgentChatAutomationSelectorTests.cs
@@ -23,7 +23,9 @@ public sealed class AgentChatAutomationSelectorTests : TestContext
             .Add(static surface => surface.DefaultAgentName, "Test Agent"));
 
         Assert.NotNull(cut.Find("[data-testid='agent-chat-surface']"));
-        Assert.NotNull(cut.Find("textarea[aria-label='Message input']"));
+        var input = cut.Find("textarea[aria-label='Message input']");
+        Assert.NotNull(input);
+        Assert.False(input.HasAttribute("value"));
         Assert.NotNull(cut.Find("button[aria-label='Send message']"));
     }
 
@@ -76,7 +78,9 @@ public sealed class AgentChatAutomationSelectorTests : TestContext
         var cut = RenderComponent<AgentChatBar>();
 
         Assert.NotNull(cut.Find("[data-testid='agent-chat-bar']"));
-        Assert.NotNull(cut.Find("[data-testid='agent-chat-bar-input'][aria-label='Message input']"));
+        var input = cut.Find("[data-testid='agent-chat-bar-input'][aria-label='Message input']");
+        Assert.NotNull(input);
+        Assert.False(input.HasAttribute("value"));
         Assert.NotNull(cut.Find("[data-testid='agent-chat-bar-send'][aria-label='Send message']"));
     }
 


### PR DESCRIPTION
## Summary
- stop rendering chat input values back into the DOM on every server-side input event
- read live input values from the DOM before submit
- use explicit JS helpers for programmatic set/clear behavior
- cover chat surface and compact chat bar selectors with regression checks

## Verification
- dotnet test tests/AgentBlazor.Components.Tests/AgentBlazor.Components.Tests.csproj --no-restore --logger "console;verbosity=minimal"
- dotnet build src/AgentBlazor.Components/AgentBlazor.Components.csproj --no-restore