### PR TITLE
Prepare 0.2.1 release

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
 
   <!-- Common package metadata for all AgentBlazor packages -->
   <PropertyGroup>
-    <Version>0.2.0</Version>
+    <Version>0.2.1</Version>
     <Authors>Ash Peterson</Authors>
     <Company>AgentBlazor</Company>
     <Copyright>Copyright (c) 2026 Ash Peterson</Copyright>
@@ -16,7 +16,7 @@
     <RepositoryType>git</RepositoryType>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <PackageIcon>icon.png</PackageIcon>
-    <PackageReleaseNotes>v0.2: structured capability error recovery, schema-only EF Core entity exposure, hosted demo observability, verified package-first quickstart updates, and tool-friendly schemas for date-like workflow parameters.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.2.1: mobile chat input stability fix for Blazor Server chat surfaces, preserving v0.2 structured capability error recovery, schema-only EF Core entity exposure, hosted demo observability, and tool-friendly schemas for date-like workflow parameters.</PackageReleaseNotes>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <Deterministic>true</Deterministic>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AgentBlazor
 
-Last updated: 2026-05-19
+Last updated: 2026-05-27
 
 Add an agent chat surface and deterministic app actions to a Blazor app.
 
@@ -16,7 +16,7 @@ Try the hosted demo:
 dotnet add package AgentBlazor
 ```
 
-Use `0.2.0` or later. This release includes the corrected EF package shape and tool-friendly schemas for `DateOnly`, `TimeOnly`, `DateTime`, `DateTimeOffset`, and `Guid` workflow parameters.
+Use `0.2.1` or later. This release includes the mobile chat input stability fix, corrected EF package shape, and tool-friendly schemas for `DateOnly`, `TimeOnly`, `DateTime`, `DateTimeOffset`, and `Guid` workflow parameters.
 
 The CLI is optional. Keep it out of the critical path unless you want scaffold help for an existing app.
 
@@ -105,6 +105,7 @@ dotnet run --project samples/AgentBlazor.Starter/AgentBlazor.Starter.csproj
 ## Docs
 
 - [Quickstart](docs/quickstart.md)
+- [0.2.1 release notes](docs/releases/0.2.1.md)
 - [0.2.0 release notes](docs/releases/0.2.0.md)
 - [Recoverable capability errors](docs/capability-errors.md)
 - [Entity Framework Core schema exposure](docs/entity-framework.md)

--- a/docs/entity-framework.md
+++ b/docs/entity-framework.md
@@ -17,7 +17,7 @@ dotnet add package AgentBlazor
 dotnet add package AgentBlazor.EntityFrameworkCore
 ```
 
-Use `0.2.0` or later. This release includes the corrected EF package shape and tool-friendly schemas for date-like workflow parameters.
+Use `0.2.1` or later. This release includes the mobile chat input stability fix, corrected EF package shape, and tool-friendly schemas for date-like workflow parameters.
 
 ## DbContext Setup
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,6 +1,6 @@
 # Quickstart
 
-Get one working AgentBlazor chat widget into a fresh Blazor app. Tested against a clean `dotnet new blazor` project with `AgentBlazor 0.2.0`.
+Get one working AgentBlazor chat widget into a fresh Blazor app. Tested against a clean `dotnet new blazor` project with `AgentBlazor 0.2.1`.
 
 Hosted demo: https://demo.agentblazor.com/demo/workflows/support-inbox
 
@@ -176,12 +176,13 @@ Say hello
 ## Notes
 
 - `MapAgentBlazorEndpoints()` is required. Without it, the widget can render but cannot call the runtime.
-- `AgentBlazorShell` includes the widget in `0.2.0`.
+- `AgentBlazorShell` includes the widget in `0.2.0` and later.
 - A registered workflow is required for the chat to respond.
 
 ## Next
 
 - [Hosted demo](https://demo.agentblazor.com/demo/workflows/support-inbox)
+- [0.2.1 release notes](releases/0.2.1.md)
 - [0.2.0 release notes](releases/0.2.0.md)
 - [Starter sample](../samples/AgentBlazor.Starter/README.md)
 - [Hosted WebAssembly client](../src/AgentBlazor.Client/PACKAGE_README.md)

--- a/docs/releases/0.2.1.md
+++ b/docs/releases/0.2.1.md
@@ -1,0 +1,35 @@
+# AgentBlazor 0.2.1 Release Notes
+
+Target package line: `0.2.1` stable.
+
+AgentBlazor 0.2.1 is a focused patch release for mobile chat input stability.
+
+## Fixes
+
+- Chat input stability on mobile: `AgentChatSurface` and `AgentChatBar` no longer render controlled `value` attributes back into the DOM on every server-side input event. This avoids stale Blazor Server renders overwriting mobile keyboard input and appearing to delete letters.
+- Safer submit path: chat surfaces now read the live DOM input value before sending, so fast mobile submit and Enter behavior use the latest typed text.
+- Programmatic prompt updates remain supported through the bundled AgentBlazor JavaScript helpers for explicit set, clear, and read operations.
+
+## Verification
+
+- Component test suite passed.
+- `AgentBlazor.Components` builds for `net8.0`, `net9.0`, and `net10.0`.
+- Hosted demo was deployed with the same fix and smoke-tested on a mobile-sized browser viewport.
+
+## Install
+
+```bash
+dotnet add package AgentBlazor --version 0.2.1
+```
+
+Optional packages:
+
+```bash
+dotnet add package AgentBlazor.Client --version 0.2.1
+dotnet add package AgentBlazor.EntityFrameworkCore --version 0.2.1
+dotnet tool install --global AgentBlazor.Cli --version 0.2.1
+```
+
+## Previous Release
+
+For the full v0.2 feature set, see [0.2.0 release notes](0.2.0.md).

--- a/src/AgentBlazor.Cli.Analysis/ExistingAppScaffoldApplier.cs
+++ b/src/AgentBlazor.Cli.Analysis/ExistingAppScaffoldApplier.cs
@@ -301,7 +301,7 @@ public sealed class ExistingAppScaffoldApplier
             .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
             ?.InformationalVersion
             ?? typeof(ExistingAppScaffoldApplier).Assembly.GetName().Version?.ToString()
-            ?? "0.2.0";
+            ?? "0.2.1";
 
         return version.Split('+', 2)[0];
     }

--- a/src/AgentBlazor.Cli/PACKAGE_README.md
+++ b/src/AgentBlazor.Cli/PACKAGE_README.md
@@ -11,7 +11,7 @@ dotnet tool install --global AgentBlazor.Cli
 If you prefer a pinned install:
 
 ```bash
-dotnet tool install --global AgentBlazor.Cli --version 0.2.0
+dotnet tool install --global AgentBlazor.Cli --version 0.2.1
 ```
 
 Example:
@@ -28,4 +28,5 @@ Docs:
 
 - Repository: https://github.com/ashpeterson/AgentBlazor
 - Advanced CLI guide: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/advanced/cli.md
+- 0.2.1 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.1.md
 - 0.2.0 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.0.md

--- a/src/AgentBlazor.Cli/Program.cs
+++ b/src/AgentBlazor.Cli/Program.cs
@@ -7,7 +7,7 @@ var version = typeof(ScaffoldCommand).Assembly
     .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
     ?.InformationalVersion
     ?? typeof(ScaffoldCommand).Assembly.GetName().Version?.ToString()
-    ?? "0.2.0";
+    ?? "0.2.1";
 version = version.Split('+', 2)[0];
 
 app.Configure(config =>

--- a/src/AgentBlazor.Client/PACKAGE_README.md
+++ b/src/AgentBlazor.Client/PACKAGE_README.md
@@ -11,7 +11,7 @@ dotnet add package AgentBlazor.Client
 If you prefer a pinned install:
 
 ```bash
-dotnet add package AgentBlazor.Client --version 0.2.0
+dotnet add package AgentBlazor.Client --version 0.2.1
 ```
 
 Server project:
@@ -35,4 +35,5 @@ Docs:
 
 - Repository: https://github.com/ashpeterson/AgentBlazor
 - Quickstart: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/quickstart.md
+- 0.2.1 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.1.md
 - 0.2.0 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.0.md

--- a/src/AgentBlazor.Components/PACKAGE_README.md
+++ b/src/AgentBlazor.Components/PACKAGE_README.md
@@ -15,10 +15,10 @@ dotnet add package AgentBlazor
 If you prefer a pinned install, use:
 
 ```bash
-dotnet add package AgentBlazor --version 0.2.0
+dotnet add package AgentBlazor --version 0.2.1
 ```
 
-Use `0.2.0` or later. This release includes the corrected EF package shape and tool-friendly schemas for date-like workflow parameters.
+Use `0.2.1` or later. This release includes the mobile chat input stability fix, corrected EF package shape, and tool-friendly schemas for date-like workflow parameters.
 
 If `dotnet` still probes an old custom package source on your machine, remove or disable that source before testing the public NuGet install path.
 
@@ -88,6 +88,7 @@ Docs and demo:
 - Hosted demo: https://demo.agentblazor.com/demo/workflows/support-inbox
 - Structured error reference: https://demo.agentblazor.com/demo/workflows/runtime-probe
 - Quickstart: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/quickstart.md
+- 0.2.1 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.1.md
 - 0.2.0 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.0.md
 - Recoverable capability errors: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/capability-errors.md
 - Optional EF Core schema exposure: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/entity-framework.md

--- a/src/AgentBlazor.EntityFrameworkCore/README.md
+++ b/src/AgentBlazor.EntityFrameworkCore/README.md
@@ -13,10 +13,10 @@ dotnet add package AgentBlazor.EntityFrameworkCore
 Pinned install:
 
 ```bash
-dotnet add package AgentBlazor.EntityFrameworkCore --version 0.2.0
+dotnet add package AgentBlazor.EntityFrameworkCore --version 0.2.1
 ```
 
-Use `0.2.0` or later. This release includes the corrected EF package shape and tool-friendly schemas for date-like workflow parameters.
+Use `0.2.1` or later. This release includes the mobile chat input stability fix, corrected EF package shape, and tool-friendly schemas for date-like workflow parameters.
 
 Register your `DbContext` with `IDbContextFactory<TContext>`:
 


### PR DESCRIPTION
## Summary
- bump package metadata to 0.2.1
- add 0.2.1 release notes for the mobile chat input stability fix
- update public README/package READMEs/quickstart/EF docs to point at 0.2.1
- update CLI fallback scaffold version to 0.2.1

## Verification
- dotnet build src/AgentBlazor.Components/AgentBlazor.Components.csproj --no-restore
- dotnet build src/AgentBlazor.Cli/AgentBlazor.Cli.csproj --no-restore