### PR TITLE
docs: add CLI v1 scope

### DIFF
--- a/docs/internal/cli-v1-scope-2026-05-24.md
+++ b/docs/internal/cli-v1-scope-2026-05-24.md
@@ -1,0 +1,314 @@
+# AgentBlazor CLI v1 Scope
+
+Status: Active development scope.
+Target ship: 3-5 weeks from May 24 2026.
+
+Document purpose: single source of truth for what AgentBlazor CLI v1 contains, what it does not contain, and how it gets there. Updates as work progresses. Decisions captured here are locked unless explicitly revised in this document.
+
+## Review Notes From Current Repo
+
+This scope has been reviewed against the current codebase.
+
+- There is no `agentblazor analyze` command today. Current commands are `init`, `update`, `watch`, `doctor`, `validate`, and `scaffold`.
+- Current `init` already performs most of the static analysis, then writes `.agentblazor/AGENT.md` and `.agentblazor/.state`. The v1 `analyze` command must reuse the analysis path but avoid state writes by default.
+- `src/AgentBlazor.Cli` and `src/AgentBlazor.Cli.Analysis` currently target `net8.0`. The `net10.0` migration is a required v1 task, not already done.
+- `.agentblazorc` currently supports host/project analysis settings, not LLM provider or model configuration. Provider/model configuration for v1 needs either new config fields or environment-variable-only behavior.
+- Workflow registration is only detected as a readiness check today by searching for `AddWorkflow<` / `.AddWorkflow(`. The analysis model does not yet strongly represent registered agent names or workflow registrations.
+- The proposed `tests/cli-targets/*` reference applications do not exist yet and are part of v1 work.
+
+## Vision
+
+AgentBlazor CLI helps a developer onboard an AI agent into their existing application. The developer runs commands in their solution directory. The CLI analyses the project, suggests workflows the agent can perform, and helps the developer wire the agent into their app.
+
+The inspiration is OpenClaw, which onboards users into agents, and Hermes Agent, which onboards agents into operating systems. AgentBlazor CLI onboards agents into existing developer applications.
+
+## Vision Scope
+
+The full CLI vision includes, in eventual priority order:
+
+- Static and LLM analysis of an existing project to identify agent integration opportunities.
+- Interactive setup for provider and model configuration.
+- Workflow suggestions based on existing services and methods.
+- `SOUL.md` generation describing the agent's role in the specific app.
+- Skill files describing what the agent can do, with multi-level loading for context efficiency.
+- Restrictions hierarchy controlling what the agent cannot do.
+- Code generation for wiring suggestions, with developer approval at every step.
+- Incremental re-analysis when the application changes.
+
+These pieces are documented for context. Only the first piece ships in v1.
+
+## v1 Scope
+
+`agentblazor analyze` is a single read-mostly command that produces a markdown analysis report.
+
+### What v1 Ships
+
+A new CLI command, `agentblazor analyze`, that:
+
+- Loads the developer's solution or project by reusing the existing `ModelBuilder.BuildModelAsync` path.
+- Runs static analysis to catalogue routes, services, capabilities, actions, and existing AgentBlazor wiring state by reusing the existing `RazorAnalyzer`, `ServiceAnalyzer`, `AttributeAnalyzer`, `DiRegistrationAnalyzer`, `ActionScorer`, `PageActionLinker`, `RecommendationEngine`, and `InstallReadinessAnalyzer`.
+- Sends a framework-neutral summary of the static analysis to a configured LLM.
+- Receives workflow suggestions from the LLM.
+- Validates LLM suggestions against the static analysis to filter hallucinated methods, types, routes, and capabilities.
+- Produces a human-readable markdown report at `.agentblazor/analysis.md`.
+
+### What v1 Does Not Do
+
+Explicit non-scope for v1:
+
+- Does not generate or modify any code in the developer's project.
+- Does not write any files other than `.agentblazor/analysis.md`.
+- Does not update the existing `.agentblazor/.state` file.
+- Does not produce `SOUL.md`.
+- Does not produce skill files.
+- Does not handle restrictions.
+- Does not include interactive setup.
+- Does not support incremental re-analysis. Every run is a fresh analysis.
+- Does not support non-Blazor frameworks in v1. The architecture is designed to allow framework adapters to be added later, but whether they get built depends on v1 traction and audience evidence.
+
+Provider and model configuration is read from new v1 configuration fields or environment variables. If no provider is configured, the command exits with a clear error explaining exactly what to configure.
+
+## Command Signature
+
+The command takes an optional path argument plus flags:
+
+- `path`: optional solution, project, or directory path. Defaults to the current directory.
+- `--output`: path to write the analysis report. Defaults to `.agentblazor/analysis.md`.
+- `--include-readiness`: include `InstallReadinessAnalyzer` output as a section of the report. Defaults to true.
+- `--framework`: explicit framework override. Defaults to auto-detection. v1 only supports `blazor`; the flag exists for future framework adapters.
+
+## Report Contents
+
+The output markdown has the following sections, in order:
+
+1. Summary: host shape, project type, AgentBlazor wiring state.
+2. Routes and pages: discovered routes and the components serving them.
+3. Existing capabilities: already discovered `[AgentCapability]` and `[AgentAction]` methods.
+4. Services: discovered service-like classes with their methods, lifetime, and DI registration state.
+5. Workflow suggestions:
+   - Suggested workflow name.
+   - Description of what the workflow would do.
+   - Which existing methods it would use.
+   - Suggested capability class structure as illustrative C# code, not generated code.
+   - Reasoning for the suggestion.
+   - Confidence rating from the LLM.
+6. Install readiness: output from `InstallReadinessAnalyzer`, optional and on by default.
+7. Recommended next steps: actionable list combining suggestion priorities and readiness gaps.
+
+## Quality Gates For v1 Ship
+
+All of the following must be true before v1 ships:
+
+- All automated tests pass: analyser tests, LLM response parsing tests, and snapshot tests for report generation.
+- Manual verification on three synthetic projects produces sensible suggestions.
+- Manual verification on two real Blazor projects produces suggestions without hallucinated method references.
+- Token cost per analysis run is documented for the user.
+- The "no LLM provider configured" error path tells the user exactly what to configure.
+
+## Foundational Decisions
+
+### Language: .NET C#
+
+`AgentBlazor.Cli` is C# and stays C#. Existing analyser infrastructure is reused, not rewritten.
+
+Escape trigger: if a specific .NET capability gap blocks v1 ship, the language decision gets revisited against that specific gap. It is not reopened as a general "TypeScript might be better" hedge.
+
+### Install Path
+
+Existing install path remains:
+
+```bash
+dotnet tool install --global AgentBlazor.Cli
+```
+
+Target audience already has the .NET SDK. Future consideration of a curl-pipe-bash wrapper depends on the audience broadening; it is not v1 work.
+
+Required fix: CLI currently targets `net8.0`. Update to `net10.0` before v1 ship.
+
+### Code Generation In v1
+
+Out of scope.
+
+`agentblazor analyze` produces suggestions only. The developer applies suggestions manually.
+
+The code-generation decision, including whether Microsoft Agent Framework, Codex SDK, Claude Code as subprocess, OpenCode, or custom code powers automated changes, happens after v1 ships and there is evidence about whether developers want automated application or prefer manual review.
+
+## Extensibility Architecture
+
+The CLI is designed to support multiple project frameworks in future versions. v1 ships with a single concrete adapter, Blazor, but the internal architecture is shaped so that adding a non-Blazor adapter later requires building the adapter, not redesigning the core.
+
+This is not a public extension contract in v1. There is no documented "how to write a framework adapter" guide in v1. The internal abstractions exist for future maintainer flexibility, not community contribution.
+
+### Framework Detection
+
+Decision: auto-detect by default, with explicit `--framework` override.
+
+The CLI examines the project on startup to determine which framework adapter applies. Detection is delegated to a registered set of detectors. Each adapter contributes a detector. The first detector that returns a positive match wins. If no detector matches, the command exits with a clear error directing the user to use `--framework` if they believe a specific adapter should apply.
+
+For v1 the Blazor detector checks for `.csproj` files with Blazor SDK references or Razor components. It is the only registered detector.
+
+### Project Model Shape
+
+Decision: generic project model with framework-specific context type parameter.
+
+The core project model is `ProjectModel<TFrameworkContext>`. Neutral fields such as routes, services, components, capabilities, actions, and readiness state live on the generic base. Framework-specific data lives on `TFrameworkContext`.
+
+For v1, `BlazorFrameworkContext` carries Blazor-specific data: host shape, Razor component metadata, MudBlazor wiring state, and AgentBlazor package wiring state. The existing `ModelBuilder` is refactored to produce `ProjectModel<BlazorFrameworkContext>` rather than the current Blazor-shaped model.
+
+Trade-off: the LLM analysis layer is generic over `TFrameworkContext`. Test fixtures are typed per framework. The benefit is type safety; the cost is more verbose analysis-layer code.
+
+### Adapter Contract
+
+Each framework adapter implements `IProjectAnalyzer<TFrameworkContext>` or a similarly named interface. The interface defines:
+
+- Detection: can this adapter handle the given project path?
+- Model construction: given a project path, produce a `ProjectModel<TFrameworkContext>` with neutral and framework-specific data populated.
+- Prompt template: the LLM prompt template used to analyse projects of this framework.
+- Response validation: verify LLM-suggested workflows reference real methods and types in the constructed model.
+
+The Blazor adapter is implemented as `BlazorProjectAnalyzer : IProjectAnalyzer<BlazorFrameworkContext>` and lives under `src/AgentBlazor.Cli.Analysis/Blazor/`.
+
+### Prompt Construction
+
+Decision: each adapter owns its prompt template.
+
+The adapter contributes the full prompt template used to generate workflow suggestions. The core supplies the project model summary as input but does not construct the framework-specific prompt itself.
+
+Trade-off: each future framework requires its own prompt-engineering investment. There is no shared prompt asset that all frameworks reuse. The benefit is that framework-aware prompts can be more directive and produce better suggestions.
+
+For v1, the Blazor adapter prompt template lives at `src/AgentBlazor.Cli.Analysis/Blazor/prompts/workflow-suggestions.md`, or a similar location settled during implementation.
+
+### Core Responsibilities
+
+The core orchestrates without knowing about specific frameworks:
+
+- Loads the configured LLM provider.
+- Calls the detected adapter's detection method.
+- Calls the detected adapter's model construction method.
+- Loads the adapter's prompt template.
+- Sends the prompt to the LLM with the model summary as context.
+- Calls the adapter's response validation.
+- Renders validated suggestions into the report alongside neutral sections.
+
+### Future React Adapter Shape
+
+If a React adapter is built later, it needs:
+
+- `ReactFrameworkContext` carrying React-specific data: routing library detected, component patterns, state management approach, and build tooling.
+- `ReactProjectDetector` that recognises React projects through `package.json`, React dependencies, JSX/TSX files, and framework-specific config files.
+- `ReactProjectAnalyzer : IProjectAnalyzer<ReactFrameworkContext>` that walks the project, parses JSX/TSX, identifies routes and services, and produces the model.
+- A prompt template tuned for React project structure and idioms.
+- A response validator that confirms LLM suggestions reference real React components and functions.
+
+Estimated effort if undertaken: 6-8 weeks for the first non-Blazor adapter, less for subsequent adapters once the contract is proven.
+
+This worked example is the architectural validation. If the v1 design cannot describe what a React adapter requires in concrete terms, the architecture is hand-waving.
+
+### What The Architecture Does Not Include
+
+- Plugin loading. Adapters are compiled into the CLI binary, not loaded from external assemblies.
+- Public extension SDK. Third parties cannot ship adapters without forking.
+- Versioned adapter contract. The interface can change between minor versions of the CLI.
+- Cross-framework analysis. The CLI handles one project at a time, one framework at a time.
+
+These constraints exist because v1 is shipping with one adapter. Designing public extension surfaces before a second adapter exists would produce wrong abstractions.
+
+## Testing Path
+
+### Test Project Structure
+
+Three reference Blazor applications are maintained in the repo for testing. These do not currently exist and are part of v1 implementation.
+
+- `tests/cli-targets/simple-blazor-app/`: minimal standard Blazor Web App with two or three services.
+- `tests/cli-targets/realistic-blazor-app/`: closer to a real app; eight to twelve services, multiple routes, EF Core, and some existing workflow infrastructure.
+- `tests/cli-targets/hosted-wasm-app/`: hosted WebAssembly variant to verify analysis against that host shape.
+
+### Automated Tests
+
+- Static analysis tests: verify each test project is classified correctly.
+- LLM response shape tests: with a mocked or recorded LLM response, verify the parser handles malformed responses, missing fields, and hallucinated method names.
+- Report generation tests: given known static and LLM inputs, verify the output markdown matches a snapshot.
+- Adapter contract tests: verify the Blazor adapter implements `IProjectAnalyzer<BlazorFrameworkContext>` correctly.
+
+### Manual Verification
+
+- Run `agentblazor analyze` against each synthetic test project and verify suggestions look sensible.
+- Run against two real Blazor projects to catch issues synthetic projects miss.
+
+This is the load-bearing test. Synthetic projects validate the mechanism. Real projects validate the suggestions.
+
+## Existing Infrastructure Reused
+
+| Responsibility | Existing implementation |
+| --- | --- |
+| Solution and project loading | `ModelBuilder.BuildModelAsync`, refactored into the Blazor adapter |
+| Route, page, component scanning | `RazorAnalyzer`, moved under or wrapped by the Blazor adapter |
+| Capability and action discovery | `AttributeAnalyzer` |
+| Service discovery | `ServiceAnalyzer` and `DiRegistrationAnalyzer` |
+| Candidate action scoring | `ActionScorer`; review during refactor for neutral versus adapter-specific scope |
+| Page-to-action linking | `PageActionLinker` |
+| Coverage and recommendations | `RecommendationEngine` |
+| Install readiness assessment | `InstallReadinessAnalyzer`; readiness is framework-specific |
+
+## New Work For v1
+
+- `AnalyzeCommand`: CLI command registration and orchestration.
+- `IProjectAnalyzer<TFrameworkContext>`: adapter contract.
+- `BlazorFrameworkContext`: Blazor-specific data structure.
+- `BlazorProjectAnalyzer`: implementation of `IProjectAnalyzer<BlazorFrameworkContext>` wrapping existing infrastructure.
+- `BlazorProjectDetector`: framework auto-detection logic.
+- LLM analysis layer: prompt loading, LLM call orchestration, response parsing.
+- Blazor-tuned prompt template: actual prompt used to generate workflow suggestions.
+- Report format: human-readable CLI report distinct from existing `AGENT.md` agent-context output.
+- Read-only mode for v1: does not write `.agentblazor/.state` by default.
+- Refactoring of `ModelBuilder` to produce typed model: turns existing Blazor-shaped output into `ProjectModel<BlazorFrameworkContext>`.
+- Stronger workflow registration model if v1 report must show registered agent names and workflow names rather than just readiness state.
+- Provider/model configuration fields or documented environment variable contract.
+
+## Out Of Scope Forever For AgentBlazor CLI
+
+- Replacing the existing AgentBlazor package plus manual wiring path. The CLI is additive. Developers who prefer the package-and-attributes approach can ignore the CLI entirely.
+- Acting as a general-purpose coding agent. The CLI's scope is agent onboarding, not arbitrary code modification.
+- Hosting the agent itself. AgentBlazor runtime stays in-process in the user's app.
+- Cross-framework projects. The CLI handles one framework per project.
+
+## v2+ Deliverables
+
+The following are the rest of the CLI vision. Each gets its own scope after v1 ships and there is data to inform the design.
+
+- v1.5: `agentblazor setup`: interactive provider and model configuration. Replaces edit-config-by-hand. Estimate: 2-3 weeks after v1.
+- v2: `SOUL.md` generation: living document describing the agent's role in the specific app. Initial generation from analyze output, updated via `agentblazor update`. Estimate: 4-6 weeks.
+- v3: skill files with multi-level loading: skill markdown files with frontmatter; Hermes-inspired index/skill-view/deep-reference loading. Estimate: 6-8 weeks.
+- v4: code generation: CLI applies suggestions automatically with developer approval. Foundation decision made based on v1-v3 learnings.
+- v5: restrictions hierarchy: system-level, mode-level, and skill-level restrictions. Depends on v3 shipping first. Estimate: 3-4 weeks once foundation exists.
+- v6+: second framework adapter, likely React. Whether it gets built depends on v1 traction and audience evidence.
+
+Realistic full-vision shipping window: late Q3 2026 or early Q4 2026.
+
+## Existing AgentBlazor During CLI Development
+
+The current AgentBlazor package, including chat widget, capability classes, and EF schema exposure, stays maintained but is not actively promoted during CLI v1 development.
+
+- Package stays on NuGet.
+- Demo at `demo.agentblazor.com` stays running.
+- Bugs get fixed when reported.
+- New chat-widget features wait until CLI v1 ships, unless a real user need surfaces.
+
+This is the answer to "what happens to people who installed v0.2.0": they get a working product that is not actively evolving, with bug fixes when reported, and a more compelling onboarding experience when CLI v1 ships.
+
+## Timeline
+
+| Milestone | Target |
+| --- | --- |
+| Scope document committed to repo | May 24 2026 |
+| CLI .NET version updated to `net10.0` | Week 1 |
+| `IProjectAnalyzer` interface defined; `ModelBuilder` refactor to produce typed model | Week 1 |
+| `BlazorProjectAnalyzer` wrapping existing infrastructure | Week 1-2 |
+| `AnalyzeCommand` skeleton wired to adapter | Week 2 |
+| Prompt template drafted and tuned against synthetic projects | Week 2-3 |
+| LLM analysis layer with response validation | Week 3 |
+| Report generation | Week 3-4 |
+| Manual verification against real projects | Week 4-5 |
+| v1 ship | Week 5 target, Week 6-7 acceptable slip |
+
+Slip past week 7 triggers a scope review, not a timeline extension.


### PR DESCRIPTION
Adds the internal AgentBlazor CLI v1 scope document, including current repo review notes and the planned analyze-command scope.