### PR TITLE
feat(cli): analyze referenced Razor projects

### DIFF
--- a/docs/internal/cli-v1-real-app-validation-2026-05-27.md
+++ b/docs/internal/cli-v1-real-app-validation-2026-05-27.md
@@ -12,7 +12,9 @@ Environment:
 - Model: environment default, currently `gpt-4o-mini` when unset
 - Temporary clone root: `/tmp/agentblazor-cli-v1-realapps`
 - Packaged tool: locally packed `AgentBlazor.Cli.0.2.1.nupkg`, installed via `dotnet tool install AgentBlazor.Cli --tool-path /tmp/agentblazor-cli-v1-tool-smoke/tool --configfile /tmp/agentblazor-cli-v1-tool-smoke/NuGet.config --version 0.2.1`
-- Packaged tool output root: `/tmp/agentblazor-cli-v1-tool-smoke`
+- Initial packaged tool output root: `/tmp/agentblazor-cli-v1-tool-smoke`
+- Expanded real-app clone root: `/tmp/agentblazor-cli-v1-more-realapps`
+- Final packaged tool output root after RCL route and semantic-validation fixes: `/tmp/agentblazor-cli-v1-tool-smoke-final2`
 
 ## Packaged Tool Quality Gates
 
@@ -86,16 +88,77 @@ Environment:
   - Report SDK-resolution failures as SDK setup problems rather than opaque unexpected exceptions.
   - Resolve target frameworks inherited from `Directory.Build.props`.
 
+## Expanded Real-App Matrix
+
+### dotnet-architecture/eShopOnBlazor
+
+- Repo: `https://github.com/dotnet-architecture/eShopOnBlazor`
+- Solution: `eShopOnBlazor.sln`
+- Host: `eShopOnBlazor`
+- Packaged tool result: 5 routes, 2 developer-facing services, 7 discovered actions, 4 accepted, 0 rejected
+- Outcome: pass. Standard Blazor Web App on `net8.0`; workflow suggestions reference real catalog service methods.
+
+### immense/Remotely
+
+- Repo: `https://github.com/immense/Remotely`
+- Solution: `Remotely.sln`
+- Host: `Server`
+- Packaged tool result after stricter validation: 45 routes, 18 developer-facing services, 113 discovered actions, 5 accepted, 0 rejected
+- Outcome: pass. Large production app with many routes and services; useful as a stress test for route volume and workflow candidate filtering.
+
+### CuriousDrive/BlazingChat
+
+- Repo: `https://github.com/CuriousDrive/BlazingChat`
+- Solution: `src/BlazingChat.sln`
+- Host: `BlazingChat.Server`
+- Initial packaged result before RCL route fix: 0 routes, 2 developer-facing services, 2 discovered actions, 2 accepted, 0 rejected
+- Final packaged result after RCL route and semantic-validation fixes: 10 routes, 1 developer-facing service, 2 discovered actions, 2 accepted, 2 rejected
+- Outcome: pass with caveat. The app targets `net6.0` and uses legacy Blazor Server hosting, so readiness correctly flags unsupported target framework and legacy host shape.
+- Fixes driven by this app:
+  - Include routed Razor components from referenced Razor Class Library projects.
+  - Exclude lifecycle/noise methods such as `Dispose` and `OnPropertyChanged` from developer-facing service reports and LLM prompts.
+  - Validate LLM workflow suggestions against scored candidate actions, not every public method.
+  - Reject suggestions whose referenced method terms do not align with the workflow description.
+
+### Yu-Core/SwashbucklerDiary
+
+- Repo: `https://github.com/Yu-Core/SwashbucklerDiary`
+- Solution: `SwashbucklerDiary.Server.slnx`
+- Host: `SwashbucklerDiary.Server`
+- Initial packaged result before RCL route fix: 2 routes, 21 developer-facing services, 79 discovered actions, 5 accepted, 0 rejected
+- Final packaged result after RCL route and semantic-validation fixes: 38 routes, 21 developer-facing services, 79 discovered actions, 3 accepted, 2 rejected
+- Outcome: pass. This validates route discovery across a server host plus referenced RCL projects in a modern `net10.0` app.
+
+### microsoft/FhirBlaze
+
+- Repo: `https://github.com/microsoft/FhirBlaze`
+- Solution: `FhirBlaze.sln`
+- Host: `FhirBlaze`
+- Initial packaged result before RCL route fix: 4 routes, 3 developer-facing services, 24 discovered actions, 5 accepted, 0 rejected
+- Final packaged result after RCL route and semantic-validation fixes: 13 routes, 3 developer-facing services, 24 discovered actions, 3 accepted, 2 rejected
+- Outcome: pass with caveat. Standalone WebAssembly host is reported as unsupported for install readiness, but analysis still discovers module routes and grounded workflow candidates.
+
+### stavroskasidis/BlazorWithIdentity
+
+- Repo: `https://github.com/stavroskasidis/BlazorWithIdentity`
+- Solution: `template/BlazorWithIdentity.sln`
+- Host: `BlazorWithIdentity.Client`
+- Result: completed after temporary clone-only `global.json` roll-forward was added because the repo pins .NET SDK `7.0.100` and this environment has .NET 10 SDK installed.
+- Packaged tool result: 5 routes, 1 developer-facing service, 4 discovered actions, 4 accepted, 0 rejected
+- Outcome: pass with caveat. Initial run against `BlazorWithIdentity.Server` correctly reported the available Blazor host as `BlazorWithIdentity.Client`.
+
 ## Current Evidence
 
-- Automated analysis tests pass: `160`
+- Automated analysis tests pass: `161`
 - CLI build passes: `dotnet build src/AgentBlazor.Cli/AgentBlazor.Cli.csproj`
 - Local packaged tool install passes from `AgentBlazor.Cli.0.2.1.nupkg`.
 - Packaged no-provider and `--static-only` paths pass.
-- Real OpenAI-backed analysis completed on 5 real GitHub Blazor applications.
-- Packaged `dotnet tool` smoke completed on the same 5 real GitHub Blazor applications.
+- Real OpenAI-backed analysis completed on 11 real GitHub Blazor applications.
+- Packaged `dotnet tool` smoke completed on 11 real GitHub Blazor applications.
 - Hallucinated methods were rejected on sparse apps.
 - Accepted workflow suggestions on larger apps reference methods present in the static model.
+- Referenced RCL routes are discovered for hosted/componentized apps.
+- Semantically misaligned LLM suggestions are rejected even when they reference real methods.
 
 ## Remaining Before v1 Complete
 

--- a/src/AgentBlazor.Cli.Analysis/AnalysisModelFilters.cs
+++ b/src/AgentBlazor.Cli.Analysis/AnalysisModelFilters.cs
@@ -78,8 +78,11 @@ public static class AnalysisModelFilters
 
     private static readonly string[] UiStateMethodNames =
     [
+        "Dispose",
+        "DisposeAsync",
         "Load",
         "LoadAsync",
+        "OnPropertyChanged",
         "Reset",
         "ResetAsync",
         "IsHighlighted",

--- a/src/AgentBlazor.Cli.Analysis/ModelBuilder.cs
+++ b/src/AgentBlazor.Cli.Analysis/ModelBuilder.cs
@@ -76,7 +76,8 @@ public sealed class ModelBuilder
             OnProgress?.Invoke("Loading project...");
             hostProject = await _solutionLoader.LoadProjectAsync(solutionOrProjectPath, ct);
             ReportDiagnostics(_solutionLoader.Diagnostics);
-            projects = [hostProject];
+            solution = hostProject.Solution;
+            projects = solution.Projects.ToList();
         }
 
         if (hostProject == null)
@@ -93,12 +94,33 @@ public sealed class ModelBuilder
 
         OnProgress?.Invoke($"Analyzing Blazor host: {hostProject.Name}");
 
-        // Get the project directory for Razor analysis
         var projectDir = Path.GetDirectoryName(hostProject.FilePath)!;
+        var relativeBaseDir = isSolution
+            ? Path.GetDirectoryName(Path.GetFullPath(solutionOrProjectPath))!
+            : projectDir;
+        var analysisProjects = solution is null
+            ? [hostProject]
+            : GetAnalysisProjects(solution, hostProject);
 
         // 1. Analyze Razor files
         OnProgress?.Invoke("Scanning Razor components...");
-        var razorAnalyses = await _razorAnalyzer.AnalyzeDirectoryAsync(projectDir, ct);
+        var razorAnalyses = new List<RazorFileAnalysis>();
+        foreach (var project in analysisProjects.Where(SolutionLoader.IsBlazorProject))
+        {
+            var directory = Path.GetDirectoryName(project.FilePath);
+            if (string.IsNullOrWhiteSpace(directory) || !Directory.Exists(directory))
+            {
+                continue;
+            }
+
+            var projectRazorAnalyses = await _razorAnalyzer.AnalyzeDirectoryAsync(directory, ct).ConfigureAwait(false);
+            razorAnalyses.AddRange(projectRazorAnalyses);
+        }
+
+        razorAnalyses = razorAnalyses
+            .GroupBy(analysis => analysis.FilePath, StringComparer.OrdinalIgnoreCase)
+            .Select(group => group.First())
+            .ToList();
 
         // 2. Extract routes
         OnProgress?.Invoke("Extracting routes...");
@@ -109,7 +131,7 @@ public sealed class ModelBuilder
                 Id = GenerateRouteId(r.Template),
                 Template = r.Template,
                 ComponentName = r.ComponentName,
-                ComponentFile = MakeRelativePath(projectDir, r.FilePath),
+                ComponentFile = MakeRelativePath(relativeBaseDir, r.FilePath),
                 Parameters = r.Parameters
             })
             .ToList();
@@ -120,7 +142,7 @@ public sealed class ModelBuilder
         {
             Id = GenerateId(r.ComponentName),
             Name = r.ComponentName,
-            FilePath = MakeRelativePath(projectDir, r.FilePath),
+            FilePath = MakeRelativePath(relativeBaseDir, r.FilePath),
             Namespace = r.Namespace,
             IsPage = r.IsPage,
             Routes = r.Routes.Select(rt => rt.Template).ToList(),
@@ -131,17 +153,11 @@ public sealed class ModelBuilder
 
         // 4. Find [AgentCapability] classes
         OnProgress?.Invoke("Detecting AgentBlazor attributes...");
-        var capabilities = await _attributeAnalyzer.FindCapabilityClassesAsync(hostProject, ct);
-
-        // Also check referenced projects
-        if (solution != null)
+        var capabilities = new List<CapabilityInfo>();
+        foreach (var project in analysisProjects)
         {
-            var referencedProjects = GetReferencedProjects(solution, hostProject);
-            foreach (var refProject in referencedProjects)
-            {
-                var refCapabilities = await _attributeAnalyzer.FindCapabilityClassesAsync(refProject, ct);
-                capabilities = capabilities.Concat(refCapabilities).ToList();
-            }
+            var projectCapabilities = await _attributeAnalyzer.FindCapabilityClassesAsync(project, ct).ConfigureAwait(false);
+            capabilities.AddRange(projectCapabilities);
         }
 
         OnProgress?.Invoke($"Found {capabilities.Count} [[AgentCapability]] classes");
@@ -158,17 +174,11 @@ public sealed class ModelBuilder
 
         // 5. Find DI registrations
         OnProgress?.Invoke("Analyzing DI registrations...");
-        var diRegistrations = await _diAnalyzer.FindRegistrationsAsync(hostProject, ct);
-
-        // Also check referenced projects
-        if (solution != null)
+        var diRegistrations = new List<DiRegistrationModel>();
+        foreach (var project in analysisProjects)
         {
-            var referencedProjects = GetReferencedProjects(solution, hostProject);
-            foreach (var refProject in referencedProjects)
-            {
-                var refDiRegs = await _diAnalyzer.FindRegistrationsAsync(refProject, ct);
-                diRegistrations = diRegistrations.Concat(refDiRegs).ToList();
-            }
+            var projectRegistrations = await _diAnalyzer.FindRegistrationsAsync(project, ct).ConfigureAwait(false);
+            diRegistrations.AddRange(projectRegistrations);
         }
 
         OnProgress?.Invoke($"Found {diRegistrations.Count} DI registrations");
@@ -181,17 +191,11 @@ public sealed class ModelBuilder
 
         // 6. Find and analyze services
         OnProgress?.Invoke("Analyzing services...");
-        var services = await _serviceAnalyzer.FindServiceClassesAsync(hostProject, ct);
-
-        // Also check referenced projects
-        if (solution != null)
+        var services = new List<ServiceModel>();
+        foreach (var project in analysisProjects)
         {
-            var referencedProjects = GetReferencedProjects(solution, hostProject);
-            foreach (var refProject in referencedProjects)
-            {
-                var refServices = await _serviceAnalyzer.FindServiceClassesAsync(refProject, ct);
-                services = services.Concat(refServices).ToList();
-            }
+            var projectServices = await _serviceAnalyzer.FindServiceClassesAsync(project, ct).ConfigureAwait(false);
+            services.AddRange(projectServices);
         }
 
         // Enhance services with DI registration info
@@ -259,7 +263,7 @@ public sealed class ModelBuilder
                         Name = GenerateActionName(actionInfo.MethodName),
                         SourceService = capability.ClassName,
                         MethodName = actionInfo.MethodName,
-                        FilePath = MakeRelativePath(projectDir, capability.FilePath),
+                        FilePath = MakeRelativePath(relativeBaseDir, capability.FilePath),
                         IsMutationLikely = actionInfo.RequiresApproval,
                         RequiresApproval = actionInfo.RequiresApproval,
                         Classification = ActionClassification.Workflow,
@@ -297,7 +301,7 @@ public sealed class ModelBuilder
                     Id = GenerateRouteId(route),
                     Route = route,
                     ComponentName = r.ComponentName,
-                    FilePath = MakeRelativePath(projectDir, r.FilePath),
+                    FilePath = MakeRelativePath(relativeBaseDir, r.FilePath),
                     VisibleComponents = r.ChildComponents,
                     InjectedServices = r.InjectedServices.Select(i => i.TypeName).ToList(),
                     SuggestedActions = link?.LinkedActions ?? [],
@@ -320,7 +324,14 @@ public sealed class ModelBuilder
 
         // 10. Calculate file hashes for incremental updates
         OnProgress?.Invoke("Computing file hashes...");
-        var fileHashes = await ComputeFileHashesAsync(projectDir, ct);
+        var fileHashes = await ComputeFileHashesAsync(
+            analysisProjects
+                .Select(project => Path.GetDirectoryName(project.FilePath))
+                .Where(directory => !string.IsNullOrWhiteSpace(directory))
+                .Select(directory => directory!)
+                .Distinct(StringComparer.OrdinalIgnoreCase),
+            relativeBaseDir,
+            ct);
 
         // 11. Build initial model for recommendations analysis
         var initialModel = new ProjectModel
@@ -366,18 +377,29 @@ public sealed class ModelBuilder
         }
     }
 
-    private static IReadOnlyList<Project> GetReferencedProjects(Solution solution, Project project)
+    private static IReadOnlyList<Project> GetAnalysisProjects(Solution solution, Project hostProject)
     {
-        var referenced = new List<Project>();
+        var projects = new List<Project> { hostProject };
+        var visited = new HashSet<ProjectId> { hostProject.Id };
+        AddReferencedProjects(solution, hostProject, projects, visited);
+        return projects;
+    }
+
+    private static void AddReferencedProjects(
+        Solution solution,
+        Project project,
+        ICollection<Project> projects,
+        ISet<ProjectId> visited)
+    {
         foreach (var projectRef in project.ProjectReferences)
         {
             var refProject = solution.GetProject(projectRef.ProjectId);
-            if (refProject != null)
+            if (refProject != null && visited.Add(refProject.Id))
             {
-                referenced.Add(refProject);
+                projects.Add(refProject);
+                AddReferencedProjects(solution, refProject, projects, visited);
             }
         }
-        return referenced;
     }
 
     private static string GenerateId(string name)
@@ -508,19 +530,23 @@ public sealed class ModelBuilder
     }
 
     private static async Task<IReadOnlyDictionary<string, string>> ComputeFileHashesAsync(
-        string directory,
+        IEnumerable<string> directories,
+        string relativeBaseDir,
         CancellationToken ct)
     {
-        var hashes = new Dictionary<string, string>();
+        var hashes = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
-        var files = Directory.GetFiles(directory, "*.*", SearchOption.AllDirectories)
+        var files = directories
+            .Where(Directory.Exists)
+            .SelectMany(directory => Directory.GetFiles(directory, "*.*", SearchOption.AllDirectories))
             .Where(f => f.EndsWith(".razor", StringComparison.OrdinalIgnoreCase) ||
-                       f.EndsWith(".cs", StringComparison.OrdinalIgnoreCase));
+                       f.EndsWith(".cs", StringComparison.OrdinalIgnoreCase))
+            .Distinct(StringComparer.OrdinalIgnoreCase);
 
         foreach (var file in files)
         {
             ct.ThrowIfCancellationRequested();
-            var relativePath = MakeRelativePath(directory, file);
+            var relativePath = MakeRelativePath(relativeBaseDir, file);
             var content = await File.ReadAllBytesAsync(file, ct).ConfigureAwait(false);
             var hash = Convert.ToHexString(SHA256.HashData(content));
             hashes[relativePath] = hash;

--- a/src/AgentBlazor.Cli.Analysis/WorkflowSuggestions/WorkflowSuggestionParser.cs
+++ b/src/AgentBlazor.Cli.Analysis/WorkflowSuggestions/WorkflowSuggestionParser.cs
@@ -18,9 +18,10 @@ public sealed class WorkflowSuggestionParser
             throw new InvalidOperationException("LLM workflow suggestion response did not contain a 'workflows' array.");
         }
 
-        var knownMethods = model.Services
-            .SelectMany(service => service.Methods.Select(method => (Service: service.TypeName, Method: NormalizeMethodReference(method.Name))))
-            .Concat(model.Actions.Select(action => (Service: action.SourceService, Method: NormalizeMethodReference(action.MethodName))))
+        var knownMethods = model.Actions
+            .Where(action => action.ExposureMode is ActionExposureMode.Suggested or ActionExposureMode.Confirmed)
+            .Where(AnalysisModelFilters.IsDeveloperFacingAction)
+            .Select(action => (Service: action.SourceService, Method: NormalizeMethodReference(action.MethodName)))
             .ToHashSet();
 
         var suggestions = new List<WorkflowSuggestion>();
@@ -69,6 +70,18 @@ public sealed class WorkflowSuggestionParser
                 {
                     Name = suggestion.Name,
                     Reason = "All referenced methods already have confirmed AgentBlazor actions."
+                });
+                continue;
+            }
+
+            var semanticallyMisalignedMethods = FindSemanticallyMisalignedMethods(suggestion);
+            if (semanticallyMisalignedMethods.Count > 0)
+            {
+                rejected.Add(new RejectedWorkflowSuggestion
+                {
+                    Name = suggestion.Name,
+                    Reason = "Referenced methods do not align with the workflow description: " +
+                        string.Join(", ", semanticallyMisalignedMethods.Select(method => $"{method.Service}.{method.Method}"))
                 });
                 continue;
             }
@@ -122,6 +135,103 @@ public sealed class WorkflowSuggestionParser
             suggestion.Methods.Count > 0 &&
             suggestion.Methods.All(method => confirmedMethodNames.Contains(NormalizeName(method.Method)));
     }
+
+    private static IReadOnlyList<WorkflowMethodReference> FindSemanticallyMisalignedMethods(WorkflowSuggestion suggestion)
+    {
+        var workflowText = NormalizeText(string.Join(
+            ' ',
+            suggestion.Name,
+            suggestion.Description,
+            suggestion.CapabilityClass,
+            suggestion.Reasoning));
+
+        return suggestion.Methods
+            .Where(method =>
+            {
+                var methodTokens = ExtractMeaningfulMethodTokens(method.Method);
+                var requiredMatches = Math.Min(2, methodTokens.Count);
+                return methodTokens.Count > 0 &&
+                    methodTokens.Count(token => workflowText.Contains(token, StringComparison.Ordinal)) < requiredMatches;
+            })
+            .ToList();
+    }
+
+    private static IReadOnlyList<string> ExtractMeaningfulMethodTokens(string methodName)
+    {
+        var normalized = methodName.EndsWith("Async", StringComparison.OrdinalIgnoreCase)
+            ? methodName[..^"Async".Length]
+            : methodName;
+
+        var words = SplitIdentifier(normalized)
+            .Where(word => !IgnoredMethodWords.Contains(word))
+            .Where(word => word.Length >= 4)
+            .ToList();
+
+        return words.Count == 0
+            ? []
+            : words;
+    }
+
+    private static IReadOnlyList<string> SplitIdentifier(string value)
+    {
+        var words = new List<string>();
+        var current = new System.Text.StringBuilder();
+
+        foreach (var character in value)
+        {
+            if (!char.IsLetterOrDigit(character))
+            {
+                Flush();
+                continue;
+            }
+
+            if (current.Length > 0 && char.IsUpper(character) && !char.IsUpper(current[current.Length - 1]))
+            {
+                Flush();
+            }
+
+            current.Append(char.ToLowerInvariant(character));
+        }
+
+        Flush();
+        return words;
+
+        void Flush()
+        {
+            if (current.Length == 0)
+            {
+                return;
+            }
+
+            words.Add(current.ToString());
+            current.Clear();
+        }
+    }
+
+    private static string NormalizeText(string value)
+        => new(value
+            .Select(character => char.IsLetterOrDigit(character) ? char.ToLowerInvariant(character) : ' ')
+            .ToArray());
+
+    private static readonly HashSet<string> IgnoredMethodWords = new(StringComparer.Ordinal)
+    {
+        "add",
+        "create",
+        "delete",
+        "dispatch",
+        "find",
+        "get",
+        "list",
+        "load",
+        "manage",
+        "query",
+        "remove",
+        "run",
+        "search",
+        "set",
+        "show",
+        "update"
+    };
 
     private static string NormalizeName(string value)
     {

--- a/src/AgentBlazor.Cli.Analysis/WorkflowSuggestions/WorkflowSuggestionPromptBuilder.cs
+++ b/src/AgentBlazor.Cli.Analysis/WorkflowSuggestions/WorkflowSuggestionPromptBuilder.cs
@@ -98,6 +98,12 @@ public sealed class WorkflowSuggestionPromptBuilder
     private static void AppendServices(StringBuilder sb, ProjectModel model)
     {
         sb.AppendLine("Discovered services and public methods:");
+        var candidateMethods = model.Actions
+            .Where(action => action.ExposureMode is ActionExposureMode.Suggested or ActionExposureMode.Confirmed)
+            .Where(AnalysisModelFilters.IsDeveloperFacingAction)
+            .Select(action => (action.SourceService, action.MethodName))
+            .ToHashSet();
+
         foreach (var service in model.Services
             .Where(service => AnalysisModelFilters.IsDeveloperFacingService(service, model))
             .OrderBy(service => service.TypeName)
@@ -106,6 +112,7 @@ public sealed class WorkflowSuggestionPromptBuilder
             var methods = service.Methods
                 .Where(method => method.IsPublic)
                 .Where(method => AnalysisModelFilters.IsDeveloperFacingMethod(method.Name))
+                .Where(method => candidateMethods.Contains((service.TypeName, method.Name)))
                 .OrderBy(method => method.Name)
                 .Take(20)
                 .Select(method => $"{method.Name}({string.Join(", ", method.Parameters.Select(parameter => $"{parameter.TypeName} {parameter.Name}"))})")

--- a/tests/AgentBlazor.Cli.Analysis.Tests/Blazor/CliTargetAnalysisTests.cs
+++ b/tests/AgentBlazor.Cli.Analysis.Tests/Blazor/CliTargetAnalysisTests.cs
@@ -8,7 +8,7 @@ public sealed class CliTargetAnalysisTests
     [Theory]
     [InlineData("simple-blazor-app/SimpleBlazorApp.csproj", 2, "CustomerService")]
     [InlineData("realistic-blazor-app/RealisticBlazorApp.csproj", 3, "OrderService")]
-    [InlineData("hosted-wasm-app/HostedWasmApp.Server/HostedWasmApp.Server.csproj", 0, "AuditBundleService")]
+    [InlineData("hosted-wasm-app/HostedWasmApp.Server/HostedWasmApp.Server.csproj", 1, "AuditBundleService")]
     public async Task BlazorAnalyzer_AnalyzesSyntheticTargetApps(
         string relativeProjectPath,
         int minimumRouteCount,

--- a/tests/AgentBlazor.Cli.Analysis.Tests/WorkflowSuggestions/WorkflowSuggestionParserTests.cs
+++ b/tests/AgentBlazor.Cli.Analysis.Tests/WorkflowSuggestions/WorkflowSuggestionParserTests.cs
@@ -78,6 +78,16 @@ public sealed class WorkflowSuggestionParserTests
                 new ActionModel
                 {
                     Name = "Find Orders",
+                    SourceService = "OrderService",
+                    MethodName = "FindOrdersAsync",
+                    FilePath = "Services/OrderService.cs",
+                    ExposureMode = ActionExposureMode.Suggested,
+                    Classification = ActionClassification.Query,
+                    Score = 0.8
+                },
+                new ActionModel
+                {
+                    Name = "Find Orders",
                     SourceService = "OrderCapabilities",
                     MethodName = "FindOrdersAsync",
                     FilePath = "Workflows/OrderCapabilities.cs",
@@ -136,6 +146,49 @@ public sealed class WorkflowSuggestionParserTests
     }
 
     [Fact]
+    public void ParseAndValidate_RejectsSuggestions_WhenMethodTermsDoNotMatchWorkflow()
+    {
+        var parser = new WorkflowSuggestionParser();
+        var model = CreateModel() with
+        {
+            Actions =
+            [
+                new ActionModel
+                {
+                    Name = "Get Access Token",
+                    SourceService = "AccessTokenService",
+                    MethodName = "GetAccessTokenAsync",
+                    FilePath = "Services/AccessTokenService.cs",
+                    ExposureMode = ActionExposureMode.Suggested,
+                    Classification = ActionClassification.Query,
+                    Score = 0.8
+                }
+            ]
+        };
+        var json = """
+        {
+          "workflows": [
+            {
+              "name": "Role assignment",
+              "description": "Assign roles to users.",
+              "methods": [
+                { "service": "AccessTokenService", "method": "GetAccessTokenAsync" }
+              ],
+              "confidence": 0.82
+            }
+          ]
+        }
+        """;
+
+        var result = parser.ParseAndValidate(json, model, "test-model");
+
+        Assert.Empty(result.Suggestions);
+        var rejected = Assert.Single(result.Rejected);
+        Assert.Contains("do not align", rejected.Reason);
+        Assert.Contains("AccessTokenService.GetAccessTokenAsync", rejected.Reason);
+    }
+
+    [Fact]
     public void ParseAndValidate_AcceptsMethodReferencesThatIncludeParameterLists()
     {
         var parser = new WorkflowSuggestionParser();
@@ -145,7 +198,7 @@ public sealed class WorkflowSuggestionParserTests
           "workflows": [
             {
               "name": "Order follow-up",
-              "description": "Find open orders.",
+              "description": "Find open orders and draft follow-up messages.",
               "methods": [
                 { "service": "OrderService", "method": "FindOrdersAsync(DateOnly since)" },
                 "OrderService.DraftFollowUpAsync(string orderId)"
@@ -191,6 +244,29 @@ public sealed class WorkflowSuggestionParserTests
                         IsAsync = true
                     }
                 ]
+            }
+        ],
+        Actions =
+        [
+            new ActionModel
+            {
+                Name = "Find Orders",
+                SourceService = "OrderService",
+                MethodName = "FindOrdersAsync",
+                FilePath = "Services/OrderService.cs",
+                ExposureMode = ActionExposureMode.Suggested,
+                Classification = ActionClassification.Query,
+                Score = 0.8
+            },
+            new ActionModel
+            {
+                Name = "Draft Follow Up",
+                SourceService = "OrderService",
+                MethodName = "DraftFollowUpAsync",
+                FilePath = "Services/OrderService.cs",
+                ExposureMode = ActionExposureMode.Suggested,
+                Classification = ActionClassification.Workflow,
+                Score = 0.8
             }
         ]
     };

--- a/tests/AgentBlazor.Cli.Analysis.Tests/WorkflowSuggestions/WorkflowSuggestionPromptBuilderTests.cs
+++ b/tests/AgentBlazor.Cli.Analysis.Tests/WorkflowSuggestions/WorkflowSuggestionPromptBuilderTests.cs
@@ -109,6 +109,16 @@ public sealed class WorkflowSuggestionPromptBuilderTests
             [
                 new ActionModel
                 {
+                    Name = "Find Orders",
+                    SourceService = "OrderService",
+                    MethodName = "FindOrdersAsync",
+                    FilePath = "Services/OrderService.cs",
+                    ExposureMode = ActionExposureMode.Suggested,
+                    Classification = ActionClassification.Query,
+                    Score = 0.8
+                },
+                new ActionModel
+                {
                     Name = "Show Open Orders",
                     SourceService = "OrderCapabilities",
                     MethodName = "ShowOpenOrdersAsync",


### PR DESCRIPTION
Extends CLI v1 analyze validation based on additional real Blazor apps.\n\nChanges:\n- Analyze routed Razor components from host project references, including RCL/client projects.\n- Use the same host-plus-transitive-reference project set for Razor, services, DI, and AgentBlazor attribute discovery.\n- Tighten LLM workflow validation so suggestions validate against scored candidate actions, not arbitrary public methods.\n- Reject suggestions whose referenced method terms do not align with the workflow description.\n- Filter lifecycle/noise methods such as Dispose and OnPropertyChanged from developer-facing reports/prompts.\n- Records expanded packaged-tool validation across 11 real GitHub Blazor apps.\n\nVerification:\n- dotnet test tests/AgentBlazor.Cli.Analysis.Tests/AgentBlazor.Cli.Analysis.Tests.csproj\n- dotnet pack src/AgentBlazor.Cli/AgentBlazor.Cli.csproj -c Release\n- local dotnet tool install from packed AgentBlazor.Cli.0.2.1.nupkg\n- packaged agentblazor analyze with real OpenAI key on additional real apps: eShopOnBlazor, Remotely, BlazingChat, SwashbucklerDiary, FhirBlaze, BlazorWithIdentity\n- packaged no-provider and --static-only checks