### PR TITLE
chore: prepare 0.2.2 CLI v1 release

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
 
   <!-- Common package metadata for all AgentBlazor packages -->
   <PropertyGroup>
-    <Version>0.2.1</Version>
+    <Version>0.2.2</Version>
     <Authors>Ash Peterson</Authors>
     <Company>AgentBlazor</Company>
     <Copyright>Copyright (c) 2026 Ash Peterson</Copyright>
@@ -16,7 +16,7 @@
     <RepositoryType>git</RepositoryType>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <PackageIcon>icon.png</PackageIcon>
-    <PackageReleaseNotes>v0.2.1: mobile chat input stability fix for Blazor Server chat surfaces, preserving v0.2 structured capability error recovery, schema-only EF Core entity exposure, hosted demo observability, and tool-friendly schemas for date-like workflow parameters.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.2.2: CLI v1 analyze package refresh targeting net10.0, referenced Razor project route discovery, stricter LLM workflow validation, and expanded real-app verification across 11 public Blazor repositories. Includes v0.2 structured errors, EF schema exposure, hosted demo observability, and mobile chat input stability fixes.</PackageReleaseNotes>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <Deterministic>true</Deterministic>

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Try the hosted demo:
 dotnet add package AgentBlazor
 ```
 
-Use `0.2.1` or later. This release includes the mobile chat input stability fix, corrected EF package shape, and tool-friendly schemas for `DateOnly`, `TimeOnly`, `DateTime`, `DateTimeOffset`, and `Guid` workflow parameters.
+Use `0.2.2` or later. This release includes the CLI v1 analyze package refresh, mobile chat input stability fix, corrected EF package shape, and tool-friendly schemas for `DateOnly`, `TimeOnly`, `DateTime`, `DateTimeOffset`, and `Guid` workflow parameters.
 
 The CLI is optional. Keep it out of the critical path unless you want scaffold help for an existing app.
 
@@ -105,6 +105,7 @@ dotnet run --project samples/AgentBlazor.Starter/AgentBlazor.Starter.csproj
 ## Docs
 
 - [Quickstart](docs/quickstart.md)
+- [0.2.2 release notes](docs/releases/0.2.2.md)
 - [0.2.1 release notes](docs/releases/0.2.1.md)
 - [0.2.0 release notes](docs/releases/0.2.0.md)
 - [Recoverable capability errors](docs/capability-errors.md)

--- a/docs/entity-framework.md
+++ b/docs/entity-framework.md
@@ -17,7 +17,7 @@ dotnet add package AgentBlazor
 dotnet add package AgentBlazor.EntityFrameworkCore
 ```
 
-Use `0.2.1` or later. This release includes the mobile chat input stability fix, corrected EF package shape, and tool-friendly schemas for date-like workflow parameters.
+Use `0.2.2` or later. This release includes the CLI v1 analyze package refresh, mobile chat input stability fix, corrected EF package shape, and tool-friendly schemas for date-like workflow parameters.
 
 ## DbContext Setup
 

--- a/docs/internal/cli-v1-real-app-validation-2026-05-27.md
+++ b/docs/internal/cli-v1-real-app-validation-2026-05-27.md
@@ -11,14 +11,14 @@ Environment:
 - LLM provider: real OpenAI API key from environment
 - Model: environment default, currently `gpt-4o-mini` when unset
 - Temporary clone root: `/tmp/agentblazor-cli-v1-realapps`
-- Packaged tool: locally packed `AgentBlazor.Cli.0.2.1.nupkg`, installed via `dotnet tool install AgentBlazor.Cli --tool-path /tmp/agentblazor-cli-v1-tool-smoke/tool --configfile /tmp/agentblazor-cli-v1-tool-smoke/NuGet.config --version 0.2.1`
+- Packaged tool: locally packed `AgentBlazor.Cli.0.2.2.nupkg`, installed via `dotnet tool install AgentBlazor.Cli --tool-path /tmp/agentblazor-cli-v1-tool-smoke/tool --configfile /tmp/agentblazor-cli-v1-tool-smoke/NuGet.config --version 0.2.2`
 - Initial packaged tool output root: `/tmp/agentblazor-cli-v1-tool-smoke`
 - Expanded real-app clone root: `/tmp/agentblazor-cli-v1-more-realapps`
 - Final packaged tool output root after RCL route and semantic-validation fixes: `/tmp/agentblazor-cli-v1-tool-smoke-final2`
 
 ## Packaged Tool Quality Gates
 
-- Install gate: local `AgentBlazor.Cli.0.2.1.nupkg` installs as a `dotnet tool` into an isolated tool path and reports `0.2.1` from `agentblazor --version`.
+- Install gate: local `AgentBlazor.Cli.0.2.2.nupkg` installs as a `dotnet tool` into an isolated tool path and reports `0.2.2` from `agentblazor --version`.
 - No-provider gate: with OpenAI and Azure OpenAI environment variables removed, `agentblazor analyze` exits cleanly with `No OpenAI API key configured for agentblazor analyze. Set OPENAI_API_KEY or OpenAI__ApiKey, and optionally set AGENTBLAZOR_ANALYZE_MODEL.`
 - Static-only gate: `agentblazor analyze ... --static-only` writes a report with routes, capabilities, services, static workflow candidates, install readiness, and recommended next steps without requiring an LLM provider.
 
@@ -151,7 +151,7 @@ Environment:
 
 - Automated analysis tests pass: `161`
 - CLI build passes: `dotnet build src/AgentBlazor.Cli/AgentBlazor.Cli.csproj`
-- Local packaged tool install passes from `AgentBlazor.Cli.0.2.1.nupkg`.
+- Local packaged tool install passes from `AgentBlazor.Cli.0.2.2.nupkg`.
 - Packaged no-provider and `--static-only` paths pass.
 - Real OpenAI-backed analysis completed on 11 real GitHub Blazor applications.
 - Packaged `dotnet tool` smoke completed on 11 real GitHub Blazor applications.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,6 +1,6 @@
 # Quickstart
 
-Get one working AgentBlazor chat widget into a fresh Blazor app. Tested against a clean `dotnet new blazor` project with `AgentBlazor 0.2.1`.
+Get one working AgentBlazor chat widget into a fresh Blazor app. Tested against a clean `dotnet new blazor` project with `AgentBlazor 0.2.2`.
 
 Hosted demo: https://demo.agentblazor.com/demo/workflows/support-inbox
 
@@ -182,6 +182,7 @@ Say hello
 ## Next
 
 - [Hosted demo](https://demo.agentblazor.com/demo/workflows/support-inbox)
+- [0.2.2 release notes](releases/0.2.2.md)
 - [0.2.1 release notes](releases/0.2.1.md)
 - [0.2.0 release notes](releases/0.2.0.md)
 - [Starter sample](../samples/AgentBlazor.Starter/README.md)

--- a/docs/releases/0.2.2.md
+++ b/docs/releases/0.2.2.md
@@ -1,0 +1,39 @@
+# AgentBlazor 0.2.2 Release Notes
+
+Target package line: `0.2.2` stable.
+
+AgentBlazor 0.2.2 is a CLI v1 analyze package refresh. It republishes the CLI on the current `net10.0` target and includes the real-app validation fixes found while testing against public Blazor repositories.
+
+## Fixes
+
+- `agentblazor analyze` now scans routed Razor components from referenced Razor Class Library and client projects, not only the host project directory.
+- The analysis model uses the same host-plus-transitive-reference project set for routes, components, services, DI registrations, and AgentBlazor attributes.
+- LLM workflow suggestions now validate against scored candidate actions instead of arbitrary public methods.
+- Semantically misaligned LLM suggestions are rejected even when they reference real methods.
+- Lifecycle/noise methods such as `Dispose` and `OnPropertyChanged` are filtered out of developer-facing reports and LLM prompts.
+
+## Verification
+
+- Analysis test suite passed: `161` tests.
+- `AgentBlazor.Cli` builds and packs for `net10.0`.
+- Local `dotnet tool` install from `AgentBlazor.Cli.0.2.2.nupkg` passed.
+- Real OpenAI-backed `agentblazor analyze` validation completed against 11 public Blazor repositories.
+- The final NuGet-installed CLI smoke should use `AgentBlazor.Cli 0.2.2`; `0.2.1` is stale and targets the previous CLI package shape.
+
+## Install
+
+```bash
+dotnet add package AgentBlazor --version 0.2.2
+```
+
+Optional packages:
+
+```bash
+dotnet add package AgentBlazor.Client --version 0.2.2
+dotnet add package AgentBlazor.EntityFrameworkCore --version 0.2.2
+dotnet tool install --global AgentBlazor.Cli --version 0.2.2
+```
+
+## Previous Release
+
+For the mobile chat input patch, see [0.2.1 release notes](0.2.1.md).

--- a/src/AgentBlazor.Cli.Analysis/ExistingAppScaffoldApplier.cs
+++ b/src/AgentBlazor.Cli.Analysis/ExistingAppScaffoldApplier.cs
@@ -301,7 +301,7 @@ public sealed class ExistingAppScaffoldApplier
             .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
             ?.InformationalVersion
             ?? typeof(ExistingAppScaffoldApplier).Assembly.GetName().Version?.ToString()
-            ?? "0.2.1";
+            ?? "0.2.2";
 
         return version.Split('+', 2)[0];
     }

--- a/src/AgentBlazor.Cli/PACKAGE_README.md
+++ b/src/AgentBlazor.Cli/PACKAGE_README.md
@@ -11,7 +11,7 @@ dotnet tool install --global AgentBlazor.Cli
 If you prefer a pinned install:
 
 ```bash
-dotnet tool install --global AgentBlazor.Cli --version 0.2.1
+dotnet tool install --global AgentBlazor.Cli --version 0.2.2
 ```
 
 Example:
@@ -36,5 +36,6 @@ Docs:
 
 - Repository: https://github.com/ashpeterson/AgentBlazor
 - Advanced CLI guide: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/advanced/cli.md
+- 0.2.2 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.2.md
 - 0.2.1 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.1.md
 - 0.2.0 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.0.md

--- a/src/AgentBlazor.Cli/Program.cs
+++ b/src/AgentBlazor.Cli/Program.cs
@@ -7,7 +7,7 @@ var version = typeof(ScaffoldCommand).Assembly
     .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
     ?.InformationalVersion
     ?? typeof(ScaffoldCommand).Assembly.GetName().Version?.ToString()
-    ?? "0.2.1";
+    ?? "0.2.2";
 version = version.Split('+', 2)[0];
 
 app.Configure(config =>

--- a/src/AgentBlazor.Client/PACKAGE_README.md
+++ b/src/AgentBlazor.Client/PACKAGE_README.md
@@ -11,7 +11,7 @@ dotnet add package AgentBlazor.Client
 If you prefer a pinned install:
 
 ```bash
-dotnet add package AgentBlazor.Client --version 0.2.1
+dotnet add package AgentBlazor.Client --version 0.2.2
 ```
 
 Server project:
@@ -35,5 +35,6 @@ Docs:
 
 - Repository: https://github.com/ashpeterson/AgentBlazor
 - Quickstart: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/quickstart.md
+- 0.2.2 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.2.md
 - 0.2.1 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.1.md
 - 0.2.0 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.0.md

--- a/src/AgentBlazor.Components/PACKAGE_README.md
+++ b/src/AgentBlazor.Components/PACKAGE_README.md
@@ -15,10 +15,10 @@ dotnet add package AgentBlazor
 If you prefer a pinned install, use:
 
 ```bash
-dotnet add package AgentBlazor --version 0.2.1
+dotnet add package AgentBlazor --version 0.2.2
 ```
 
-Use `0.2.1` or later. This release includes the mobile chat input stability fix, corrected EF package shape, and tool-friendly schemas for date-like workflow parameters.
+Use `0.2.2` or later. This release includes the CLI v1 analyze package refresh, mobile chat input stability fix, corrected EF package shape, and tool-friendly schemas for date-like workflow parameters.
 
 If `dotnet` still probes an old custom package source on your machine, remove or disable that source before testing the public NuGet install path.
 
@@ -88,6 +88,7 @@ Docs and demo:
 - Hosted demo: https://demo.agentblazor.com/demo/workflows/support-inbox
 - Structured error reference: https://demo.agentblazor.com/demo/workflows/runtime-probe
 - Quickstart: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/quickstart.md
+- 0.2.2 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.2.md
 - 0.2.1 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.1.md
 - 0.2.0 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.0.md
 - Recoverable capability errors: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/capability-errors.md

--- a/src/AgentBlazor.EntityFrameworkCore/README.md
+++ b/src/AgentBlazor.EntityFrameworkCore/README.md
@@ -13,10 +13,10 @@ dotnet add package AgentBlazor.EntityFrameworkCore
 Pinned install:
 
 ```bash
-dotnet add package AgentBlazor.EntityFrameworkCore --version 0.2.1
+dotnet add package AgentBlazor.EntityFrameworkCore --version 0.2.2
 ```
 
-Use `0.2.1` or later. This release includes the mobile chat input stability fix, corrected EF package shape, and tool-friendly schemas for date-like workflow parameters.
+Use `0.2.2` or later. This release includes the CLI v1 analyze package refresh, mobile chat input stability fix, corrected EF package shape, and tool-friendly schemas for date-like workflow parameters.
 
 Register your `DbContext` with `IDbContextFactory<TContext>`:
 

--- a/tests/AgentBlazor.Cli.Analysis.Tests/ExistingAppScaffoldPlannerTests.cs
+++ b/tests/AgentBlazor.Cli.Analysis.Tests/ExistingAppScaffoldPlannerTests.cs
@@ -250,7 +250,7 @@ public sealed class ExistingAppScaffoldPlannerTests : IDisposable
         Assert.Contains("""<PackageReference Include="MudBlazor" />""", projectText, StringComparison.Ordinal);
         Assert.DoesNotContain("PackageReference Include=\"AgentBlazor\" Version=", projectText, StringComparison.Ordinal);
         Assert.DoesNotContain("PackageReference Include=\"MudBlazor\" Version=", projectText, StringComparison.Ordinal);
-        Assert.Contains("""<PackageVersion Include="AgentBlazor" Version="0.2.1" />""", centralPackagesText, StringComparison.Ordinal);
+        Assert.Contains("""<PackageVersion Include="AgentBlazor" Version="0.2.2" />""", centralPackagesText, StringComparison.Ordinal);
         Assert.Contains("""<PackageVersion Include="MudBlazor" Version="9.0.0" />""", centralPackagesText, StringComparison.Ordinal);
     }
 


### PR DESCRIPTION
Prepares 0.2.2 for the final CLI v1 NuGet gate.\n\nWhy:\n- Published AgentBlazor.Cli 0.2.1 is stale for the CLI v1 path and targets the previous package shape. In this .NET 10 validation environment, the NuGet-installed 0.2.1 tool installs but fails at runtime requesting Microsoft.NETCore.App 8.0.0.\n- Current master has the net10 CLI, referenced-Razor-project route analysis, stricter workflow validation, and expanded real-app evidence. NuGet needs a new immutable version.\n\nChanges:\n- Bump package version to 0.2.2.\n- Update CLI fallback/scaffold default versions to 0.2.2.\n- Add 0.2.2 release notes.\n- Update public READMEs/package READMEs and validation evidence.\n- Update scaffold test expectation for the default AgentBlazor package version.\n\nVerification run locally:\n- dotnet test tests/AgentBlazor.Cli.Analysis.Tests/AgentBlazor.Cli.Analysis.Tests.csproj\n- dotnet pack src/AgentBlazor.Cli/AgentBlazor.Cli.csproj -c Release -o /tmp/agentblazor-0.2.2-pack /p:Version=0.2.2\n- dotnet tool install AgentBlazor.Cli from the local 0.2.2 package and verified agentblazor --version returns 0.2.2\n\nPost-merge gate:\n- Dispatch publish-nuget-org with package_version=0.2.2.\n- Install AgentBlazor.Cli 0.2.2 from nuget.org into an isolated tool path.\n- Run real OpenAI-backed agentblazor analyze against the real-app matrix.