### PR TITLE
docs: record CLI v1 final NuGet validation

### DIFF
--- a/docs/internal/cli-v1-real-app-validation-2026-05-27.md
+++ b/docs/internal/cli-v1-real-app-validation-2026-05-27.md
@@ -15,6 +15,7 @@ Environment:
 - Initial packaged tool output root: `/tmp/agentblazor-cli-v1-tool-smoke`
 - Expanded real-app clone root: `/tmp/agentblazor-cli-v1-more-realapps`
 - Final packaged tool output root after RCL route and semantic-validation fixes: `/tmp/agentblazor-cli-v1-tool-smoke-final2`
+- Final NuGet-installed tool output root after publish: `/tmp/agentblazor-cli-v1-nuget-smoke-022`
 
 ## Packaged Tool Quality Gates
 
@@ -152,16 +153,47 @@ Environment:
 - Automated analysis tests pass: `161`
 - CLI build passes: `dotnet build src/AgentBlazor.Cli/AgentBlazor.Cli.csproj`
 - Local packaged tool install passes from `AgentBlazor.Cli.0.2.2.nupkg`.
+- NuGet.org published package is available from `https://api.nuget.org/v3-flatcontainer/agentblazor.cli/0.2.2/agentblazor.cli.0.2.2.nupkg`.
+- NuGet.org package install passes into an isolated tool path using a NuGet-only config, and `agentblazor --version` reports `0.2.2`.
 - Packaged no-provider and `--static-only` paths pass.
 - Real OpenAI-backed analysis completed on 11 real GitHub Blazor applications.
 - Packaged `dotnet tool` smoke completed on 11 real GitHub Blazor applications.
+- Final NuGet-installed `dotnet tool` smoke completed on 5 real GitHub Blazor applications with the real OpenAI provider.
 - Hallucinated methods were rejected on sparse apps.
 - Accepted workflow suggestions on larger apps reference methods present in the static model.
 - Referenced RCL routes are discovered for hosted/componentized apps.
 - Semantically misaligned LLM suggestions are rejected even when they reference real methods.
 
-## Remaining Before v1 Complete
+## Final NuGet-Installed Smoke
 
-- Publish or otherwise cut the CLI package from a green commit.
-- Run final NuGet-installed tool smoke after publish.
-- Decide whether the report should hide rejected suggestions by default or keep them as validation evidence.
+Environment:
+
+- Tool install root: `/tmp/agentblazor-cli-v1-nuget-smoke-022/tool`
+- Report root: `/tmp/agentblazor-cli-v1-nuget-smoke-022/reports`
+- Install command used only `https://api.nuget.org/v3/index.json` via an isolated `NuGet.config`
+- Tool version: `0.2.2`
+- LLM provider: real OpenAI API key from environment
+
+Results:
+
+| App | Host | Routes | Services | Actions | Readiness | Suggestions |
+| --- | --- | ---: | ---: | ---: | --- | --- |
+| CuriousDrive/BlazingChat | `BlazingChat.Server` | 10 | 1 | 2 discovered | 0 passed, 4 warnings, 6 missing | 2 accepted, 3 rejected |
+| Yu-Core/SwashbucklerDiary | `SwashbucklerDiary.Server` | 38 | 21 | 79 discovered | 2 passed, 3 warnings, 5 missing | 1 accepted, 4 rejected |
+| microsoft/FhirBlaze | `FhirBlaze` | 13 | 3 | 24 discovered | 0 passed, 4 warnings, 6 missing | 2 accepted, 3 rejected |
+| immense/Remotely | `Server` | 45 | 18 | 113 discovered | 2 passed, 3 warnings, 5 missing | 1 accepted, 4 rejected |
+| neozhu/CleanArchitectureWithBlazorServer | `Server.UI` | 31 | 21 | 19 discovered | 4 passed, 2 warnings, 4 missing | 2 accepted, 3 rejected |
+
+Synthetic target refresh using the NuGet-installed tool:
+
+| Target | Routes | Services | Actions | Readiness | Suggestions | Outcome |
+| --- | ---: | ---: | ---: | --- | --- | --- |
+| `simple-blazor-app` | 2 | 2 | 3 discovered | 2 passed, 3 warnings, 5 missing | 3 accepted, 0 rejected | Pass; useful new workflow suggestions were generated from services. |
+| `realistic-blazor-app` | 3 | 3 | 4 confirmed, 6 discovered | 10 passed, 0 warnings, 0 missing | 0 accepted, 4 rejected | Pass; suggestions targeted methods that already have confirmed AgentBlazor actions, so duplicate workflow suggestions were correctly rejected. |
+| `hosted-wasm-app` | 1 | 1 | 2 confirmed, 2 discovered | 4 passed, 5 warnings, 1 missing | 0 accepted, 3 rejected | Pass; suggestions targeted methods that already have confirmed AgentBlazor actions, so duplicate workflow suggestions were correctly rejected. |
+
+Additional command-path gates:
+
+- No-provider path exits cleanly with: `No OpenAI API key configured for agentblazor analyze. Set OPENAI_API_KEY or OpenAI__ApiKey, and optionally set AGENTBLAZOR_ANALYZE_MODEL.`
+- `--static-only` works without an LLM provider and writes an analysis report.
+- Rejected suggestions remain visible in the report for now as validation evidence. Hiding them by default is a future UX decision, not a v1 ship blocker.

--- a/docs/internal/cli-v1-scope-2026-05-24.md
+++ b/docs/internal/cli-v1-scope-2026-05-24.md
@@ -5,16 +5,16 @@ Target ship: 3-5 weeks from May 24 2026.
 
 Document purpose: single source of truth for what AgentBlazor CLI v1 contains, what it does not contain, and how it gets there. Updates as work progresses. Decisions captured here are locked unless explicitly revised in this document.
 
-## Review Notes From Current Repo
+## Implementation Notes From Current Repo
 
-This scope has been reviewed against the current codebase.
+This scope has been reviewed against the current codebase after the v1 implementation work.
 
-- There is no `agentblazor analyze` command today. Current commands are `init`, `update`, `watch`, `doctor`, `validate`, and `scaffold`.
-- Current `init` already performs most of the static analysis, then writes `.agentblazor/AGENT.md` and `.agentblazor/.state`. The v1 `analyze` command must reuse the analysis path but avoid state writes by default.
-- `src/AgentBlazor.Cli` and `src/AgentBlazor.Cli.Analysis` currently target `net8.0`. The `net10.0` migration is a required v1 task, not already done.
-- `.agentblazorc` currently supports host/project analysis settings, not LLM provider or model configuration. Provider/model configuration for v1 needs either new config fields or environment-variable-only behavior.
-- Workflow registration is only detected as a readiness check today by searching for `AddWorkflow<` / `.AddWorkflow(`. The analysis model does not yet strongly represent registered agent names or workflow registrations.
-- The proposed `tests/cli-targets/*` reference applications do not exist yet and are part of v1 work.
+- `agentblazor analyze` exists and is published in `AgentBlazor.Cli` `0.2.2`.
+- `src/AgentBlazor.Cli` and `src/AgentBlazor.Cli.Analysis` target `net10.0`.
+- The command is read-mostly: it writes the configured markdown report and does not update `.agentblazor/.state`.
+- Provider/model configuration is environment-driven for v1. `OPENAI_API_KEY` or `OpenAI__ApiKey` is required for LLM suggestions, unless `--static-only` is used. `AGENTBLAZOR_ANALYZE_MODEL`, `OPENAI_MODEL`, or `OpenAI__Model` can override the model.
+- The synthetic `tests/cli-targets/*` reference applications exist and are covered by automated tests.
+- Final validation evidence is recorded in `docs/internal/cli-v1-real-app-validation-2026-05-27.md`.
 
 ## Vision
 
@@ -74,7 +74,7 @@ The command takes an optional path argument plus flags:
 
 - `path`: optional solution, project, or directory path. Defaults to the current directory.
 - `--output`: path to write the analysis report. Defaults to `.agentblazor/analysis.md`.
-- `--include-readiness`: include `InstallReadinessAnalyzer` output as a section of the report. Defaults to true.
+- `--no-readiness`: skip `InstallReadinessAnalyzer` output. Readiness is included by default.
 - `--framework`: explicit framework override. Defaults to auto-detection. v1 only supports `blazor`; the flag exists for future framework adapters.
 
 ## Report Contents


### PR DESCRIPTION
## Summary
- record final NuGet-installed AgentBlazor.Cli 0.2.2 validation evidence
- update the CLI v1 scope doc to reflect the implemented command shape
- document final real-app, synthetic, no-provider, and static-only smoke results

## Verification
- dotnet test tests/AgentBlazor.Cli.Analysis.Tests/AgentBlazor.Cli.Analysis.Tests.csproj
- dotnet tool install AgentBlazor.Cli --tool-path /tmp/agentblazor-cli-v1-nuget-smoke-022/tool --configfile /tmp/agentblazor-cli-v1-nuget-smoke-022/NuGet.config --version 0.2.2
- /tmp/agentblazor-cli-v1-nuget-smoke-022/tool/agentblazor --version
- NuGet-installed real OpenAI-backed analyze runs on BlazingChat, SwashbucklerDiary, FhirBlaze, Remotely, and CleanArchitectureWithBlazorServer
- NuGet-installed synthetic analyze runs on simple-blazor-app, realistic-blazor-app, and hosted-wasm-app
- No-provider and --static-only command-path smoke checks