### PR TITLE
feat(cli): prompt for missing analyze API key

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
 
   <!-- Common package metadata for all AgentBlazor packages -->
   <PropertyGroup>
-    <Version>0.2.2</Version>
+    <Version>0.2.3</Version>
     <Authors>Ash Peterson</Authors>
     <Company>AgentBlazor</Company>
     <Copyright>Copyright (c) 2026 Ash Peterson</Copyright>
@@ -16,7 +16,7 @@
     <RepositoryType>git</RepositoryType>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <PackageIcon>icon.png</PackageIcon>
-    <PackageReleaseNotes>v0.2.2: CLI v1 analyze package refresh targeting net10.0, referenced Razor project route discovery, stricter LLM workflow validation, and expanded real-app verification across 11 public Blazor repositories. Includes v0.2 structured errors, EF schema exposure, hosted demo observability, and mobile chat input stability fixes.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.2.3: CLI analyze now prompts for a missing OpenAI API key in interactive terminals and uses it for the current run only. Non-interactive and static-only paths remain deterministic. Includes the v0.2.2 CLI v1 analyze package refresh, structured errors, EF schema exposure, hosted demo observability, and mobile chat input stability fixes.</PackageReleaseNotes>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <Deterministic>true</Deterministic>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AgentBlazor
 
-Last updated: 2026-05-27
+Last updated: 2026-05-28
 
 Add an agent chat surface and deterministic app actions to a Blazor app.
 
@@ -16,7 +16,7 @@ Try the hosted demo:
 dotnet add package AgentBlazor
 ```
 
-Use `0.2.2` or later. This release includes the CLI v1 analyze package refresh, mobile chat input stability fix, corrected EF package shape, and tool-friendly schemas for `DateOnly`, `TimeOnly`, `DateTime`, `DateTimeOffset`, and `Guid` workflow parameters.
+Use `0.2.3` or later. This release includes the CLI first-run API-key prompt, CLI v1 analyze package refresh, mobile chat input stability fix, corrected EF package shape, and tool-friendly schemas for `DateOnly`, `TimeOnly`, `DateTime`, `DateTimeOffset`, and `Guid` workflow parameters.
 
 The CLI is optional. Keep it out of the critical path unless you want scaffold help for an existing app.
 
@@ -105,6 +105,7 @@ dotnet run --project samples/AgentBlazor.Starter/AgentBlazor.Starter.csproj
 ## Docs
 
 - [Quickstart](docs/quickstart.md)
+- [0.2.3 release notes](docs/releases/0.2.3.md)
 - [0.2.2 release notes](docs/releases/0.2.2.md)
 - [0.2.1 release notes](docs/releases/0.2.1.md)
 - [0.2.0 release notes](docs/releases/0.2.0.md)

--- a/docs/advanced/cli.md
+++ b/docs/advanced/cli.md
@@ -52,7 +52,13 @@ agentblazor analyze ./MySolution.slnx --host MyBlazorApp --static-only
 
 ## Analyze Provider Configuration
 
-For OpenAI, set an API key before running `analyze`:
+For OpenAI, run `analyze` directly. If no key is configured and the terminal is interactive, the CLI asks for one and uses it for that run only:
+
+```bash
+agentblazor analyze ./MySolution.slnx --host MyBlazorApp
+```
+
+The key is not written to disk. For repeat runs, CI, or non-interactive shells, set an environment variable:
 
 ```bash
 export OPENAI_API_KEY="<openai-api-key>"
@@ -83,7 +89,7 @@ export AZURE_OPENAI_API_KEY="<azure-openai-api-key>"
 agentblazor analyze ./MySolution.slnx --host MyBlazorApp
 ```
 
-If no provider is configured, `analyze` exits before scanning and tells you which environment variables to set. Use `--static-only` to avoid provider configuration entirely.
+If no provider is configured and the command cannot prompt, `analyze` exits before scanning and tells you which environment variables to set. Use `--static-only` to avoid provider configuration entirely.
 
 ## Analyze Token Cost
 

--- a/docs/entity-framework.md
+++ b/docs/entity-framework.md
@@ -17,7 +17,7 @@ dotnet add package AgentBlazor
 dotnet add package AgentBlazor.EntityFrameworkCore
 ```
 
-Use `0.2.2` or later. This release includes the CLI v1 analyze package refresh, mobile chat input stability fix, corrected EF package shape, and tool-friendly schemas for date-like workflow parameters.
+Use `0.2.3` or later. This release includes the CLI first-run API-key prompt, CLI v1 analyze package refresh, mobile chat input stability fix, corrected EF package shape, and tool-friendly schemas for date-like workflow parameters.
 
 ## DbContext Setup
 

--- a/docs/internal/cli-v1-real-app-validation-2026-05-27.md
+++ b/docs/internal/cli-v1-real-app-validation-2026-05-27.md
@@ -20,7 +20,7 @@ Environment:
 ## Packaged Tool Quality Gates
 
 - Install gate: local `AgentBlazor.Cli.0.2.2.nupkg` installs as a `dotnet tool` into an isolated tool path and reports `0.2.2` from `agentblazor --version`.
-- No-provider gate: with OpenAI and Azure OpenAI environment variables removed, `agentblazor analyze` exits cleanly with `No OpenAI API key configured for agentblazor analyze. Set OPENAI_API_KEY or OpenAI__ApiKey, and optionally set AGENTBLAZOR_ANALYZE_MODEL.`
+- No-provider non-interactive gate: with OpenAI and Azure OpenAI environment variables removed, `agentblazor analyze --non-interactive` exits cleanly with `No OpenAI API key configured for agentblazor analyze. Set OPENAI_API_KEY or OpenAI__ApiKey, and optionally set AGENTBLAZOR_ANALYZE_MODEL.`
 - Static-only gate: `agentblazor analyze ... --static-only` writes a report with routes, capabilities, services, static workflow candidates, install readiness, and recommended next steps without requiring an LLM provider.
 
 ## Applications Tested
@@ -194,6 +194,7 @@ Synthetic target refresh using the NuGet-installed tool:
 
 Additional command-path gates:
 
-- No-provider path exits cleanly with: `No OpenAI API key configured for agentblazor analyze. Set OPENAI_API_KEY or OpenAI__ApiKey, and optionally set AGENTBLAZOR_ANALYZE_MODEL.`
+- No-provider non-interactive path exits cleanly with: `No OpenAI API key configured for agentblazor analyze. Set OPENAI_API_KEY or OpenAI__ApiKey, and optionally set AGENTBLAZOR_ANALYZE_MODEL.`
+- No-provider interactive path prompts for an OpenAI API key, masks the input, and uses it for the current run without writing it to disk.
 - `--static-only` works without an LLM provider and writes an analysis report.
 - Rejected suggestions remain visible in the report for now as validation evidence. Hiding them by default is a future UX decision, not a v1 ship blocker.

--- a/docs/internal/cli-v1-scope-2026-05-24.md
+++ b/docs/internal/cli-v1-scope-2026-05-24.md
@@ -12,7 +12,7 @@ This scope has been reviewed against the current codebase after the v1 implement
 - `agentblazor analyze` exists and is published in `AgentBlazor.Cli` `0.2.2`.
 - `src/AgentBlazor.Cli` and `src/AgentBlazor.Cli.Analysis` target `net10.0`.
 - The command is read-mostly: it writes the configured markdown report and does not update `.agentblazor/.state`.
-- Provider/model configuration is environment-driven for v1. `OPENAI_API_KEY` or `OpenAI__ApiKey` is required for LLM suggestions, unless `--static-only` is used. `AGENTBLAZOR_ANALYZE_MODEL`, `OPENAI_MODEL`, or `OpenAI__Model` can override the model.
+- Provider/model configuration is environment-driven for repeatable and non-interactive v1 use, but interactive OpenAI runs prompt for a missing API key and use it for that run only. `OPENAI_API_KEY` or `OpenAI__ApiKey` is required for non-interactive LLM suggestions, unless `--static-only` is used. `AGENTBLAZOR_ANALYZE_MODEL`, `OPENAI_MODEL`, or `OpenAI__Model` can override the model.
 - The synthetic `tests/cli-targets/*` reference applications exist and are covered by automated tests.
 - Final validation evidence is recorded in `docs/internal/cli-v1-real-app-validation-2026-05-27.md`.
 
@@ -66,7 +66,7 @@ Explicit non-scope for v1:
 - Does not support incremental re-analysis. Every run is a fresh analysis.
 - Does not support non-Blazor frameworks in v1. The architecture is designed to allow framework adapters to be added later, but whether they get built depends on v1 traction and audience evidence.
 
-Provider and model configuration is read from new v1 configuration fields or environment variables. If no provider is configured, the command exits with a clear error explaining exactly what to configure.
+Provider and model configuration is read from v1 configuration fields or environment variables. For the default OpenAI provider, an interactive terminal can prompt for a missing API key and use it for the current run without writing it to disk. If provider configuration is still missing in a non-interactive path, the command exits with a clear error explaining exactly what to configure.
 
 ## Command Signature
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,6 +1,6 @@
 # Quickstart
 
-Get one working AgentBlazor chat widget into a fresh Blazor app. Tested against a clean `dotnet new blazor` project with `AgentBlazor 0.2.2`.
+Get one working AgentBlazor chat widget into a fresh Blazor app. Tested against a clean `dotnet new blazor` project with `AgentBlazor 0.2.3`.
 
 Hosted demo: https://demo.agentblazor.com/demo/workflows/support-inbox
 
@@ -182,6 +182,7 @@ Say hello
 ## Next
 
 - [Hosted demo](https://demo.agentblazor.com/demo/workflows/support-inbox)
+- [0.2.3 release notes](releases/0.2.3.md)
 - [0.2.2 release notes](releases/0.2.2.md)
 - [0.2.1 release notes](releases/0.2.1.md)
 - [0.2.0 release notes](releases/0.2.0.md)

--- a/docs/releases/0.2.3.md
+++ b/docs/releases/0.2.3.md
@@ -1,0 +1,39 @@
+# AgentBlazor 0.2.3 Release Notes
+
+Target package line: `0.2.3` stable.
+
+AgentBlazor 0.2.3 is a CLI first-run usability patch.
+
+## Fixes
+
+- `agentblazor analyze` now prompts for an OpenAI API key when no key is configured and the terminal is interactive.
+- The prompted key is used for the current analysis run only and is not written to disk.
+- `--non-interactive`, redirected shells, and CI-style runs keep the explicit environment-variable error.
+- `--static-only` still avoids provider configuration entirely.
+
+## Verification
+
+- CLI build passed: `dotnet build src/AgentBlazor.Cli/AgentBlazor.Cli.csproj`.
+- Analysis test suite passed: `161` tests.
+- Existing environment-key analyze path passed against `tests/cli-targets/simple-blazor-app`.
+- No-key `--non-interactive` path returned the expected configuration error.
+- No-key `--static-only` path wrote a report without an LLM provider.
+- Interactive no-key path prompted for an API key and masked the input.
+
+## Install
+
+```bash
+dotnet add package AgentBlazor --version 0.2.3
+```
+
+Optional packages:
+
+```bash
+dotnet add package AgentBlazor.Client --version 0.2.3
+dotnet add package AgentBlazor.EntityFrameworkCore --version 0.2.3
+dotnet tool install --global AgentBlazor.Cli --version 0.2.3
+```
+
+## Previous Release
+
+For the CLI v1 analyze package refresh, see [0.2.2 release notes](0.2.2.md).

--- a/src/AgentBlazor.Cli.Analysis/ExistingAppScaffoldApplier.cs
+++ b/src/AgentBlazor.Cli.Analysis/ExistingAppScaffoldApplier.cs
@@ -301,7 +301,7 @@ public sealed class ExistingAppScaffoldApplier
             .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
             ?.InformationalVersion
             ?? typeof(ExistingAppScaffoldApplier).Assembly.GetName().Version?.ToString()
-            ?? "0.2.2";
+            ?? "0.2.3";
 
         return version.Split('+', 2)[0];
     }

--- a/src/AgentBlazor.Cli/Commands/AnalyzeCommand.cs
+++ b/src/AgentBlazor.Cli/Commands/AnalyzeCommand.cs
@@ -59,9 +59,13 @@ public sealed class AnalyzeCommand : AsyncCommand<AnalyzeCommand.Settings>
             var hostProject = settings.HostProject ?? config?.HostProject;
             var description = config?.Description ?? "A Blazor application";
             var outputPath = ResolveOutputPath(settings.Output, outputDirectory);
+            var clientOptions = WorkflowSuggestionClientFactory.FromEnvironment(config);
+            clientOptions = settings.StaticOnly
+                ? clientOptions
+                : PromptForMissingOpenAIApiKey(clientOptions, settings.NonInteractive);
             var suggestionClient = settings.StaticOnly
                 ? null
-                : WorkflowSuggestionClientFactory.Create(WorkflowSuggestionClientFactory.FromEnvironment(config));
+                : WorkflowSuggestionClientFactory.Create(clientOptions);
             var analyzerRegistry = new ProjectAnalyzerRegistry();
             var analyzer = analyzerRegistry.ResolveBlazor(settings.Framework, path);
 
@@ -165,6 +169,32 @@ public sealed class AnalyzeCommand : AsyncCommand<AnalyzeCommand.Settings>
         return Path.IsPathRooted(output)
             ? output
             : Path.GetFullPath(Path.Combine(Directory.GetCurrentDirectory(), output));
+    }
+
+    private static WorkflowSuggestionClientOptions PromptForMissingOpenAIApiKey(
+        WorkflowSuggestionClientOptions options,
+        bool nonInteractive)
+    {
+        if (!options.Provider.Equals("openai", StringComparison.OrdinalIgnoreCase) ||
+            !string.IsNullOrWhiteSpace(options.OpenAIApiKey) ||
+            nonInteractive ||
+            Console.IsInputRedirected ||
+            Console.IsOutputRedirected)
+        {
+            return options;
+        }
+
+        AnsiConsole.MarkupLine("[yellow]No OpenAI API key found.[/]");
+        AnsiConsole.MarkupLine("[grey]Enter a key for this analysis run. It will not be written to disk.[/]");
+
+        var apiKey = AnsiConsole.Prompt(
+            new TextPrompt<string>("OpenAI API key:")
+                .PromptStyle("grey")
+                .Secret());
+
+        return string.IsNullOrWhiteSpace(apiKey)
+            ? options
+            : options with { OpenAIApiKey = apiKey };
     }
 
     private static void RenderSummary(

--- a/src/AgentBlazor.Cli/PACKAGE_README.md
+++ b/src/AgentBlazor.Cli/PACKAGE_README.md
@@ -11,7 +11,7 @@ dotnet tool install --global AgentBlazor.Cli
 If you prefer a pinned install:
 
 ```bash
-dotnet tool install --global AgentBlazor.Cli --version 0.2.2
+dotnet tool install --global AgentBlazor.Cli --version 0.2.3
 ```
 
 Example:
@@ -28,7 +28,9 @@ Read-only analysis:
 agentblazor analyze ./MySolution.slnx --host MyBlazorApp
 ```
 
-`analyze` writes `.agentblazor/analysis.md` and does not modify application code. Set `OPENAI_API_KEY` and optionally `AGENTBLAZOR_ANALYZE_MODEL` for LLM workflow suggestions, or pass `--static-only` to generate a static report without an LLM call.
+`analyze` writes `.agentblazor/analysis.md` and does not modify application code. It uses OpenAI for workflow suggestions, or you can pass `--static-only` to generate a static report without an LLM call.
+
+If no OpenAI key is configured and the terminal is interactive, `analyze` prompts for a key and uses it for that run only. The key is not written to disk.
 
 The CLI is an advanced path. The default install story is still `dotnet add package AgentBlazor` plus manual runtime wiring.
 
@@ -36,6 +38,7 @@ Docs:
 
 - Repository: https://github.com/ashpeterson/AgentBlazor
 - Advanced CLI guide: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/advanced/cli.md
+- 0.2.3 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.3.md
 - 0.2.2 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.2.md
 - 0.2.1 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.1.md
 - 0.2.0 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.0.md

--- a/src/AgentBlazor.Cli/Program.cs
+++ b/src/AgentBlazor.Cli/Program.cs
@@ -7,7 +7,7 @@ var version = typeof(ScaffoldCommand).Assembly
     .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
     ?.InformationalVersion
     ?? typeof(ScaffoldCommand).Assembly.GetName().Version?.ToString()
-    ?? "0.2.2";
+    ?? "0.2.3";
 version = version.Split('+', 2)[0];
 
 app.Configure(config =>

--- a/src/AgentBlazor.Cli/README.md
+++ b/src/AgentBlazor.Cli/README.md
@@ -8,7 +8,7 @@ Read-only analysis:
 agentblazor analyze ./MySolution.slnx --host MyBlazorApp
 ```
 
-Set `OPENAI_API_KEY` and optionally `AGENTBLAZOR_ANALYZE_MODEL` for LLM workflow suggestions, or pass `--static-only` to skip the LLM call.
+If no OpenAI key is configured and the terminal is interactive, `analyze` prompts for one and uses it for that run only. For repeat runs or CI, set `OPENAI_API_KEY` and optionally `AGENTBLAZOR_ANALYZE_MODEL`. Pass `--static-only` to skip the LLM call.
 
 See:
 

--- a/src/AgentBlazor.Client/PACKAGE_README.md
+++ b/src/AgentBlazor.Client/PACKAGE_README.md
@@ -11,7 +11,7 @@ dotnet add package AgentBlazor.Client
 If you prefer a pinned install:
 
 ```bash
-dotnet add package AgentBlazor.Client --version 0.2.2
+dotnet add package AgentBlazor.Client --version 0.2.3
 ```
 
 Server project:
@@ -35,6 +35,7 @@ Docs:
 
 - Repository: https://github.com/ashpeterson/AgentBlazor
 - Quickstart: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/quickstart.md
+- 0.2.3 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.3.md
 - 0.2.2 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.2.md
 - 0.2.1 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.1.md
 - 0.2.0 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.0.md

--- a/src/AgentBlazor.Components/PACKAGE_README.md
+++ b/src/AgentBlazor.Components/PACKAGE_README.md
@@ -15,10 +15,10 @@ dotnet add package AgentBlazor
 If you prefer a pinned install, use:
 
 ```bash
-dotnet add package AgentBlazor --version 0.2.2
+dotnet add package AgentBlazor --version 0.2.3
 ```
 
-Use `0.2.2` or later. This release includes the CLI v1 analyze package refresh, mobile chat input stability fix, corrected EF package shape, and tool-friendly schemas for date-like workflow parameters.
+Use `0.2.3` or later. This release includes the CLI first-run API-key prompt, CLI v1 analyze package refresh, mobile chat input stability fix, corrected EF package shape, and tool-friendly schemas for date-like workflow parameters.
 
 If `dotnet` still probes an old custom package source on your machine, remove or disable that source before testing the public NuGet install path.
 
@@ -88,6 +88,7 @@ Docs and demo:
 - Hosted demo: https://demo.agentblazor.com/demo/workflows/support-inbox
 - Structured error reference: https://demo.agentblazor.com/demo/workflows/runtime-probe
 - Quickstart: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/quickstart.md
+- 0.2.3 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.3.md
 - 0.2.2 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.2.md
 - 0.2.1 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.1.md
 - 0.2.0 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.0.md

--- a/src/AgentBlazor.EntityFrameworkCore/README.md
+++ b/src/AgentBlazor.EntityFrameworkCore/README.md
@@ -13,10 +13,10 @@ dotnet add package AgentBlazor.EntityFrameworkCore
 Pinned install:
 
 ```bash
-dotnet add package AgentBlazor.EntityFrameworkCore --version 0.2.2
+dotnet add package AgentBlazor.EntityFrameworkCore --version 0.2.3
 ```
 
-Use `0.2.2` or later. This release includes the CLI v1 analyze package refresh, mobile chat input stability fix, corrected EF package shape, and tool-friendly schemas for date-like workflow parameters.
+Use `0.2.3` or later. This release includes the CLI first-run API-key prompt, CLI v1 analyze package refresh, mobile chat input stability fix, corrected EF package shape, and tool-friendly schemas for date-like workflow parameters.
 
 Register your `DbContext` with `IDbContextFactory<TContext>`:
 

--- a/tests/AgentBlazor.Cli.Analysis.Tests/ExistingAppScaffoldPlannerTests.cs
+++ b/tests/AgentBlazor.Cli.Analysis.Tests/ExistingAppScaffoldPlannerTests.cs
@@ -250,7 +250,7 @@ public sealed class ExistingAppScaffoldPlannerTests : IDisposable
         Assert.Contains("""<PackageReference Include="MudBlazor" />""", projectText, StringComparison.Ordinal);
         Assert.DoesNotContain("PackageReference Include=\"AgentBlazor\" Version=", projectText, StringComparison.Ordinal);
         Assert.DoesNotContain("PackageReference Include=\"MudBlazor\" Version=", projectText, StringComparison.Ordinal);
-        Assert.Contains("""<PackageVersion Include="AgentBlazor" Version="0.2.2" />""", centralPackagesText, StringComparison.Ordinal);
+        Assert.Contains("""<PackageVersion Include="AgentBlazor" Version="0.2.3" />""", centralPackagesText, StringComparison.Ordinal);
         Assert.Contains("""<PackageVersion Include="MudBlazor" Version="9.0.0" />""", centralPackagesText, StringComparison.Ordinal);
     }
 


### PR DESCRIPTION
## Summary
- prompt for a missing OpenAI API key during interactive `agentblazor analyze` runs
- keep `--non-interactive`, redirected shells, and `--static-only` deterministic
- prepare 0.2.3 package docs and release notes for the first-run CLI usability patch

## Verification
- dotnet build src/AgentBlazor.Cli/AgentBlazor.Cli.csproj
- dotnet test tests/AgentBlazor.Cli.Analysis.Tests/AgentBlazor.Cli.Analysis.Tests.csproj
- dotnet run --project src/AgentBlazor.Cli/AgentBlazor.Cli.csproj -- --version
- no-key `--non-interactive` analyze returns the expected provider configuration error
- no-key `--static-only` analyze writes a report without provider configuration
- env-key analyze with real OpenAI key completes on tests/cli-targets/simple-blazor-app
- pseudo-terminal no-key run prompts for an OpenAI key and masks input