### PR TITLE
fix(cli): fall back when MSBuildWorkspace fails

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
 
   <!-- Common package metadata for all AgentBlazor packages -->
   <PropertyGroup>
-    <Version>0.2.3</Version>
+    <Version>0.2.4</Version>
     <Authors>Ash Peterson</Authors>
     <Company>AgentBlazor</Company>
     <Copyright>Copyright (c) 2026 Ash Peterson</Copyright>
@@ -16,7 +16,7 @@
     <RepositoryType>git</RepositoryType>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <PackageIcon>icon.png</PackageIcon>
-    <PackageReleaseNotes>v0.2.3: CLI analyze now prompts for a missing OpenAI API key in interactive terminals and uses it for the current run only. Non-interactive and static-only paths remain deterministic. Includes the v0.2.2 CLI v1 analyze package refresh, structured errors, EF schema exposure, hosted demo observability, and mobile chat input stability fixes.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.2.4: CLI analyze now falls back to static source-file analysis when Roslyn MSBuildWorkspace fails, including the Windows XMakeElements failure seen with conflicting Visual Studio/MSBuild installations. Includes the v0.2.3 first-run API-key prompt, CLI v1 analyze refresh, structured errors, EF schema exposure, hosted demo observability, and mobile chat input stability fixes.</PackageReleaseNotes>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <Deterministic>true</Deterministic>

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Try the hosted demo:
 dotnet add package AgentBlazor
 ```
 
-Use `0.2.3` or later. This release includes the CLI first-run API-key prompt, CLI v1 analyze package refresh, mobile chat input stability fix, corrected EF package shape, and tool-friendly schemas for `DateOnly`, `TimeOnly`, `DateTime`, `DateTimeOffset`, and `Guid` workflow parameters.
+Use `0.2.4` or later. This release includes the CLI Windows MSBuild fallback and first-run API-key prompt, CLI v1 analyze package refresh, mobile chat input stability fix, corrected EF package shape, and tool-friendly schemas for `DateOnly`, `TimeOnly`, `DateTime`, `DateTimeOffset`, and `Guid` workflow parameters.
 
 The CLI is optional. Keep it out of the critical path unless you want scaffold help for an existing app.
 
@@ -105,6 +105,7 @@ dotnet run --project samples/AgentBlazor.Starter/AgentBlazor.Starter.csproj
 ## Docs
 
 - [Quickstart](docs/quickstart.md)
+- [0.2.4 release notes](docs/releases/0.2.4.md)
 - [0.2.3 release notes](docs/releases/0.2.3.md)
 - [0.2.2 release notes](docs/releases/0.2.2.md)
 - [0.2.1 release notes](docs/releases/0.2.1.md)

--- a/docs/entity-framework.md
+++ b/docs/entity-framework.md
@@ -17,7 +17,7 @@ dotnet add package AgentBlazor
 dotnet add package AgentBlazor.EntityFrameworkCore
 ```
 
-Use `0.2.3` or later. This release includes the CLI first-run API-key prompt, CLI v1 analyze package refresh, mobile chat input stability fix, corrected EF package shape, and tool-friendly schemas for date-like workflow parameters.
+Use `0.2.4` or later. This release includes the CLI Windows MSBuild fallback and first-run API-key prompt, CLI v1 analyze package refresh, mobile chat input stability fix, corrected EF package shape, and tool-friendly schemas for date-like workflow parameters.
 
 ## DbContext Setup
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,6 +1,6 @@
 # Quickstart
 
-Get one working AgentBlazor chat widget into a fresh Blazor app. Tested against a clean `dotnet new blazor` project with `AgentBlazor 0.2.3`.
+Get one working AgentBlazor chat widget into a fresh Blazor app. Tested against a clean `dotnet new blazor` project with `AgentBlazor 0.2.4`.
 
 Hosted demo: https://demo.agentblazor.com/demo/workflows/support-inbox
 
@@ -182,6 +182,7 @@ Say hello
 ## Next
 
 - [Hosted demo](https://demo.agentblazor.com/demo/workflows/support-inbox)
+- [0.2.4 release notes](releases/0.2.4.md)
 - [0.2.3 release notes](releases/0.2.3.md)
 - [0.2.2 release notes](releases/0.2.2.md)
 - [0.2.1 release notes](releases/0.2.1.md)

--- a/docs/releases/0.2.4.md
+++ b/docs/releases/0.2.4.md
@@ -1,0 +1,38 @@
+# AgentBlazor 0.2.4 Release Notes
+
+Target package line: `0.2.4` stable.
+
+AgentBlazor 0.2.4 is a CLI Windows/MSBuild resilience patch.
+
+## Fixes
+
+- `agentblazor analyze` now falls back to static source-file analysis when Roslyn `MSBuildWorkspace` fails to load a solution.
+- This covers the Windows `Microsoft.Build.Shared.XMakeElements` `TypeInitializationException` seen when Visual Studio/MSBuild installations conflict.
+- The fallback still discovers Blazor routes, components, services, DI registrations, `[AgentCapability]` classes, and candidate actions from source files.
+- A hidden `AGENTBLAZOR_STATIC_WORKSPACE=1` switch can force the static loader for diagnostics or machines with broken MSBuildWorkspace installations.
+
+## Verification
+
+- CLI build passed: `dotnet build src/AgentBlazor.Cli/AgentBlazor.Cli.csproj`.
+- Analysis test suite passed: `161` tests.
+- Static fallback analyzed `dotnet-architecture/eShopOnBlazor`: 5 routes, 2 services, 7 discovered actions.
+- Static fallback plus real OpenAI suggestions analyzed `dotnet-architecture/eShopOnBlazor`: 5 accepted suggestions, 0 rejected.
+- Existing `MSBuildWorkspace` path remains unchanged for machines where Roslyn solution loading succeeds.
+
+## Install
+
+```bash
+dotnet add package AgentBlazor --version 0.2.4
+```
+
+Optional packages:
+
+```bash
+dotnet add package AgentBlazor.Client --version 0.2.4
+dotnet add package AgentBlazor.EntityFrameworkCore --version 0.2.4
+dotnet tool install --global AgentBlazor.Cli --version 0.2.4
+```
+
+## Previous Release
+
+For the first-run CLI API-key prompt, see [0.2.3 release notes](0.2.3.md).

--- a/src/AgentBlazor.Cli.Analysis/ExistingAppScaffoldApplier.cs
+++ b/src/AgentBlazor.Cli.Analysis/ExistingAppScaffoldApplier.cs
@@ -301,7 +301,7 @@ public sealed class ExistingAppScaffoldApplier
             .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
             ?.InformationalVersion
             ?? typeof(ExistingAppScaffoldApplier).Assembly.GetName().Version?.ToString()
-            ?? "0.2.3";
+            ?? "0.2.4";
 
         return version.Split('+', 2)[0];
     }

--- a/src/AgentBlazor.Cli.Analysis/SolutionLoader.cs
+++ b/src/AgentBlazor.Cli.Analysis/SolutionLoader.cs
@@ -1,6 +1,8 @@
 using Microsoft.Build.Locator;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.MSBuild;
+using Microsoft.CodeAnalysis.Text;
+using System.Xml.Linq;
 
 namespace AgentBlazor.Cli.Analysis;
 
@@ -39,28 +41,56 @@ public sealed class SolutionLoader : IDisposable
 
     public async Task<Solution> LoadSolutionAsync(string solutionPath, CancellationToken ct = default)
     {
-        EnsureMSBuildRegistered();
+        if (UseStaticWorkspace())
+        {
+            Diagnostics = ["Using static source-file analysis because AGENTBLAZOR_STATIC_WORKSPACE=1 is set."];
+            return await StaticWorkspaceLoader.LoadSolutionAsync(solutionPath, ct).ConfigureAwait(false);
+        }
 
-        var diagnostics = new List<string>();
-        _workspace = MSBuildWorkspace.Create();
-        RegisterWorkspaceDiagnostics(_workspace, diagnostics);
+        try
+        {
+            EnsureMSBuildRegistered();
 
-        var solution = await _workspace.OpenSolutionAsync(solutionPath, cancellationToken: ct);
-        Diagnostics = diagnostics;
-        return solution;
+            var diagnostics = new List<string>();
+            _workspace = MSBuildWorkspace.Create();
+            RegisterWorkspaceDiagnostics(_workspace, diagnostics);
+
+            var solution = await _workspace.OpenSolutionAsync(solutionPath, cancellationToken: ct);
+            Diagnostics = diagnostics;
+            return solution;
+        }
+        catch (Exception ex) when (ShouldFallbackToStaticWorkspace(ex))
+        {
+            Diagnostics = [$"MSBuildWorkspace failed ({GetRelevantExceptionMessage(ex)}). Falling back to static source-file analysis."];
+            return await StaticWorkspaceLoader.LoadSolutionAsync(solutionPath, ct).ConfigureAwait(false);
+        }
     }
 
     public async Task<Project> LoadProjectAsync(string projectPath, CancellationToken ct = default)
     {
-        EnsureMSBuildRegistered();
+        if (UseStaticWorkspace())
+        {
+            Diagnostics = ["Using static source-file analysis because AGENTBLAZOR_STATIC_WORKSPACE=1 is set."];
+            return await StaticWorkspaceLoader.LoadProjectAsync(projectPath, ct).ConfigureAwait(false);
+        }
 
-        var diagnostics = new List<string>();
-        _workspace = MSBuildWorkspace.Create();
-        RegisterWorkspaceDiagnostics(_workspace, diagnostics);
+        try
+        {
+            EnsureMSBuildRegistered();
 
-        var project = await _workspace.OpenProjectAsync(projectPath, cancellationToken: ct);
-        Diagnostics = diagnostics;
-        return project;
+            var diagnostics = new List<string>();
+            _workspace = MSBuildWorkspace.Create();
+            RegisterWorkspaceDiagnostics(_workspace, diagnostics);
+
+            var project = await _workspace.OpenProjectAsync(projectPath, cancellationToken: ct);
+            Diagnostics = diagnostics;
+            return project;
+        }
+        catch (Exception ex) when (ShouldFallbackToStaticWorkspace(ex))
+        {
+            Diagnostics = [$"MSBuildWorkspace failed ({GetRelevantExceptionMessage(ex)}). Falling back to static source-file analysis."];
+            return await StaticWorkspaceLoader.LoadProjectAsync(projectPath, ct).ConfigureAwait(false);
+        }
     }
 
     private static void RegisterWorkspaceDiagnostics(Workspace workspace, ICollection<string> diagnostics)
@@ -119,5 +149,225 @@ public sealed class SolutionLoader : IDisposable
     public void Dispose()
     {
         _workspace?.Dispose();
+    }
+
+    private static bool ShouldFallbackToStaticWorkspace(Exception ex)
+    {
+        for (var current = ex; current is not null; current = current.InnerException)
+        {
+            if (current.GetType().FullName?.Contains("RemoteInvocationException", StringComparison.OrdinalIgnoreCase) == true ||
+                current is TypeInitializationException ||
+                current.Message.Contains("XMakeElements", StringComparison.OrdinalIgnoreCase) ||
+                current.Message.Contains("MSBuildWorkspace", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool UseStaticWorkspace()
+        => Environment.GetEnvironmentVariable("AGENTBLAZOR_STATIC_WORKSPACE") == "1";
+
+    private static string GetRelevantExceptionMessage(Exception ex)
+    {
+        for (var current = ex; current is not null; current = current.InnerException)
+        {
+            if (current.Message.Contains("XMakeElements", StringComparison.OrdinalIgnoreCase))
+            {
+                return current.Message;
+            }
+        }
+
+        return ex.Message;
+    }
+}
+
+internal static class StaticWorkspaceLoader
+{
+    public static async Task<Solution> LoadSolutionAsync(string solutionPath, CancellationToken ct)
+    {
+        var solutionFullPath = Path.GetFullPath(solutionPath);
+        var solutionDirectory = Path.GetDirectoryName(solutionFullPath)!;
+        var projectPaths = solutionFullPath.EndsWith(".slnx", StringComparison.OrdinalIgnoreCase)
+            ? ReadSlnxProjectPaths(solutionFullPath, solutionDirectory)
+            : ReadSlnProjectPaths(solutionFullPath, solutionDirectory);
+
+        if (projectPaths.Count == 0)
+        {
+            projectPaths = Directory.GetFiles(solutionDirectory, "*.csproj", SearchOption.AllDirectories)
+                .Where(path => !IsUnderIgnoredDirectory(path))
+                .ToList();
+        }
+
+        return await BuildSolutionAsync(projectPaths, ct).ConfigureAwait(false);
+    }
+
+    public static async Task<Project> LoadProjectAsync(string projectPath, CancellationToken ct)
+    {
+        var solution = await BuildSolutionAsync([Path.GetFullPath(projectPath)], ct).ConfigureAwait(false);
+        return solution.Projects.First();
+    }
+
+    private static async Task<Solution> BuildSolutionAsync(IReadOnlyList<string> projectPaths, CancellationToken ct)
+    {
+        var workspace = new AdhocWorkspace();
+        var solution = workspace.CurrentSolution;
+        var projectIds = new Dictionary<string, ProjectId>(StringComparer.OrdinalIgnoreCase);
+        var projectInfos = new Dictionary<string, StaticProjectInfo>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var projectPath in projectPaths.Distinct(StringComparer.OrdinalIgnoreCase).Where(File.Exists))
+        {
+            ct.ThrowIfCancellationRequested();
+            var info = StaticProjectInfo.Read(projectPath);
+            var projectId = ProjectId.CreateNewId(info.Name);
+            projectIds[projectPath] = projectId;
+            projectInfos[projectPath] = info;
+
+            solution = solution.AddProject(
+                ProjectInfo.Create(
+                    projectId,
+                    VersionStamp.Create(),
+                    info.Name,
+                    info.Name,
+                    LanguageNames.CSharp,
+                    filePath: projectPath));
+        }
+
+        foreach (var (projectPath, info) in projectInfos)
+        {
+            ct.ThrowIfCancellationRequested();
+            var projectId = projectIds[projectPath];
+
+            foreach (var referencePath in info.ProjectReferences)
+            {
+                if (projectIds.TryGetValue(referencePath, out var referenceId))
+                {
+                    solution = solution.AddProjectReference(projectId, new ProjectReference(referenceId));
+                }
+            }
+
+            foreach (var filePath in EnumerateSourceFiles(info.Directory))
+            {
+                ct.ThrowIfCancellationRequested();
+                var text = SourceText.From(await File.ReadAllTextAsync(filePath, ct).ConfigureAwait(false));
+
+                if (filePath.EndsWith(".razor", StringComparison.OrdinalIgnoreCase))
+                {
+                    solution = solution.AddAdditionalDocument(
+                        DocumentId.CreateNewId(projectId),
+                        Path.GetFileName(filePath),
+                        text,
+                        filePath: filePath);
+                }
+                else
+                {
+                    solution = solution.AddDocument(
+                        DocumentId.CreateNewId(projectId),
+                        Path.GetFileName(filePath),
+                        text,
+                        filePath: filePath);
+                }
+            }
+        }
+
+        return solution;
+    }
+
+    private static List<string> ReadSlnProjectPaths(string solutionPath, string solutionDirectory)
+    {
+        var projectPaths = new List<string>();
+
+        foreach (var line in File.ReadLines(solutionPath))
+        {
+            var trimmed = line.Trim();
+            if (!trimmed.StartsWith("Project(", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var parts = trimmed.Split(',', StringSplitOptions.TrimEntries);
+            if (parts.Length < 2)
+            {
+                continue;
+            }
+
+            var relativePath = NormalizeSolutionPath(parts[1].Trim('"'));
+            if (!relativePath.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            projectPaths.Add(Path.GetFullPath(Path.Combine(solutionDirectory, relativePath)));
+        }
+
+        return projectPaths;
+    }
+
+    private static List<string> ReadSlnxProjectPaths(string solutionPath, string solutionDirectory)
+    {
+        var document = XDocument.Load(solutionPath);
+        return document
+            .Descendants("Project")
+            .Select(element => element.Attribute("Path")?.Value)
+            .Where(path => !string.IsNullOrWhiteSpace(path) && path.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase))
+            .Select(path => Path.GetFullPath(Path.Combine(solutionDirectory, NormalizeSolutionPath(path!))))
+            .ToList();
+    }
+
+    private static string NormalizeSolutionPath(string path)
+        => path.Replace('\\', Path.DirectorySeparatorChar).Replace('/', Path.DirectorySeparatorChar);
+
+    private static IEnumerable<string> EnumerateSourceFiles(string projectDirectory)
+        => Directory
+            .EnumerateFiles(projectDirectory, "*.*", SearchOption.AllDirectories)
+            .Where(path =>
+                (path.EndsWith(".cs", StringComparison.OrdinalIgnoreCase) ||
+                 path.EndsWith(".razor", StringComparison.OrdinalIgnoreCase)) &&
+                !IsUnderIgnoredDirectory(path));
+
+    private static bool IsUnderIgnoredDirectory(string path)
+    {
+        var parts = path.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        return parts.Any(part =>
+            part.Equals("bin", StringComparison.OrdinalIgnoreCase) ||
+            part.Equals("obj", StringComparison.OrdinalIgnoreCase) ||
+            part.Equals(".git", StringComparison.OrdinalIgnoreCase) ||
+            part.Equals("node_modules", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private sealed record StaticProjectInfo(
+        string Name,
+        string Path,
+        string Directory,
+        IReadOnlyList<string> ProjectReferences)
+    {
+        public static StaticProjectInfo Read(string projectPath)
+        {
+            var fullPath = System.IO.Path.GetFullPath(projectPath);
+            var directory = System.IO.Path.GetDirectoryName(fullPath)!;
+            var name = System.IO.Path.GetFileNameWithoutExtension(fullPath);
+            var references = new List<string>();
+
+            try
+            {
+                var document = XDocument.Load(fullPath);
+                foreach (var reference in document.Descendants("ProjectReference"))
+                {
+                    var include = reference.Attribute("Include")?.Value;
+                    if (!string.IsNullOrWhiteSpace(include))
+                    {
+                        references.Add(System.IO.Path.GetFullPath(System.IO.Path.Combine(directory, include)));
+                    }
+                }
+            }
+            catch
+            {
+                // Keep fallback loading best-effort. The caller still gets source files from this project.
+            }
+
+            return new StaticProjectInfo(name, fullPath, directory, references);
+        }
     }
 }

--- a/src/AgentBlazor.Cli/PACKAGE_README.md
+++ b/src/AgentBlazor.Cli/PACKAGE_README.md
@@ -11,7 +11,7 @@ dotnet tool install --global AgentBlazor.Cli
 If you prefer a pinned install:
 
 ```bash
-dotnet tool install --global AgentBlazor.Cli --version 0.2.3
+dotnet tool install --global AgentBlazor.Cli --version 0.2.4
 ```
 
 Example:
@@ -38,6 +38,7 @@ Docs:
 
 - Repository: https://github.com/ashpeterson/AgentBlazor
 - Advanced CLI guide: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/advanced/cli.md
+- 0.2.4 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.4.md
 - 0.2.3 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.3.md
 - 0.2.2 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.2.md
 - 0.2.1 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.1.md

--- a/src/AgentBlazor.Cli/Program.cs
+++ b/src/AgentBlazor.Cli/Program.cs
@@ -7,7 +7,7 @@ var version = typeof(ScaffoldCommand).Assembly
     .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
     ?.InformationalVersion
     ?? typeof(ScaffoldCommand).Assembly.GetName().Version?.ToString()
-    ?? "0.2.3";
+    ?? "0.2.4";
 version = version.Split('+', 2)[0];
 
 app.Configure(config =>

--- a/src/AgentBlazor.Client/PACKAGE_README.md
+++ b/src/AgentBlazor.Client/PACKAGE_README.md
@@ -11,7 +11,7 @@ dotnet add package AgentBlazor.Client
 If you prefer a pinned install:
 
 ```bash
-dotnet add package AgentBlazor.Client --version 0.2.3
+dotnet add package AgentBlazor.Client --version 0.2.4
 ```
 
 Server project:
@@ -35,6 +35,7 @@ Docs:
 
 - Repository: https://github.com/ashpeterson/AgentBlazor
 - Quickstart: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/quickstart.md
+- 0.2.4 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.4.md
 - 0.2.3 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.3.md
 - 0.2.2 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.2.md
 - 0.2.1 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.1.md

--- a/src/AgentBlazor.Components/PACKAGE_README.md
+++ b/src/AgentBlazor.Components/PACKAGE_README.md
@@ -15,10 +15,10 @@ dotnet add package AgentBlazor
 If you prefer a pinned install, use:
 
 ```bash
-dotnet add package AgentBlazor --version 0.2.3
+dotnet add package AgentBlazor --version 0.2.4
 ```
 
-Use `0.2.3` or later. This release includes the CLI first-run API-key prompt, CLI v1 analyze package refresh, mobile chat input stability fix, corrected EF package shape, and tool-friendly schemas for date-like workflow parameters.
+Use `0.2.4` or later. This release includes the CLI Windows MSBuild fallback and first-run API-key prompt, CLI v1 analyze package refresh, mobile chat input stability fix, corrected EF package shape, and tool-friendly schemas for date-like workflow parameters.
 
 If `dotnet` still probes an old custom package source on your machine, remove or disable that source before testing the public NuGet install path.
 
@@ -88,6 +88,7 @@ Docs and demo:
 - Hosted demo: https://demo.agentblazor.com/demo/workflows/support-inbox
 - Structured error reference: https://demo.agentblazor.com/demo/workflows/runtime-probe
 - Quickstart: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/quickstart.md
+- 0.2.4 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.4.md
 - 0.2.3 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.3.md
 - 0.2.2 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.2.md
 - 0.2.1 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.1.md

--- a/src/AgentBlazor.EntityFrameworkCore/README.md
+++ b/src/AgentBlazor.EntityFrameworkCore/README.md
@@ -13,10 +13,10 @@ dotnet add package AgentBlazor.EntityFrameworkCore
 Pinned install:
 
 ```bash
-dotnet add package AgentBlazor.EntityFrameworkCore --version 0.2.3
+dotnet add package AgentBlazor.EntityFrameworkCore --version 0.2.4
 ```
 
-Use `0.2.3` or later. This release includes the CLI first-run API-key prompt, CLI v1 analyze package refresh, mobile chat input stability fix, corrected EF package shape, and tool-friendly schemas for date-like workflow parameters.
+Use `0.2.4` or later. This release includes the CLI Windows MSBuild fallback and first-run API-key prompt, CLI v1 analyze package refresh, mobile chat input stability fix, corrected EF package shape, and tool-friendly schemas for date-like workflow parameters.
 
 Register your `DbContext` with `IDbContextFactory<TContext>`:
 

--- a/tests/AgentBlazor.Cli.Analysis.Tests/Blazor/BlazorProjectAnalyzerTests.cs
+++ b/tests/AgentBlazor.Cli.Analysis.Tests/Blazor/BlazorProjectAnalyzerTests.cs
@@ -52,6 +52,44 @@ public sealed class BlazorProjectAnalyzerTests : IDisposable
         Assert.Null(analysis.Readiness);
     }
 
+    [Fact]
+    public async Task AnalyzeAsync_StaticWorkspaceFallback_LoadsSolutionProjectsAndRoutes()
+    {
+        var projectPath = CreateMinimalBlazorProject("FallbackBlazor");
+        var solutionPath = Path.Combine(_tempDir, "FallbackBlazor.sln");
+        File.WriteAllText(
+            solutionPath,
+            $$"""
+            Microsoft Visual Studio Solution File, Format Version 12.00
+            # Visual Studio Version 17
+            Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FallbackBlazor", "FallbackBlazor\FallbackBlazor.csproj", "{11111111-1111-1111-1111-111111111111}"
+            EndProject
+            Global
+            EndGlobal
+            """);
+
+        var previous = Environment.GetEnvironmentVariable("AGENTBLAZOR_STATIC_WORKSPACE");
+        Environment.SetEnvironmentVariable("AGENTBLAZOR_STATIC_WORKSPACE", "1");
+        try
+        {
+            var analyzer = new BlazorProjectAnalyzer();
+
+            var analysis = await analyzer.AnalyzeAsync(
+                solutionPath,
+                hostProjectName: "FallbackBlazor",
+                description: "Fallback app",
+                includeReadiness: true);
+
+            Assert.Equal("FallbackBlazor", analysis.Model.BlazorHostProject);
+            Assert.Contains(analysis.Model.Routes, route => route.Template == "/");
+            Assert.Contains(analysis.Model.Projects, project => project.Name == "FallbackBlazor");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("AGENTBLAZOR_STATIC_WORKSPACE", previous);
+        }
+    }
+
     private string CreateMinimalBlazorProject(string projectName)
     {
         var projectDirectory = Path.Combine(_tempDir, projectName);

--- a/tests/AgentBlazor.Cli.Analysis.Tests/ExistingAppScaffoldPlannerTests.cs
+++ b/tests/AgentBlazor.Cli.Analysis.Tests/ExistingAppScaffoldPlannerTests.cs
@@ -250,7 +250,7 @@ public sealed class ExistingAppScaffoldPlannerTests : IDisposable
         Assert.Contains("""<PackageReference Include="MudBlazor" />""", projectText, StringComparison.Ordinal);
         Assert.DoesNotContain("PackageReference Include=\"AgentBlazor\" Version=", projectText, StringComparison.Ordinal);
         Assert.DoesNotContain("PackageReference Include=\"MudBlazor\" Version=", projectText, StringComparison.Ordinal);
-        Assert.Contains("""<PackageVersion Include="AgentBlazor" Version="0.2.3" />""", centralPackagesText, StringComparison.Ordinal);
+        Assert.Contains("""<PackageVersion Include="AgentBlazor" Version="0.2.4" />""", centralPackagesText, StringComparison.Ordinal);
         Assert.Contains("""<PackageVersion Include="MudBlazor" Version="9.0.0" />""", centralPackagesText, StringComparison.Ordinal);
     }
 


### PR DESCRIPTION
## Summary
- add static source-file analysis fallback when Roslyn MSBuildWorkspace fails
- cover Windows XMakeElements TypeInitializationException caused by MSBuild/Visual Studio assembly conflicts
- add hidden AGENTBLAZOR_STATIC_WORKSPACE=1 diagnostic switch
- bump package line to 0.2.4 and add release notes

## Verification
- dotnet build src/AgentBlazor.Cli/AgentBlazor.Cli.csproj
- dotnet test tests/AgentBlazor.Cli.Analysis.Tests/AgentBlazor.Cli.Analysis.Tests.csproj
- dotnet run --project src/AgentBlazor.Cli/AgentBlazor.Cli.csproj -- --version
- AGENTBLAZOR_STATIC_WORKSPACE=1 dotnet run --project src/AgentBlazor.Cli/AgentBlazor.Cli.csproj -- analyze /tmp/agentblazor-cli-v1-more-realapps/eShopOnBlazor/eShopOnBlazor.sln --host eShopOnBlazor --static-only --output /tmp/eshop-static-fallback-024.md
- AGENTBLAZOR_STATIC_WORKSPACE=1 real OpenAI analyze on eShopOnBlazor produced 5 accepted suggestions, 0 rejected