### PR TITLE
Improve CLI analysis report quality

### DIFF
--- a/docs/advanced/cli.md
+++ b/docs/advanced/cli.md
@@ -39,10 +39,13 @@ The report includes:
 
 - discovered routes and pages
 - existing `[AgentCapability]` / `[AgentAction]` methods
-- developer-facing services and public methods
+- developer-facing services and public methods, with framework/helper noise filtered out
 - LLM workflow suggestions validated against the static analysis model
+- approval guidance for suggestions that reference mutating methods
 - install-readiness checks
 - recommended next steps
+
+The summary uses "AgentBlazor action adoption" to show how many actions are already confirmed with AgentBlazor attributes versus how many candidate actions were discovered but are not exposed yet.
 
 Run static analysis only when you do not want an LLM call:
 
@@ -90,6 +93,18 @@ agentblazor analyze ./MySolution.slnx --host MyBlazorApp
 ```
 
 If no provider is configured and the command cannot prompt, `analyze` exits before scanning and tells you which environment variables to set. Use `--static-only` to avoid provider configuration entirely.
+
+## Windows MSBuild Fallback
+
+`analyze` normally loads solutions through Roslyn `MSBuildWorkspace`. On machines where Visual Studio/MSBuild assemblies conflict, this can fail before project analysis starts. Version `0.2.4` and later fall back to static source-file analysis for known MSBuildWorkspace failures, including the `Microsoft.Build.Shared.XMakeElements` type-initializer error.
+
+You normally do not need to do anything. To force the fallback for diagnostics:
+
+```powershell
+$env:AGENTBLAZOR_STATIC_WORKSPACE = "1"
+agentblazor analyze .\MySolution.slnx --host MyBlazorApp --output .\analysis.md
+Remove-Item Env:AGENTBLAZOR_STATIC_WORKSPACE
+```
 
 ## Analyze Token Cost
 

--- a/docs/internal/cli-v1-scope-2026-05-24.md
+++ b/docs/internal/cli-v1-scope-2026-05-24.md
@@ -9,12 +9,15 @@ Document purpose: single source of truth for what AgentBlazor CLI v1 contains, w
 
 This scope has been reviewed against the current codebase after the v1 implementation work.
 
-- `agentblazor analyze` exists and is published in `AgentBlazor.Cli` `0.2.2`.
+- `agentblazor analyze` exists and is published in `AgentBlazor.Cli` `0.2.4`.
 - `src/AgentBlazor.Cli` and `src/AgentBlazor.Cli.Analysis` target `net10.0`.
 - The command is read-mostly: it writes the configured markdown report and does not update `.agentblazor/.state`.
 - Provider/model configuration is environment-driven for repeatable and non-interactive v1 use, but interactive OpenAI runs prompt for a missing API key and use it for that run only. `OPENAI_API_KEY` or `OpenAI__ApiKey` is required for non-interactive LLM suggestions, unless `--static-only` is used. `AGENTBLAZOR_ANALYZE_MODEL`, `OPENAI_MODEL`, or `OpenAI__Model` can override the model.
+- Windows/Roslyn solution-loading failures are handled by a static source-file fallback. The hidden `AGENTBLAZOR_STATIC_WORKSPACE=1` switch can force that path for diagnostics.
+- Current report quality pass hides helper/object-method noise such as `ActivityIdHelper.ToString()`, reports "AgentBlazor action adoption" instead of the old ambiguous action coverage ratio, and adds explicit `RequiresApproval = true` guidance when LLM suggestions reference mutating methods.
 - The synthetic `tests/cli-targets/*` reference applications exist and are covered by automated tests.
 - Final validation evidence is recorded in `docs/internal/cli-v1-real-app-validation-2026-05-27.md`.
+- Additional real-app smoke testing on `dotnet-architecture/eShopOnBlazor` verifies 5 routes, 1 developer-facing service after filtering, 7 discovered candidate actions, and validated LLM suggestions without hallucinated method references.
 
 ## Vision
 

--- a/src/AgentBlazor.Cli.Analysis/AnalysisModelFilters.cs
+++ b/src/AgentBlazor.Cli.Analysis/AnalysisModelFilters.cs
@@ -19,6 +19,8 @@ public static class AnalysisModelFilters
         "DbContext",
         "DbContextFactory",
         "Factory",
+        "Helper",
+        "Utility",
         "Provider",
         "Notifier",
         "SignInManager",
@@ -80,11 +82,15 @@ public static class AnalysisModelFilters
     [
         "Dispose",
         "DisposeAsync",
+        "Equals",
+        "GetHashCode",
+        "GetType",
         "Load",
         "LoadAsync",
         "OnPropertyChanged",
         "Reset",
         "ResetAsync",
+        "ToString",
         "IsHighlighted",
         "DescribeSignals"
     ];

--- a/src/AgentBlazor.Cli.Analysis/Generation/AnalysisReportGenerator.cs
+++ b/src/AgentBlazor.Cli.Analysis/Generation/AnalysisReportGenerator.cs
@@ -77,9 +77,10 @@ public sealed class AnalysisReportGenerator
             sb.AppendLine($"- Host shape: {readiness.HostShape.Title}");
         }
 
-        if (model.Coverage is not null)
+        var adoptionTotal = confirmedCount + discoveredCount;
+        if (adoptionTotal > 0)
         {
-            sb.AppendLine($"- Action coverage: {model.Coverage.ConfirmedActions}/{model.Coverage.TotalActions} confirmed ({model.Coverage.ActionCoveragePercent.ToString(CultureInfo.InvariantCulture)}%)");
+            sb.AppendLine($"- AgentBlazor action adoption: {confirmedCount} confirmed, {discoveredCount} candidate actions not yet exposed");
         }
 
         sb.AppendLine();
@@ -217,6 +218,13 @@ public sealed class AnalysisReportGenerator
                     if (!string.IsNullOrWhiteSpace(suggestion.CapabilityClass))
                     {
                         sb.AppendLine($"- Suggested capability class: `{suggestion.CapabilityClass}`");
+                    }
+
+                    var referencesMutationLikelyMethod = ReferencesMutationLikelyMethod(suggestion, model);
+                    if (referencesMutationLikelyMethod)
+                    {
+                        sb.AppendLine("- Approval guidance: this workflow references mutating methods. Mark generated `[AgentAction]` methods with `RequiresApproval = true` unless a human-reviewed policy says the action is safe to run automatically.");
+                        sb.AppendLine($"- Suggested attribute: `[AgentAction(\"{EscapeAttributeValue(suggestion.Name)}\", RequiresApproval = true)]`");
                     }
 
                     if (suggestion.Methods.Count > 0)
@@ -383,6 +391,10 @@ public sealed class AnalysisReportGenerator
     private static string EscapeTableCell(string value)
         => value.Replace("|", "\\|", StringComparison.Ordinal);
 
+    private static string EscapeAttributeValue(string value)
+        => value.Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("\"", "\\\"", StringComparison.Ordinal);
+
     private static bool DuplicatesConfirmedAction(RecommendationModel recommendation, ProjectModel model)
     {
         if (recommendation.Type is not RecommendationType.AddAgentAction)
@@ -427,6 +439,18 @@ public sealed class AnalysisReportGenerator
             .Any(action =>
                 NormalizeName(action.MethodName) == normalizedMethod ||
                 (!string.IsNullOrWhiteSpace(action.Name) && NormalizeName(action.Name) == normalizedName));
+    }
+
+    private static bool ReferencesMutationLikelyMethod(WorkflowSuggestion suggestion, ProjectModel model)
+    {
+        return suggestion.Methods.Any(method => model.Actions
+            .Where(AnalysisModelFilters.IsDeveloperFacingAction)
+            .Any(action =>
+                string.Equals(action.SourceService, method.Service, StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(action.MethodName, method.Method, StringComparison.OrdinalIgnoreCase) &&
+                (action.IsMutationLikely ||
+                 action.RequiresApproval ||
+                 action.Classification is ActionClassification.Command or ActionClassification.Workflow)));
     }
 
     private static string NormalizeName(string value)

--- a/src/AgentBlazor.Cli.Analysis/WorkflowSuggestions/WorkflowSuggestionPromptBuilder.cs
+++ b/src/AgentBlazor.Cli.Analysis/WorkflowSuggestions/WorkflowSuggestionPromptBuilder.cs
@@ -23,6 +23,7 @@ public sealed class WorkflowSuggestionPromptBuilder
         sb.AppendLine("- Suggested C# code is illustrative only and must be short.");
         sb.AppendLine("- Suggested C# code must use AgentBlazor CapabilityResult and only call listed methods.");
         sb.AppendLine("- Do not invent DTO or entity types in code. If a type is unclear, use comments rather than fake types.");
+        sb.AppendLine("- If a listed method has approvalRecommended=true, the suggested [AgentAction] example must include RequiresApproval = true.");
         sb.AppendLine();
         sb.AppendLine("JSON shape:");
         sb.AppendLine("""
@@ -98,11 +99,13 @@ public sealed class WorkflowSuggestionPromptBuilder
     private static void AppendServices(StringBuilder sb, ProjectModel model)
     {
         sb.AppendLine("Discovered services and public methods:");
-        var candidateMethods = model.Actions
+        var candidateActions = model.Actions
             .Where(action => action.ExposureMode is ActionExposureMode.Suggested or ActionExposureMode.Confirmed)
             .Where(AnalysisModelFilters.IsDeveloperFacingAction)
-            .Select(action => (action.SourceService, action.MethodName))
-            .ToHashSet();
+            .ToDictionary(
+                action => (action.SourceService, action.MethodName),
+                action => action,
+                new MethodKeyComparer());
 
         foreach (var service in model.Services
             .Where(service => AnalysisModelFilters.IsDeveloperFacingService(service, model))
@@ -112,10 +115,17 @@ public sealed class WorkflowSuggestionPromptBuilder
             var methods = service.Methods
                 .Where(method => method.IsPublic)
                 .Where(method => AnalysisModelFilters.IsDeveloperFacingMethod(method.Name))
-                .Where(method => candidateMethods.Contains((service.TypeName, method.Name)))
+                .Where(method => candidateActions.ContainsKey((service.TypeName, method.Name)))
                 .OrderBy(method => method.Name)
                 .Take(20)
-                .Select(method => $"{method.Name}({string.Join(", ", method.Parameters.Select(parameter => $"{parameter.TypeName} {parameter.Name}"))})")
+                .Select(method =>
+                {
+                    var action = candidateActions[(service.TypeName, method.Name)];
+                    var approvalRecommended = action.IsMutationLikely ||
+                        action.RequiresApproval ||
+                        action.Classification is ActionClassification.Command or ActionClassification.Workflow;
+                    return $"{method.Name}({string.Join(", ", method.Parameters.Select(parameter => $"{parameter.TypeName} {parameter.Name}"))}) [mutation={approvalRecommended.ToString().ToLowerInvariant()}, approvalRecommended={approvalRecommended.ToString().ToLowerInvariant()}]";
+                })
                 .ToList();
 
             if (methods.Count == 0)
@@ -129,5 +139,17 @@ public sealed class WorkflowSuggestionPromptBuilder
                 sb.AppendLine($"  - {method}");
             }
         }
+    }
+
+    private sealed class MethodKeyComparer : IEqualityComparer<(string SourceService, string MethodName)>
+    {
+        public bool Equals((string SourceService, string MethodName) x, (string SourceService, string MethodName) y)
+            => string.Equals(x.SourceService, y.SourceService, StringComparison.OrdinalIgnoreCase) &&
+               string.Equals(x.MethodName, y.MethodName, StringComparison.OrdinalIgnoreCase);
+
+        public int GetHashCode((string SourceService, string MethodName) obj)
+            => HashCode.Combine(
+                StringComparer.OrdinalIgnoreCase.GetHashCode(obj.SourceService),
+                StringComparer.OrdinalIgnoreCase.GetHashCode(obj.MethodName));
     }
 }

--- a/src/AgentBlazor.Cli/PACKAGE_README.md
+++ b/src/AgentBlazor.Cli/PACKAGE_README.md
@@ -32,6 +32,10 @@ agentblazor analyze ./MySolution.slnx --host MyBlazorApp
 
 If no OpenAI key is configured and the terminal is interactive, `analyze` prompts for a key and uses it for that run only. The key is not written to disk.
 
+Version `0.2.4` and later include a Windows/Roslyn fallback for MSBuildWorkspace load failures. If a machine has conflicting Visual Studio/MSBuild assemblies, `analyze` falls back to static source-file analysis instead of failing before the report is generated.
+
+Reports filter helper/framework noise, show AgentBlazor action adoption, and call out `RequiresApproval = true` guidance for workflow suggestions that reference mutating methods.
+
 The CLI is an advanced path. The default install story is still `dotnet add package AgentBlazor` plus manual runtime wiring.
 
 Docs:

--- a/src/AgentBlazor.Cli/README.md
+++ b/src/AgentBlazor.Cli/README.md
@@ -10,6 +10,8 @@ agentblazor analyze ./MySolution.slnx --host MyBlazorApp
 
 If no OpenAI key is configured and the terminal is interactive, `analyze` prompts for one and uses it for that run only. For repeat runs or CI, set `OPENAI_API_KEY` and optionally `AGENTBLAZOR_ANALYZE_MODEL`. Pass `--static-only` to skip the LLM call.
 
+Version `0.2.4` and later include a static source-file fallback for Windows/Roslyn MSBuildWorkspace load failures. Current reports filter helper noise, show AgentBlazor action adoption, and include approval guidance for mutating workflow suggestions.
+
 See:
 
 - `docs/advanced/cli.md`

--- a/tests/AgentBlazor.Cli.Analysis.Tests/AssemblyInfo.cs
+++ b/tests/AgentBlazor.Cli.Analysis.Tests/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/tests/AgentBlazor.Cli.Analysis.Tests/Generation/AnalysisReportGeneratorTests.cs
+++ b/tests/AgentBlazor.Cli.Analysis.Tests/Generation/AnalysisReportGeneratorTests.cs
@@ -68,7 +68,24 @@ public sealed class AnalysisReportGeneratorTests : IDisposable
     [Fact]
     public void GenerateMarkdown_IncludesValidatedWorkflowSuggestions_WhenProvided()
     {
-        var model = CreateModel();
+        var model = CreateModel() with
+        {
+            Actions =
+            [
+                .. CreateModel().Actions,
+                new ActionModel
+                {
+                    Name = "Draft order follow-up",
+                    SourceService = "OrderService",
+                    MethodName = "DraftFollowUpAsync",
+                    FilePath = "Services/OrderService.cs",
+                    ExposureMode = ActionExposureMode.Suggested,
+                    Classification = ActionClassification.Command,
+                    IsMutationLikely = true,
+                    Score = 0.88
+                }
+            ]
+        };
         var suggestions = new WorkflowSuggestionSet
         {
             Model = "test-model",
@@ -81,7 +98,8 @@ public sealed class AnalysisReportGeneratorTests : IDisposable
                     CapabilityClass = "OrderFollowUpCapabilities",
                     Methods =
                     [
-                        new WorkflowMethodReference { Service = "OrderService", Method = "FindOrdersAsync" }
+                        new WorkflowMethodReference { Service = "OrderService", Method = "FindOrdersAsync" },
+                        new WorkflowMethodReference { Service = "OrderService", Method = "DraftFollowUpAsync" }
                     ],
                     Reasoning = "The app has an orders page and an order lookup service.",
                     Confidence = 0.84
@@ -101,6 +119,7 @@ public sealed class AnalysisReportGeneratorTests : IDisposable
 
         Assert.Contains("Order follow-up", content);
         Assert.Contains("OrderService.FindOrdersAsync", content);
+        Assert.Contains("RequiresApproval = true", content);
         Assert.Contains("Rejected Suggestions", content);
         Assert.Contains("MissingService.RunAsync", content);
     }
@@ -113,6 +132,20 @@ public sealed class AnalysisReportGeneratorTests : IDisposable
             Services =
             [
                 .. CreateModel().Services,
+                new ServiceModel
+                {
+                    TypeName = "ActivityIdHelper",
+                    FilePath = "ActivityIdHelper.cs",
+                    Methods =
+                    [
+                        new ServiceMethodModel
+                        {
+                            Name = "ToString",
+                            ReturnType = "string",
+                            IsPublic = true
+                        }
+                    ]
+                },
                 new ServiceModel
                 {
                     TypeName = "AgentBlazorBuilder",
@@ -239,6 +272,8 @@ public sealed class AnalysisReportGeneratorTests : IDisposable
 
         var content = _generator.GenerateMarkdown(model);
 
+        Assert.DoesNotContain("ActivityIdHelper", content);
+        Assert.DoesNotContain("ToString", content);
         Assert.DoesNotContain("AgentBlazorBuilder", content);
         Assert.DoesNotContain("SetSelectedNodeAsync", content);
         Assert.DoesNotContain("DialogServiceHelper", content);
@@ -248,6 +283,15 @@ public sealed class AnalysisReportGeneratorTests : IDisposable
         Assert.DoesNotContain("EmailFactory", content);
         Assert.Contains("OrderService", content);
         Assert.Contains("FindOrdersAsync", content);
+    }
+
+    [Fact]
+    public void GenerateMarkdown_ReportsActionAdoption_FromDeveloperFacingActions()
+    {
+        var content = _generator.GenerateMarkdown(CreateModel());
+
+        Assert.Contains("AgentBlazor action adoption: 0 confirmed, 1 candidate actions not yet exposed", content);
+        Assert.DoesNotContain("Action coverage:", content);
     }
 
     [Fact]

--- a/tests/AgentBlazor.Cli.Analysis.Tests/WorkflowSuggestions/WorkflowSuggestionPromptBuilderTests.cs
+++ b/tests/AgentBlazor.Cli.Analysis.Tests/WorkflowSuggestions/WorkflowSuggestionPromptBuilderTests.cs
@@ -27,6 +27,27 @@ public sealed class WorkflowSuggestionPromptBuilderTests
                             ReturnType = "Task<IReadOnlyList<Order>>",
                             IsPublic = true,
                             IsAsync = true
+                        },
+                        new ServiceMethodModel
+                        {
+                            Name = "CreateOrderAsync",
+                            ReturnType = "Task",
+                            IsPublic = true,
+                            IsAsync = true
+                        }
+                    ]
+                },
+                new ServiceModel
+                {
+                    TypeName = "ActivityIdHelper",
+                    FilePath = "ActivityIdHelper.cs",
+                    Methods =
+                    [
+                        new ServiceMethodModel
+                        {
+                            Name = "ToString",
+                            ReturnType = "string",
+                            IsPublic = true
                         }
                     ]
                 },
@@ -109,6 +130,17 @@ public sealed class WorkflowSuggestionPromptBuilderTests
             [
                 new ActionModel
                 {
+                    Name = "Create Order",
+                    SourceService = "OrderService",
+                    MethodName = "CreateOrderAsync",
+                    FilePath = "Services/OrderService.cs",
+                    ExposureMode = ActionExposureMode.Suggested,
+                    Classification = ActionClassification.Command,
+                    IsMutationLikely = true,
+                    Score = 0.9
+                },
+                new ActionModel
+                {
                     Name = "Find Orders",
                     SourceService = "OrderService",
                     MethodName = "FindOrdersAsync",
@@ -133,6 +165,12 @@ public sealed class WorkflowSuggestionPromptBuilderTests
 
         Assert.Contains("OrderService", prompt);
         Assert.Contains("FindOrdersAsync", prompt);
+        Assert.Contains("approvalRecommended=false", prompt);
+        Assert.Contains("CreateOrderAsync", prompt);
+        Assert.Contains("approvalRecommended=true", prompt);
+        Assert.Contains("RequiresApproval = true", prompt);
+        Assert.DoesNotContain("ActivityIdHelper", prompt);
+        Assert.DoesNotContain("ToString", prompt);
         Assert.DoesNotContain("AgentBlazorBuilder", prompt);
         Assert.DoesNotContain("SetSelectedNodeAsync", prompt);
         Assert.DoesNotContain("DialogServiceHelper", prompt);


### PR DESCRIPTION
## Summary\n- Filter helper/object-method noise from CLI analysis report and prompt sections\n- Replace ambiguous action coverage wording with AgentBlazor action adoption\n- Add explicit RequiresApproval guidance for mutating workflow suggestions\n- Document current CLI v1 status, Windows fallback, and report-quality behavior\n\n## Verification\n- dotnet test tests/AgentBlazor.Cli.Analysis.Tests/AgentBlazor.Cli.Analysis.Tests.csproj\n- eShop smoke: 5 routes, 1 developer-facing service, 7 discovered actions, mutating LLM suggestions include approval guidance