### PR TITLE
Mark CLI analyze v1 ready for 0.2.5

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
 
   <!-- Common package metadata for all AgentBlazor packages -->
   <PropertyGroup>
-    <Version>0.2.4</Version>
+    <Version>0.2.5</Version>
     <Authors>Ash Peterson</Authors>
     <Company>AgentBlazor</Company>
     <Copyright>Copyright (c) 2026 Ash Peterson</Copyright>
@@ -16,7 +16,7 @@
     <RepositoryType>git</RepositoryType>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <PackageIcon>icon.png</PackageIcon>
-    <PackageReleaseNotes>v0.2.4: CLI analyze now falls back to static source-file analysis when Roslyn MSBuildWorkspace fails, including the Windows XMakeElements failure seen with conflicting Visual Studio/MSBuild installations. Includes the v0.2.3 first-run API-key prompt, CLI v1 analyze refresh, structured errors, EF schema exposure, hosted demo observability, and mobile chat input stability fixes.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.2.5: CLI v1 analyze finalization. Filters helper/object-method noise from reports, replaces ambiguous action coverage with AgentBlazor action adoption, adds explicit RequiresApproval guidance for mutating workflow suggestions, and includes the v0.2.4 Windows MSBuildWorkspace static fallback.</PackageReleaseNotes>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <Deterministic>true</Deterministic>

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Try the hosted demo:
 dotnet add package AgentBlazor
 ```
 
-Use `0.2.4` or later. This release includes the CLI Windows MSBuild fallback and first-run API-key prompt, CLI v1 analyze package refresh, mobile chat input stability fix, corrected EF package shape, and tool-friendly schemas for `DateOnly`, `TimeOnly`, `DateTime`, `DateTimeOffset`, and `Guid` workflow parameters.
+Use `0.2.5` or later. This release includes the CLI Windows MSBuild fallback and first-run API-key prompt, CLI v1 analyze package refresh, mobile chat input stability fix, corrected EF package shape, and tool-friendly schemas for `DateOnly`, `TimeOnly`, `DateTime`, `DateTimeOffset`, and `Guid` workflow parameters.
 
 The CLI is optional. Keep it out of the critical path unless you want scaffold help for an existing app.
 
@@ -105,7 +105,7 @@ dotnet run --project samples/AgentBlazor.Starter/AgentBlazor.Starter.csproj
 ## Docs
 
 - [Quickstart](docs/quickstart.md)
-- [0.2.4 release notes](docs/releases/0.2.4.md)
+- [0.2.5 release notes](docs/releases/0.2.5.md)
 - [0.2.3 release notes](docs/releases/0.2.3.md)
 - [0.2.2 release notes](docs/releases/0.2.2.md)
 - [0.2.1 release notes](docs/releases/0.2.1.md)

--- a/docs/entity-framework.md
+++ b/docs/entity-framework.md
@@ -17,7 +17,7 @@ dotnet add package AgentBlazor
 dotnet add package AgentBlazor.EntityFrameworkCore
 ```
 
-Use `0.2.4` or later. This release includes the CLI Windows MSBuild fallback and first-run API-key prompt, CLI v1 analyze package refresh, mobile chat input stability fix, corrected EF package shape, and tool-friendly schemas for date-like workflow parameters.
+Use `0.2.5` or later. This release includes the CLI Windows MSBuild fallback and first-run API-key prompt, CLI v1 analyze package refresh, mobile chat input stability fix, corrected EF package shape, and tool-friendly schemas for date-like workflow parameters.
 
 ## DbContext Setup
 

--- a/docs/internal/cli-v1-real-app-validation-2026-05-27.md
+++ b/docs/internal/cli-v1-real-app-validation-2026-05-27.md
@@ -2,6 +2,8 @@
 
 Purpose: evidence for the CLI v1 scope gate requiring real Blazor applications to produce useful `agentblazor analyze` reports without hallucinated method references.
 
+Status: v1 validation complete. `agentblazor analyze` shipped as the CLI v1 line in `AgentBlazor.Cli` `0.2.5` on May 29 2026.
+
 Environment:
 
 - Source-validation branch: `feature/cli-v1-analyze-spine`
@@ -11,7 +13,8 @@ Environment:
 - LLM provider: real OpenAI API key from environment
 - Model: environment default, currently `gpt-4o-mini` when unset
 - Temporary clone root: `/tmp/agentblazor-cli-v1-realapps`
-- Packaged tool: locally packed `AgentBlazor.Cli.0.2.2.nupkg`, installed via `dotnet tool install AgentBlazor.Cli --tool-path /tmp/agentblazor-cli-v1-tool-smoke/tool --configfile /tmp/agentblazor-cli-v1-tool-smoke/NuGet.config --version 0.2.2`
+- Initial packaged tool: locally packed `AgentBlazor.Cli.0.2.2.nupkg`, installed via `dotnet tool install AgentBlazor.Cli --tool-path /tmp/agentblazor-cli-v1-tool-smoke/tool --configfile /tmp/agentblazor-cli-v1-tool-smoke/NuGet.config --version 0.2.2`
+- Final shipped packaged tool: NuGet.org `AgentBlazor.Cli` `0.2.5`
 - Initial packaged tool output root: `/tmp/agentblazor-cli-v1-tool-smoke`
 - Expanded real-app clone root: `/tmp/agentblazor-cli-v1-more-realapps`
 - Final packaged tool output root after RCL route and semantic-validation fixes: `/tmp/agentblazor-cli-v1-tool-smoke-final2`
@@ -19,9 +22,11 @@ Environment:
 
 ## Packaged Tool Quality Gates
 
-- Install gate: local `AgentBlazor.Cli.0.2.2.nupkg` installs as a `dotnet tool` into an isolated tool path and reports `0.2.2` from `agentblazor --version`.
+- Install gate: NuGet.org `AgentBlazor.Cli` `0.2.5` installs as a `dotnet tool` into an isolated tool path and reports `0.2.5` from `agentblazor --version`.
 - No-provider non-interactive gate: with OpenAI and Azure OpenAI environment variables removed, `agentblazor analyze --non-interactive` exits cleanly with `No OpenAI API key configured for agentblazor analyze. Set OPENAI_API_KEY or OpenAI__ApiKey, and optionally set AGENTBLAZOR_ANALYZE_MODEL.`
 - Static-only gate: `agentblazor analyze ... --static-only` writes a report with routes, capabilities, services, static workflow candidates, install readiness, and recommended next steps without requiring an LLM provider.
+- Windows fallback gate: `AgentBlazor.Cli` `0.2.5` falls back to static source-file analysis when Roslyn `MSBuildWorkspace` fails with known MSBuild/Visual Studio assembly conflicts such as `Microsoft.Build.Shared.XMakeElements`.
+- Report-quality gate: helper/object-method noise is filtered from developer-facing sections, the summary uses AgentBlazor action adoption, and mutating workflow suggestions include explicit `RequiresApproval = true` guidance.
 
 ## Applications Tested
 
@@ -150,21 +155,44 @@ Environment:
 
 ## Current Evidence
 
-- Automated analysis tests pass: `161`
+- Automated analysis tests pass: `163`
 - CLI build passes: `dotnet build src/AgentBlazor.Cli/AgentBlazor.Cli.csproj`
-- Local packaged tool install passes from `AgentBlazor.Cli.0.2.2.nupkg`.
-- NuGet.org published package is available from `https://api.nuget.org/v3-flatcontainer/agentblazor.cli/0.2.2/agentblazor.cli.0.2.2.nupkg`.
-- NuGet.org package install passes into an isolated tool path using a NuGet-only config, and `agentblazor --version` reports `0.2.2`.
+- NuGet.org published package is available from `https://api.nuget.org/v3-flatcontainer/agentblazor.cli/0.2.5/agentblazor.cli.0.2.5.nupkg`.
+- NuGet.org package install passes into an isolated tool path using a NuGet-only config, and `agentblazor --version` reports `0.2.5`.
 - Packaged no-provider and `--static-only` paths pass.
 - Real OpenAI-backed analysis completed on 11 real GitHub Blazor applications.
 - Packaged `dotnet tool` smoke completed on 11 real GitHub Blazor applications.
 - Final NuGet-installed `dotnet tool` smoke completed on 5 real GitHub Blazor applications with the real OpenAI provider.
+- Final `0.2.5` eShopOnBlazor smoke completed with 5 routes, 1 developer-facing service after helper filtering, 7 discovered candidate actions, and mutating LLM suggestions that include approval guidance.
 - Hallucinated methods were rejected on sparse apps.
 - Accepted workflow suggestions on larger apps reference methods present in the static model.
 - Referenced RCL routes are discovered for hosted/componentized apps.
 - Semantically misaligned LLM suggestions are rejected even when they reference real methods.
 
+## Final 0.2.5 Smoke
+
+Environment:
+
+- Tool version: `0.2.5`
+- Command shape: `agentblazor analyze <solution> --host <host> --output <report>`
+- Fallback diagnostic shape: `AGENTBLAZOR_STATIC_WORKSPACE=1 agentblazor analyze <solution> --host <host> --output <report>`
+- LLM provider: real OpenAI API key from environment
+
+Results:
+
+| App | Host | Routes | Services | Actions | Suggestions | Outcome |
+| --- | --- | ---: | ---: | ---: | --- | --- |
+| dotnet-architecture/eShopOnBlazor | `eShopOnBlazor` | 5 | 1 | 7 discovered | 3 accepted, 0 rejected | Pass; helper noise filtered, candidate methods grounded in `CatalogService`, mutating suggestions include approval guidance. |
+
+Additional command-path gates:
+
+- Clean NuGet install from `https://api.nuget.org/v3/index.json` reports `agentblazor --version` as `0.2.5`.
+- Forced static workspace fallback on eShopOnBlazor reports 5 routes, 1 developer-facing service, and 7 discovered candidate actions.
+- Full LLM run on eShopOnBlazor reports validated workflow suggestions without hallucinated method references.
+
 ## Final NuGet-Installed Smoke
+
+This section records the earlier `0.2.2` validation matrix. It remains useful as breadth evidence, but the shipped v1 package line is `0.2.5`.
 
 Environment:
 

--- a/docs/internal/cli-v1-scope-2026-05-24.md
+++ b/docs/internal/cli-v1-scope-2026-05-24.md
@@ -1,15 +1,15 @@
 # AgentBlazor CLI v1 Scope
 
-Status: Active development scope.
-Target ship: 3-5 weeks from May 24 2026.
+Status: Shipped as the `agentblazor analyze` v1 line in `AgentBlazor.Cli` `0.2.5`.
+Target ship: achieved on May 29 2026.
 
 Document purpose: single source of truth for what AgentBlazor CLI v1 contains, what it does not contain, and how it gets there. Updates as work progresses. Decisions captured here are locked unless explicitly revised in this document.
 
 ## Implementation Notes From Current Repo
 
-This scope has been reviewed against the current codebase after the v1 implementation work.
+This scope has been reviewed against the current codebase after the v1 implementation work. The v1 deliverable is considered shipped; future changes belong in a new scope document unless they are bug fixes to `agentblazor analyze`.
 
-- `agentblazor analyze` exists and is published in `AgentBlazor.Cli` `0.2.4`.
+- `agentblazor analyze` exists and is published in `AgentBlazor.Cli` `0.2.5`.
 - `src/AgentBlazor.Cli` and `src/AgentBlazor.Cli.Analysis` target `net10.0`.
 - The command is read-mostly: it writes the configured markdown report and does not update `.agentblazor/.state`.
 - Provider/model configuration is environment-driven for repeatable and non-interactive v1 use, but interactive OpenAI runs prompt for a missing API key and use it for that run only. `OPENAI_API_KEY` or `OpenAI__ApiKey` is required for non-interactive LLM suggestions, unless `--static-only` is used. `AGENTBLAZOR_ANALYZE_MODEL`, `OPENAI_MODEL`, or `OpenAI__Model` can override the model.
@@ -18,6 +18,7 @@ This scope has been reviewed against the current codebase after the v1 implement
 - The synthetic `tests/cli-targets/*` reference applications exist and are covered by automated tests.
 - Final validation evidence is recorded in `docs/internal/cli-v1-real-app-validation-2026-05-27.md`.
 - Additional real-app smoke testing on `dotnet-architecture/eShopOnBlazor` verifies 5 routes, 1 developer-facing service after filtering, 7 discovered candidate actions, and validated LLM suggestions without hallucinated method references.
+- Current final gate: `dotnet test tests/AgentBlazor.Cli.Analysis.Tests/AgentBlazor.Cli.Analysis.Tests.csproj` passes with 163 tests. PR checks for the final report-quality pass passed before merge.
 
 ## Vision
 
@@ -146,52 +147,49 @@ This is not a public extension contract in v1. There is no documented "how to wr
 
 Decision: auto-detect by default, with explicit `--framework` override.
 
-The CLI examines the project on startup to determine which framework adapter applies. Detection is delegated to a registered set of detectors. Each adapter contributes a detector. The first detector that returns a positive match wins. If no detector matches, the command exits with a clear error directing the user to use `--framework` if they believe a specific adapter should apply.
+The CLI examines the project on startup to determine which framework adapter applies. In shipped v1 this is handled by `ProjectAnalyzerRegistry` and `BlazorProjectAnalyzer.CanAnalyze`. If no adapter matches, the command exits with a clear error directing the user to pass a `.sln`, `.slnx`, `.csproj`, or Blazor project directory.
 
-For v1 the Blazor detector checks for `.csproj` files with Blazor SDK references or Razor components. It is the only registered detector.
+For v1 the Blazor analyzer accepts `.sln`, `.slnx`, `.csproj`, project directories, and directories containing Razor components. It is the only registered analyzer.
 
 ### Project Model Shape
 
 Decision: generic project model with framework-specific context type parameter.
 
-The core project model is `ProjectModel<TFrameworkContext>`. Neutral fields such as routes, services, components, capabilities, actions, and readiness state live on the generic base. Framework-specific data lives on `TFrameworkContext`.
+The shipped v1 shape is `ProjectAnalysis<TFrameworkContext>` containing a neutral `ProjectModel`, a framework-specific context, and optional readiness output. Neutral fields such as routes, services, components, capabilities, actions, and readiness-derived report data live on `ProjectModel`. Framework-specific data lives on `TFrameworkContext`.
 
-For v1, `BlazorFrameworkContext` carries Blazor-specific data: host shape, Razor component metadata, MudBlazor wiring state, and AgentBlazor package wiring state. The existing `ModelBuilder` is refactored to produce `ProjectModel<BlazorFrameworkContext>` rather than the current Blazor-shaped model.
+For v1, `BlazorFrameworkContext` carries Blazor-specific readiness data: host project, optional UI project, host shape, AgentBlazor services state, workflow registration state, endpoint mapping state, and chat surface state. `ModelBuilder` remains the neutral model construction path and is wrapped by `BlazorProjectAnalyzer`.
 
-Trade-off: the LLM analysis layer is generic over `TFrameworkContext`. Test fixtures are typed per framework. The benefit is type safety; the cost is more verbose analysis-layer code.
+Trade-off: this is less type-heavy than the original generic-project-model design, but it is enough for the single Blazor adapter in v1 and keeps the future adapter seam at `ProjectAnalysis<TFrameworkContext>`.
 
 ### Adapter Contract
 
-Each framework adapter implements `IProjectAnalyzer<TFrameworkContext>` or a similarly named interface. The interface defines:
+Each framework adapter implements `IProjectAnalyzer<TFrameworkContext>`. The interface defines:
 
 - Detection: can this adapter handle the given project path?
-- Model construction: given a project path, produce a `ProjectModel<TFrameworkContext>` with neutral and framework-specific data populated.
-- Prompt template: the LLM prompt template used to analyse projects of this framework.
-- Response validation: verify LLM-suggested workflows reference real methods and types in the constructed model.
+- Model construction: build the neutral `ProjectModel` and framework-specific context.
+- Response validation: handled by the shared workflow suggestion parser against the constructed neutral model.
 
 The Blazor adapter is implemented as `BlazorProjectAnalyzer : IProjectAnalyzer<BlazorFrameworkContext>` and lives under `src/AgentBlazor.Cli.Analysis/Blazor/`.
 
 ### Prompt Construction
 
-Decision: each adapter owns its prompt template.
+Decision for shipped v1: the prompt builder is shared and Blazor-tuned.
 
-The adapter contributes the full prompt template used to generate workflow suggestions. The core supplies the project model summary as input but does not construct the framework-specific prompt itself.
+`WorkflowSuggestionPromptBuilder` constructs the prompt from the static model. Because v1 has only one adapter, a separate adapter-owned prompt template would add structure without current value. If a second framework adapter is built, prompt ownership should be revisited with the second adapter's real needs in hand.
 
-Trade-off: each future framework requires its own prompt-engineering investment. There is no shared prompt asset that all frameworks reuse. The benefit is that framework-aware prompts can be more directive and produce better suggestions.
-
-For v1, the Blazor adapter prompt template lives at `src/AgentBlazor.Cli.Analysis/Blazor/prompts/workflow-suggestions.md`, or a similar location settled during implementation.
+Trade-off: v1 is pragmatic and simpler. The future adapter contract is intentionally not public, so this can change without breaking external extensions.
 
 ### Core Responsibilities
 
 The core orchestrates without knowing about specific frameworks:
 
-- Loads the configured LLM provider.
-- Calls the detected adapter's detection method.
-- Calls the detected adapter's model construction method.
-- Loads the adapter's prompt template.
-- Sends the prompt to the LLM with the model summary as context.
-- Calls the adapter's response validation.
-- Renders validated suggestions into the report alongside neutral sections.
+- Loads the configured LLM provider, or prompts for a one-run OpenAI key in an interactive terminal.
+- Resolves the Blazor adapter through `ProjectAnalyzerRegistry`.
+- Calls the adapter's model construction method.
+- Builds a compact prompt from the static model.
+- Sends the prompt to the configured model.
+- Validates LLM suggestions against discovered candidate/confirmed actions.
+- Renders validated suggestions, rejected suggestions, readiness, and recommended next steps into the report.
 
 ### Future React Adapter Shape
 
@@ -220,7 +218,7 @@ These constraints exist because v1 is shipping with one adapter. Designing publi
 
 ### Test Project Structure
 
-Three reference Blazor applications are maintained in the repo for testing. These do not currently exist and are part of v1 implementation.
+Three reference Blazor applications are maintained in the repo for testing.
 
 - `tests/cli-targets/simple-blazor-app/`: minimal standard Blazor Web App with two or three services.
 - `tests/cli-targets/realistic-blazor-app/`: closer to a real app; eight to twelve services, multiple routes, EF Core, and some existing workflow infrastructure.
@@ -228,24 +226,24 @@ Three reference Blazor applications are maintained in the repo for testing. Thes
 
 ### Automated Tests
 
-- Static analysis tests: verify each test project is classified correctly.
-- LLM response shape tests: with a mocked or recorded LLM response, verify the parser handles malformed responses, missing fields, and hallucinated method names.
-- Report generation tests: given known static and LLM inputs, verify the output markdown matches a snapshot.
-- Adapter contract tests: verify the Blazor adapter implements `IProjectAnalyzer<BlazorFrameworkContext>` correctly.
+- Static analysis tests verify each test project is classified correctly.
+- LLM response shape tests verify the parser handles malformed responses, missing fields, hallucinated method names, already-confirmed actions, and semantically misaligned method references.
+- Report generation tests verify the markdown contains the expected sections, filters helper/framework noise, avoids duplicate capability/service output, shows action adoption, and adds approval guidance for mutating suggestions.
+- Adapter contract tests verify the Blazor adapter implements `IProjectAnalyzer<BlazorFrameworkContext>` correctly.
 
 ### Manual Verification
 
-- Run `agentblazor analyze` against each synthetic test project and verify suggestions look sensible.
-- Run against two real Blazor projects to catch issues synthetic projects miss.
+- `agentblazor analyze` has been run against each synthetic test project.
+- `agentblazor analyze` has been run against more than two real Blazor projects. Final evidence is recorded in `docs/internal/cli-v1-real-app-validation-2026-05-27.md`.
 
 This is the load-bearing test. Synthetic projects validate the mechanism. Real projects validate the suggestions.
 
 ## Existing Infrastructure Reused
 
-| Responsibility | Existing implementation |
+| Responsibility | Shipped implementation |
 | --- | --- |
-| Solution and project loading | `ModelBuilder.BuildModelAsync`, refactored into the Blazor adapter |
-| Route, page, component scanning | `RazorAnalyzer`, moved under or wrapped by the Blazor adapter |
+| Solution and project loading | `ModelBuilder.BuildModelAsync`, wrapped by the Blazor adapter, with `MSBuildWorkspace` plus static source-file fallback |
+| Route, page, component scanning | `RazorAnalyzer`, used by `ModelBuilder` and the Blazor adapter path |
 | Capability and action discovery | `AttributeAnalyzer` |
 | Service discovery | `ServiceAnalyzer` and `DiRegistrationAnalyzer` |
 | Candidate action scoring | `ActionScorer`; review during refactor for neutral versus adapter-specific scope |
@@ -255,18 +253,18 @@ This is the load-bearing test. Synthetic projects validate the mechanism. Real p
 
 ## New Work For v1
 
-- `AnalyzeCommand`: CLI command registration and orchestration.
-- `IProjectAnalyzer<TFrameworkContext>`: adapter contract.
-- `BlazorFrameworkContext`: Blazor-specific data structure.
-- `BlazorProjectAnalyzer`: implementation of `IProjectAnalyzer<BlazorFrameworkContext>` wrapping existing infrastructure.
-- `BlazorProjectDetector`: framework auto-detection logic.
-- LLM analysis layer: prompt loading, LLM call orchestration, response parsing.
-- Blazor-tuned prompt template: actual prompt used to generate workflow suggestions.
-- Report format: human-readable CLI report distinct from existing `AGENT.md` agent-context output.
-- Read-only mode for v1: does not write `.agentblazor/.state` by default.
-- Refactoring of `ModelBuilder` to produce typed model: turns existing Blazor-shaped output into `ProjectModel<BlazorFrameworkContext>`.
-- Stronger workflow registration model if v1 report must show registered agent names and workflow names rather than just readiness state.
-- Provider/model configuration fields or documented environment variable contract.
+- `AnalyzeCommand`: complete.
+- `IProjectAnalyzer<TFrameworkContext>`: complete.
+- `BlazorFrameworkContext`: complete.
+- `BlazorProjectAnalyzer`: complete.
+- Blazor framework detection through `ProjectAnalyzerRegistry` and `BlazorProjectAnalyzer.CanAnalyze`: complete for v1.
+- LLM analysis layer: complete for OpenAI and Azure OpenAI environment configuration, plus interactive OpenAI key prompt.
+- Blazor-tuned workflow prompt builder: complete.
+- Report format: complete.
+- Read-only mode for v1: complete.
+- Static source-file fallback for broken `MSBuildWorkspace` environments: complete.
+- Stronger workflow registration model showing registered agent names/workflow names: deferred. Readiness state is sufficient for v1.
+- Provider/model configuration fields or documented environment variable contract: complete.
 
 ## Out Of Scope Forever For AgentBlazor CLI
 
@@ -304,14 +302,14 @@ This is the answer to "what happens to people who installed v0.2.0": they get a 
 | Milestone | Target |
 | --- | --- |
 | Scope document committed to repo | May 24 2026 |
-| CLI .NET version updated to `net10.0` | Week 1 |
-| `IProjectAnalyzer` interface defined; `ModelBuilder` refactor to produce typed model | Week 1 |
-| `BlazorProjectAnalyzer` wrapping existing infrastructure | Week 1-2 |
-| `AnalyzeCommand` skeleton wired to adapter | Week 2 |
-| Prompt template drafted and tuned against synthetic projects | Week 2-3 |
-| LLM analysis layer with response validation | Week 3 |
-| Report generation | Week 3-4 |
-| Manual verification against real projects | Week 4-5 |
-| v1 ship | Week 5 target, Week 6-7 acceptable slip |
+| CLI .NET version updated to `net10.0` | Complete |
+| `IProjectAnalyzer` interface defined; analyzer wrapped by Blazor adapter | Complete |
+| `BlazorProjectAnalyzer` wrapping existing infrastructure | Complete |
+| `AnalyzeCommand` wired to adapter | Complete |
+| Prompt builder drafted and tuned against synthetic and real projects | Complete |
+| LLM analysis layer with response validation | Complete |
+| Report generation | Complete |
+| Manual verification against real projects | Complete |
+| v1 ship | Complete on May 29 2026 via `AgentBlazor.Cli` `0.2.5` |
 
-Slip past week 7 triggers a scope review, not a timeline extension.
+Any further CLI work should start from a new scope document or a focused bug-fix issue.

--- a/docs/releases/0.2.5.md
+++ b/docs/releases/0.2.5.md
@@ -1,0 +1,44 @@
+# AgentBlazor 0.2.5 Release Notes
+
+Target package line: `0.2.5` stable.
+
+AgentBlazor 0.2.5 is the CLI v1 analyze finalization release.
+
+## CLI v1
+
+- `agentblazor analyze` is the shipped v1 CLI onboarding command.
+- The command scans an existing Blazor solution, writes a markdown report, and does not modify application code.
+- Interactive OpenAI runs prompt for a missing API key and use it for that run only.
+- Non-interactive runs fail early with a clear provider-configuration message unless `--static-only` is used.
+- Windows/Roslyn `MSBuildWorkspace` load failures fall back to static source-file analysis.
+
+## Report Quality
+
+- Helper/object-method noise such as `ActivityIdHelper.ToString()` is filtered from developer-facing report and prompt sections.
+- The summary now reports `AgentBlazor action adoption` instead of the old ambiguous action coverage ratio.
+- Mutating workflow suggestions include explicit `RequiresApproval = true` guidance and a suggested `[AgentAction(..., RequiresApproval = true)]` attribute.
+- LLM suggestions are validated against the static analysis model before they are accepted into the report.
+
+## Verification
+
+- Analysis test suite passed: `163` tests.
+- Clean NuGet tool install verified with `AgentBlazor.Cli` `0.2.5`.
+- Final eShopOnBlazor smoke verified route discovery, helper filtering, candidate action discovery, and grounded workflow suggestions.
+
+## Install
+
+```bash
+dotnet add package AgentBlazor --version 0.2.5
+```
+
+Optional packages:
+
+```bash
+dotnet add package AgentBlazor.Client --version 0.2.5
+dotnet add package AgentBlazor.EntityFrameworkCore --version 0.2.5
+dotnet tool install --global AgentBlazor.Cli --version 0.2.5
+```
+
+## Previous Release
+
+For the Windows `MSBuildWorkspace` fallback, see [0.2.4 release notes](0.2.4.md).

--- a/src/AgentBlazor.Cli.Analysis/ExistingAppScaffoldApplier.cs
+++ b/src/AgentBlazor.Cli.Analysis/ExistingAppScaffoldApplier.cs
@@ -301,7 +301,7 @@ public sealed class ExistingAppScaffoldApplier
             .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
             ?.InformationalVersion
             ?? typeof(ExistingAppScaffoldApplier).Assembly.GetName().Version?.ToString()
-            ?? "0.2.4";
+            ?? "0.2.5";
 
         return version.Split('+', 2)[0];
     }

--- a/src/AgentBlazor.Cli/PACKAGE_README.md
+++ b/src/AgentBlazor.Cli/PACKAGE_README.md
@@ -11,7 +11,7 @@ dotnet tool install --global AgentBlazor.Cli
 If you prefer a pinned install:
 
 ```bash
-dotnet tool install --global AgentBlazor.Cli --version 0.2.4
+dotnet tool install --global AgentBlazor.Cli --version 0.2.5
 ```
 
 Example:
@@ -32,7 +32,7 @@ agentblazor analyze ./MySolution.slnx --host MyBlazorApp
 
 If no OpenAI key is configured and the terminal is interactive, `analyze` prompts for a key and uses it for that run only. The key is not written to disk.
 
-Version `0.2.4` and later include a Windows/Roslyn fallback for MSBuildWorkspace load failures. If a machine has conflicting Visual Studio/MSBuild assemblies, `analyze` falls back to static source-file analysis instead of failing before the report is generated.
+Version `0.2.5` and later include a Windows/Roslyn fallback for MSBuildWorkspace load failures. If a machine has conflicting Visual Studio/MSBuild assemblies, `analyze` falls back to static source-file analysis instead of failing before the report is generated.
 
 Reports filter helper/framework noise, show AgentBlazor action adoption, and call out `RequiresApproval = true` guidance for workflow suggestions that reference mutating methods.
 
@@ -42,7 +42,7 @@ Docs:
 
 - Repository: https://github.com/ashpeterson/AgentBlazor
 - Advanced CLI guide: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/advanced/cli.md
-- 0.2.4 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.4.md
+- 0.2.5 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.5.md
 - 0.2.3 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.3.md
 - 0.2.2 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.2.md
 - 0.2.1 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.1.md

--- a/src/AgentBlazor.Cli/Program.cs
+++ b/src/AgentBlazor.Cli/Program.cs
@@ -7,7 +7,7 @@ var version = typeof(ScaffoldCommand).Assembly
     .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
     ?.InformationalVersion
     ?? typeof(ScaffoldCommand).Assembly.GetName().Version?.ToString()
-    ?? "0.2.4";
+    ?? "0.2.5";
 version = version.Split('+', 2)[0];
 
 app.Configure(config =>

--- a/src/AgentBlazor.Cli/README.md
+++ b/src/AgentBlazor.Cli/README.md
@@ -10,7 +10,7 @@ agentblazor analyze ./MySolution.slnx --host MyBlazorApp
 
 If no OpenAI key is configured and the terminal is interactive, `analyze` prompts for one and uses it for that run only. For repeat runs or CI, set `OPENAI_API_KEY` and optionally `AGENTBLAZOR_ANALYZE_MODEL`. Pass `--static-only` to skip the LLM call.
 
-Version `0.2.4` and later include a static source-file fallback for Windows/Roslyn MSBuildWorkspace load failures. Current reports filter helper noise, show AgentBlazor action adoption, and include approval guidance for mutating workflow suggestions.
+Version `0.2.5` and later include a static source-file fallback for Windows/Roslyn MSBuildWorkspace load failures. Current reports filter helper noise, show AgentBlazor action adoption, and include approval guidance for mutating workflow suggestions.
 
 See:
 

--- a/src/AgentBlazor.Client/PACKAGE_README.md
+++ b/src/AgentBlazor.Client/PACKAGE_README.md
@@ -11,7 +11,7 @@ dotnet add package AgentBlazor.Client
 If you prefer a pinned install:
 
 ```bash
-dotnet add package AgentBlazor.Client --version 0.2.4
+dotnet add package AgentBlazor.Client --version 0.2.5
 ```
 
 Server project:
@@ -35,7 +35,7 @@ Docs:
 
 - Repository: https://github.com/ashpeterson/AgentBlazor
 - Quickstart: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/quickstart.md
-- 0.2.4 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.4.md
+- 0.2.5 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.5.md
 - 0.2.3 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.3.md
 - 0.2.2 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.2.md
 - 0.2.1 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.1.md

--- a/src/AgentBlazor.Components/PACKAGE_README.md
+++ b/src/AgentBlazor.Components/PACKAGE_README.md
@@ -15,10 +15,10 @@ dotnet add package AgentBlazor
 If you prefer a pinned install, use:
 
 ```bash
-dotnet add package AgentBlazor --version 0.2.4
+dotnet add package AgentBlazor --version 0.2.5
 ```
 
-Use `0.2.4` or later. This release includes the CLI Windows MSBuild fallback and first-run API-key prompt, CLI v1 analyze package refresh, mobile chat input stability fix, corrected EF package shape, and tool-friendly schemas for date-like workflow parameters.
+Use `0.2.5` or later. This release includes the CLI Windows MSBuild fallback and first-run API-key prompt, CLI v1 analyze package refresh, mobile chat input stability fix, corrected EF package shape, and tool-friendly schemas for date-like workflow parameters.
 
 If `dotnet` still probes an old custom package source on your machine, remove or disable that source before testing the public NuGet install path.
 
@@ -88,7 +88,7 @@ Docs and demo:
 - Hosted demo: https://demo.agentblazor.com/demo/workflows/support-inbox
 - Structured error reference: https://demo.agentblazor.com/demo/workflows/runtime-probe
 - Quickstart: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/quickstart.md
-- 0.2.4 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.4.md
+- 0.2.5 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.5.md
 - 0.2.3 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.3.md
 - 0.2.2 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.2.md
 - 0.2.1 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.1.md

--- a/src/AgentBlazor.EntityFrameworkCore/README.md
+++ b/src/AgentBlazor.EntityFrameworkCore/README.md
@@ -13,10 +13,10 @@ dotnet add package AgentBlazor.EntityFrameworkCore
 Pinned install:
 
 ```bash
-dotnet add package AgentBlazor.EntityFrameworkCore --version 0.2.4
+dotnet add package AgentBlazor.EntityFrameworkCore --version 0.2.5
 ```
 
-Use `0.2.4` or later. This release includes the CLI Windows MSBuild fallback and first-run API-key prompt, CLI v1 analyze package refresh, mobile chat input stability fix, corrected EF package shape, and tool-friendly schemas for date-like workflow parameters.
+Use `0.2.5` or later. This release includes the CLI Windows MSBuild fallback and first-run API-key prompt, CLI v1 analyze package refresh, mobile chat input stability fix, corrected EF package shape, and tool-friendly schemas for date-like workflow parameters.
 
 Register your `DbContext` with `IDbContextFactory<TContext>`:
 

--- a/tests/AgentBlazor.Cli.Analysis.Tests/ExistingAppScaffoldPlannerTests.cs
+++ b/tests/AgentBlazor.Cli.Analysis.Tests/ExistingAppScaffoldPlannerTests.cs
@@ -250,7 +250,7 @@ public sealed class ExistingAppScaffoldPlannerTests : IDisposable
         Assert.Contains("""<PackageReference Include="MudBlazor" />""", projectText, StringComparison.Ordinal);
         Assert.DoesNotContain("PackageReference Include=\"AgentBlazor\" Version=", projectText, StringComparison.Ordinal);
         Assert.DoesNotContain("PackageReference Include=\"MudBlazor\" Version=", projectText, StringComparison.Ordinal);
-        Assert.Contains("""<PackageVersion Include="AgentBlazor" Version="0.2.4" />""", centralPackagesText, StringComparison.Ordinal);
+        Assert.Contains("""<PackageVersion Include="AgentBlazor" Version="0.2.5" />""", centralPackagesText, StringComparison.Ordinal);
         Assert.Contains("""<PackageVersion Include="MudBlazor" Version="9.0.0" />""", centralPackagesText, StringComparison.Ordinal);
     }
 


### PR DESCRIPTION
## Summary\n- Bump package line to 0.2.5 for CLI v1 analyze finalization\n- Add 0.2.5 release notes\n- Update CLI v1 scope and validation docs to mark analyze v1 as shipped on 0.2.5\n- Update public/package docs and scaffold fallback versions\n\n## Verification\n- dotnet test tests/AgentBlazor.Cli.Analysis.Tests/AgentBlazor.Cli.Analysis.Tests.csproj\n- dotnet run --project src/AgentBlazor.Cli/AgentBlazor.Cli.csproj -- --version => 0.2.5\n- AGENTBLAZOR_STATIC_WORKSPACE=1 source eShop smoke => 5 routes, 1 developer-facing service, 7 discovered actions