### PR TITLE
chore: prepare 0.2.7 release

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
 
   <!-- Common package metadata for all AgentBlazor packages -->
   <PropertyGroup>
-    <Version>0.2.5</Version>
+    <Version>0.2.7</Version>
     <Authors>Ash Peterson</Authors>
     <Company>AgentBlazor</Company>
     <Copyright>Copyright (c) 2026 Ash Peterson</Copyright>
@@ -16,7 +16,7 @@
     <RepositoryType>git</RepositoryType>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <PackageIcon>icon.png</PackageIcon>
-    <PackageReleaseNotes>v0.2.5: CLI v1 analyze finalization. Filters helper/object-method noise from reports, replaces ambiguous action coverage with AgentBlazor action adoption, adds explicit RequiresApproval guidance for mutating workflow suggestions, and includes the v0.2.4 Windows MSBuildWorkspace static fallback.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.2.7: CLI multi-tenant solution scan scope. Adds analyze --scan-scope solution and fixes package assembly version metadata.</PackageReleaseNotes>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <Deterministic>true</Deterministic>

--- a/docs/releases/0.2.6.md
+++ b/docs/releases/0.2.6.md
@@ -4,6 +4,8 @@ Target package line: `0.2.6` stable.
 
 AgentBlazor 0.2.6 is a CLI patch release focused on multi-tenant and modular solution analysis.
 
+Note: 0.2.6 was superseded by [0.2.7](0.2.7.md), which fixes CLI executable version metadata. Use 0.2.7 for validation.
+
 ## CLI Analyze
 
 - Added `agentblazor analyze --scan-scope solution`.

--- a/docs/releases/0.2.7.md
+++ b/docs/releases/0.2.7.md
@@ -1,0 +1,48 @@
+# AgentBlazor 0.2.7 Release Notes
+
+Target package line: `0.2.7` stable.
+
+AgentBlazor 0.2.7 supersedes 0.2.6 for the CLI multi-tenant scan-scope release.
+
+## CLI Analyze
+
+- Includes `agentblazor analyze --scan-scope solution` for multi-tenant and modular Blazor solutions.
+- Keeps default scan behavior as `references`: host project plus transitive project references.
+- Keeps `--host` semantics focused on the Blazor startup project used for host-shape and install-readiness checks.
+- Full-solution scan behavior includes every project in the supplied `.sln` or `.slnx`, allowing sibling tenant/module projects to contribute routes, services, capabilities, and candidate actions.
+
+Example:
+
+```bash
+agentblazor analyze ./MySolution.slnx --host MyBlazorApp --scan-scope solution
+```
+
+## Version Metadata Fix
+
+0.2.6 was accepted by nuget.org, but the CLI executable still reported `0.2.5` because the repository-level assembly version remained pinned to `0.2.5`.
+
+0.2.7 fixes that root version metadata so `agentblazor --version` reports the installed package line correctly.
+
+## Verification
+
+- CI passed before merge for the multi-tenant scan-scope implementation.
+- NuGet publish workflow passed for 0.2.6 and accepted the packages.
+- 0.2.7 fixes package version metadata and should be used for validation.
+
+## Install
+
+```bash
+dotnet add package AgentBlazor --version 0.2.7
+```
+
+Optional packages:
+
+```bash
+dotnet add package AgentBlazor.Client --version 0.2.7
+dotnet add package AgentBlazor.EntityFrameworkCore --version 0.2.7
+dotnet tool install --global AgentBlazor.Cli --version 0.2.7
+```
+
+## Previous Release
+
+For the original multi-tenant scan-scope release notes, see [0.2.6 release notes](0.2.6.md).

--- a/src/AgentBlazor.Cli.Analysis/ExistingAppScaffoldApplier.cs
+++ b/src/AgentBlazor.Cli.Analysis/ExistingAppScaffoldApplier.cs
@@ -301,7 +301,7 @@ public sealed class ExistingAppScaffoldApplier
             .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
             ?.InformationalVersion
             ?? typeof(ExistingAppScaffoldApplier).Assembly.GetName().Version?.ToString()
-            ?? "0.2.6";
+            ?? "0.2.7";
 
         return version.Split('+', 2)[0];
     }

--- a/src/AgentBlazor.Cli/PACKAGE_README.md
+++ b/src/AgentBlazor.Cli/PACKAGE_README.md
@@ -11,7 +11,7 @@ dotnet tool install --global AgentBlazor.Cli
 If you prefer a pinned install:
 
 ```bash
-dotnet tool install --global AgentBlazor.Cli --version 0.2.6
+dotnet tool install --global AgentBlazor.Cli --version 0.2.7
 ```
 
 Example:
@@ -34,7 +34,7 @@ If no OpenAI key is configured and the terminal is interactive, `analyze` prompt
 
 Version `0.2.5` and later include a Windows/Roslyn fallback for MSBuildWorkspace load failures. If a machine has conflicting Visual Studio/MSBuild assemblies, `analyze` falls back to static source-file analysis instead of failing before the report is generated.
 
-Version `0.2.6` and later add `--scan-scope solution` for multi-tenant and modular solutions where sibling projects live in the same `.slnx` but are not referenced by the Blazor host project.
+Version `0.2.7` and later add `--scan-scope solution` for multi-tenant and modular solutions where sibling projects live in the same `.slnx` but are not referenced by the Blazor host project.
 
 Reports filter helper/framework noise, show AgentBlazor action adoption, and call out `RequiresApproval = true` guidance for workflow suggestions that reference mutating methods.
 
@@ -44,7 +44,7 @@ Docs:
 
 - Repository: https://github.com/ashpeterson/AgentBlazor
 - Advanced CLI guide: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/advanced/cli.md
-- 0.2.6 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.6.md
+- 0.2.7 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.7.md
 - 0.2.5 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.5.md
 - 0.2.3 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.3.md
 - 0.2.2 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.2.md

--- a/src/AgentBlazor.Cli/Program.cs
+++ b/src/AgentBlazor.Cli/Program.cs
@@ -7,7 +7,7 @@ var version = typeof(ScaffoldCommand).Assembly
     .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
     ?.InformationalVersion
     ?? typeof(ScaffoldCommand).Assembly.GetName().Version?.ToString()
-    ?? "0.2.6";
+    ?? "0.2.7";
 version = version.Split('+', 2)[0];
 
 app.Configure(config =>

--- a/src/AgentBlazor.Cli/README.md
+++ b/src/AgentBlazor.Cli/README.md
@@ -12,7 +12,7 @@ If no OpenAI key is configured and the terminal is interactive, `analyze` prompt
 
 Version `0.2.5` and later include a static source-file fallback for Windows/Roslyn MSBuildWorkspace load failures. Current reports filter helper noise, show AgentBlazor action adoption, and include approval guidance for mutating workflow suggestions.
 
-Version `0.2.6` and later include `--scan-scope solution` for multi-tenant and modular `.slnx` files where sibling projects should be scanned even when the Blazor host project does not reference them directly.
+Version `0.2.7` and later include `--scan-scope solution` for multi-tenant and modular `.slnx` files where sibling projects should be scanned even when the Blazor host project does not reference them directly.
 
 See:
 


### PR DESCRIPTION
Supersedes 0.2.6 because the package installed correctly but the CLI executable still reported 0.2.5 from Directory.Build.props.\n\nChanges:\n- Bumps repository version metadata to 0.2.7.\n- Updates CLI fallback/scaffold version strings to 0.2.7.\n- Adds 0.2.7 release notes and marks 0.2.6 as superseded.\n\nVerification:\n- `dotnet build src/AgentBlazor.Cli/AgentBlazor.Cli.csproj --no-restore -v minimal`\n- `dotnet test tests/AgentBlazor.Cli.Analysis.Tests/AgentBlazor.Cli.Analysis.Tests.csproj --filter FullyQualifiedName~CliTargetAnalysisTests --no-restore -v minimal`\n- Local pack/install of `AgentBlazor.Cli 0.2.7` reports `agentblazor --version` as `0.2.7`.