### PR TITLE
fix(cli): tolerate duplicate method keys in solution analysis

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
 
   <!-- Common package metadata for all AgentBlazor packages -->
   <PropertyGroup>
-    <Version>0.2.7</Version>
+    <Version>0.2.8</Version>
     <Authors>Ash Peterson</Authors>
     <Company>AgentBlazor</Company>
     <Copyright>Copyright (c) 2026 Ash Peterson</Copyright>
@@ -16,7 +16,7 @@
     <RepositoryType>git</RepositoryType>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <PackageIcon>icon.png</PackageIcon>
-    <PackageReleaseNotes>v0.2.7: CLI multi-tenant solution scan scope. Adds analyze --scan-scope solution and fixes package assembly version metadata.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.2.8: CLI solution-scope analysis hardening. Fixes duplicate service method keys in workflow suggestion prompt generation for multi-project solutions.</PackageReleaseNotes>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <Deterministic>true</Deterministic>

--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ dotnet run --project samples/AgentBlazor.Starter/AgentBlazor.Starter.csproj
 
 - [Quickstart](docs/quickstart.md)
 - [CLI v1 announcement](docs/cli-v1-analyze-announcement.md)
+- [0.2.8 release notes](docs/releases/0.2.8.md)
+- [0.2.7 release notes](docs/releases/0.2.7.md)
+- [0.2.6 release notes](docs/releases/0.2.6.md)
 - [0.2.5 release notes](docs/releases/0.2.5.md)
 - [0.2.3 release notes](docs/releases/0.2.3.md)
 - [0.2.2 release notes](docs/releases/0.2.2.md)

--- a/src/AgentBlazor.Cli.Analysis/ExistingAppScaffoldApplier.cs
+++ b/src/AgentBlazor.Cli.Analysis/ExistingAppScaffoldApplier.cs
@@ -301,7 +301,7 @@ public sealed class ExistingAppScaffoldApplier
             .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
             ?.InformationalVersion
             ?? typeof(ExistingAppScaffoldApplier).Assembly.GetName().Version?.ToString()
-            ?? "0.2.7";
+            ?? "0.2.8";
 
         return version.Split('+', 2)[0];
     }

--- a/src/AgentBlazor.Cli.Analysis/WorkflowSuggestions/WorkflowSuggestionPromptBuilder.cs
+++ b/src/AgentBlazor.Cli.Analysis/WorkflowSuggestions/WorkflowSuggestionPromptBuilder.cs
@@ -102,9 +102,15 @@ public sealed class WorkflowSuggestionPromptBuilder
         var candidateActions = model.Actions
             .Where(action => action.ExposureMode is ActionExposureMode.Suggested or ActionExposureMode.Confirmed)
             .Where(AnalysisModelFilters.IsDeveloperFacingAction)
-            .ToDictionary(
+            .GroupBy(
                 action => (action.SourceService, action.MethodName),
-                action => action,
+                new MethodKeyComparer())
+            .ToDictionary(
+                group => group.Key,
+                group => group
+                    .OrderByDescending(action => action.ExposureMode == ActionExposureMode.Confirmed)
+                    .ThenByDescending(action => action.Score)
+                    .First(),
                 new MethodKeyComparer());
 
         foreach (var service in model.Services

--- a/src/AgentBlazor.Cli/PACKAGE_README.md
+++ b/src/AgentBlazor.Cli/PACKAGE_README.md
@@ -11,7 +11,7 @@ dotnet tool install --global AgentBlazor.Cli
 If you prefer a pinned install:
 
 ```bash
-dotnet tool install --global AgentBlazor.Cli --version 0.2.7
+dotnet tool install --global AgentBlazor.Cli --version 0.2.8
 ```
 
 Example:
@@ -36,6 +36,8 @@ Version `0.2.5` and later include a Windows/Roslyn fallback for MSBuildWorkspace
 
 Version `0.2.7` and later add `--scan-scope solution` for multi-tenant and modular solutions where sibling projects live in the same `.slnx` but are not referenced by the Blazor host project.
 
+Version `0.2.8` hardens solution-scope workflow suggestions when multiple projects expose the same service and method names.
+
 Reports filter helper/framework noise, show AgentBlazor action adoption, and call out `RequiresApproval = true` guidance for workflow suggestions that reference mutating methods.
 
 The CLI is an advanced path. The default install story is still `dotnet add package AgentBlazor` plus manual runtime wiring.
@@ -44,7 +46,7 @@ Docs:
 
 - Repository: https://github.com/ashpeterson/AgentBlazor
 - Advanced CLI guide: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/advanced/cli.md
-- 0.2.7 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.7.md
+- 0.2.8 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.8.md
 - 0.2.5 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.5.md
 - 0.2.3 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.3.md
 - 0.2.2 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.2.md

--- a/src/AgentBlazor.Cli/Program.cs
+++ b/src/AgentBlazor.Cli/Program.cs
@@ -7,7 +7,7 @@ var version = typeof(ScaffoldCommand).Assembly
     .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
     ?.InformationalVersion
     ?? typeof(ScaffoldCommand).Assembly.GetName().Version?.ToString()
-    ?? "0.2.7";
+    ?? "0.2.8";
 version = version.Split('+', 2)[0];
 
 app.Configure(config =>

--- a/src/AgentBlazor.Cli/README.md
+++ b/src/AgentBlazor.Cli/README.md
@@ -14,6 +14,8 @@ Version `0.2.5` and later include a static source-file fallback for Windows/Rosl
 
 Version `0.2.7` and later include `--scan-scope solution` for multi-tenant and modular `.slnx` files where sibling projects should be scanned even when the Blazor host project does not reference them directly.
 
+Version `0.2.8` hardens solution-scope workflow suggestions when multiple scanned projects expose the same service and method names.
+
 See:
 
 - `docs/advanced/cli.md`

--- a/tests/AgentBlazor.Cli.Analysis.Tests/WorkflowSuggestions/WorkflowSuggestionPromptBuilderTests.cs
+++ b/tests/AgentBlazor.Cli.Analysis.Tests/WorkflowSuggestions/WorkflowSuggestionPromptBuilderTests.cs
@@ -179,4 +179,63 @@ public sealed class WorkflowSuggestionPromptBuilderTests
         Assert.Contains("OrderCapabilities.ShowOpenOrdersAsync", prompt);
         Assert.DoesNotContain("- OrderCapabilities [", prompt);
     }
+
+    [Fact]
+    public void Build_AllowsDuplicateActionKeysFromSolutionScan()
+    {
+        var builder = new WorkflowSuggestionPromptBuilder();
+        var model = new ProjectModel
+        {
+            AppName = "TestApp",
+            BlazorHostProject = "TestApp",
+            Services =
+            [
+                new ServiceModel
+                {
+                    TypeName = "EmailService",
+                    FilePath = "TenantA/EmailService.cs",
+                    Methods =
+                    [
+                        new ServiceMethodModel
+                        {
+                            Name = "SendEmailAsync",
+                            ReturnType = "Task",
+                            IsPublic = true,
+                            IsAsync = true
+                        }
+                    ]
+                }
+            ],
+            Actions =
+            [
+                new ActionModel
+                {
+                    Name = "Send Email",
+                    SourceService = "EmailService",
+                    MethodName = "SendEmailAsync",
+                    FilePath = "TenantA/EmailService.cs",
+                    ExposureMode = ActionExposureMode.Suggested,
+                    Classification = ActionClassification.Command,
+                    IsMutationLikely = true,
+                    Score = 0.8
+                },
+                new ActionModel
+                {
+                    Name = "Send Email",
+                    SourceService = "EmailService",
+                    MethodName = "SendEmailAsync",
+                    FilePath = "TenantB/EmailService.cs",
+                    ExposureMode = ActionExposureMode.Suggested,
+                    Classification = ActionClassification.Command,
+                    IsMutationLikely = true,
+                    Score = 0.7
+                }
+            ]
+        };
+
+        var prompt = builder.Build(model);
+
+        Assert.Contains("EmailService", prompt);
+        Assert.Contains("SendEmailAsync", prompt);
+    }
 }


### PR DESCRIPTION
## Summary
- Fixes solution-scope analysis crashing when multiple scanned projects expose the same service and method name, e.g. EmailService.SendEmailAsync.
- Groups duplicate workflow-suggestion action keys and keeps the strongest candidate instead of throwing in prompt generation.
- Bumps package metadata to 0.2.8 and documents the patch release.

## Verification
- dotnet test tests/AgentBlazor.Cli.Analysis.Tests/AgentBlazor.Cli.Analysis.Tests.csproj --filter FullyQualifiedName~WorkflowSuggestionPromptBuilderTests --no-restore -v minimal
- dotnet build src/AgentBlazor.Cli/AgentBlazor.Cli.csproj --no-restore -v minimal
- local dotnet pack/install smoke for AgentBlazor.Cli 0.2.8
- local analyze smoke with --scan-scope solution against multitenant synthetic target