### PR TITLE
fix(cli): exclude test projects from solution analysis

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
 
   <!-- Common package metadata for all AgentBlazor packages -->
   <PropertyGroup>
-    <Version>0.2.8</Version>
+    <Version>0.2.9</Version>
     <Authors>Ash Peterson</Authors>
     <Company>AgentBlazor</Company>
     <Copyright>Copyright (c) 2026 Ash Peterson</Copyright>
@@ -16,7 +16,7 @@
     <RepositoryType>git</RepositoryType>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <PackageIcon>icon.png</PackageIcon>
-    <PackageReleaseNotes>v0.2.8: CLI solution-scope analysis hardening. Fixes duplicate service method keys in workflow suggestion prompt generation for multi-project solutions.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.2.9: CLI analysis filtering. Excludes test projects and test asset folders from default solution-scope analysis.</PackageReleaseNotes>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <Deterministic>true</Deterministic>

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ dotnet run --project samples/AgentBlazor.Starter/AgentBlazor.Starter.csproj
 
 - [Quickstart](docs/quickstart.md)
 - [CLI v1 announcement](docs/cli-v1-analyze-announcement.md)
+- [0.2.9 release notes](docs/releases/0.2.9.md)
 - [0.2.8 release notes](docs/releases/0.2.8.md)
 - [0.2.7 release notes](docs/releases/0.2.7.md)
 - [0.2.6 release notes](docs/releases/0.2.6.md)

--- a/docs/releases/0.2.9.md
+++ b/docs/releases/0.2.9.md
@@ -1,0 +1,25 @@
+# AgentBlazor 0.2.9 Release Notes
+
+Target package line: `0.2.9` stable.
+
+AgentBlazor 0.2.9 is a CLI analysis quality patch.
+
+## What Changed
+
+- `agentblazor analyze --scan-scope solution` now excludes test projects and test asset folders from default analysis.
+- Excluded projects include common test naming and folder patterns such as `.Tests`, `Tests`, `_tests`, `__tests__`, `test-assets`, and `fixtures`.
+- The Blazor host project is always retained, even if its name matches a test-like pattern.
+- Added regression coverage for a `_tests/Assets/fwCRUD/Restore.cs`-style project so test utilities do not appear as workflow suggestions.
+
+## Why
+
+Full-solution analysis is meant to find real application routes and services. Test fixtures, restore helpers, and test asset projects add noise and can produce unsafe or irrelevant workflow suggestions.
+
+## Test
+
+```powershell
+dotnet tool update --global AgentBlazor.Cli --version 0.2.9
+agentblazor analyze .\YourSolution.slnx --host YourHostProject --scan-scope solution --output .\analysis.md
+```
+
+Use `--static-only` if you want to verify scanner coverage without calling the LLM.

--- a/src/AgentBlazor.Cli.Analysis/ExistingAppScaffoldApplier.cs
+++ b/src/AgentBlazor.Cli.Analysis/ExistingAppScaffoldApplier.cs
@@ -301,7 +301,7 @@ public sealed class ExistingAppScaffoldApplier
             .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
             ?.InformationalVersion
             ?? typeof(ExistingAppScaffoldApplier).Assembly.GetName().Version?.ToString()
-            ?? "0.2.8";
+            ?? "0.2.9";
 
         return version.Split('+', 2)[0];
     }

--- a/src/AgentBlazor.Cli.Analysis/ModelBuilder.cs
+++ b/src/AgentBlazor.Cli.Analysis/ModelBuilder.cs
@@ -102,6 +102,9 @@ public sealed class ModelBuilder
         var analysisProjects = solution is null
             ? [hostProject]
             : GetAnalysisProjects(solution, hostProject, scanScope);
+        analysisProjects = analysisProjects
+            .Where(project => project.Id == hostProject.Id || !IsTestProject(project))
+            .ToList();
 
         // 1. Analyze Razor files
         OnProgress?.Invoke("Scanning Razor components...");
@@ -313,7 +316,7 @@ public sealed class ModelBuilder
             .ToList();
 
         // 9. Build project nodes
-        var projectNodes = projects.Select(p => new ProjectNode
+        var projectNodes = analysisProjects.Select(p => new ProjectNode
         {
             Name = p.Name,
             Path = MakeRelativePath(Path.GetDirectoryName(solutionOrProjectPath)!, p.FilePath ?? ""),
@@ -392,6 +395,75 @@ public sealed class ModelBuilder
         var visited = new HashSet<ProjectId> { hostProject.Id };
         AddReferencedProjects(solution, hostProject, projects, visited);
         return projects;
+    }
+
+    private static bool IsTestProject(Project project)
+    {
+        if (IsTestLikeName(project.Name))
+        {
+            return true;
+        }
+
+        if (string.IsNullOrWhiteSpace(project.FilePath))
+        {
+            return false;
+        }
+
+        var fullPath = Path.GetFullPath(project.FilePath);
+        var fileName = Path.GetFileNameWithoutExtension(fullPath);
+        if (IsTestLikeName(fileName))
+        {
+            return true;
+        }
+
+        var segments = fullPath
+            .Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+            .Where(segment => !string.IsNullOrWhiteSpace(segment));
+
+        foreach (var segment in segments)
+        {
+            if (IsTestLikePathSegment(segment))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsTestLikeName(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return false;
+        }
+
+        return name.Equals("Tests", StringComparison.OrdinalIgnoreCase) ||
+            name.Equals("Test", StringComparison.OrdinalIgnoreCase) ||
+            name.Contains(".Tests", StringComparison.OrdinalIgnoreCase) ||
+            name.Contains(".Test", StringComparison.OrdinalIgnoreCase) ||
+            name.EndsWith("Tests", StringComparison.OrdinalIgnoreCase) ||
+            name.EndsWith("Test", StringComparison.OrdinalIgnoreCase) ||
+            name.StartsWith("Test", StringComparison.OrdinalIgnoreCase) ||
+            name.Contains("xunit", StringComparison.OrdinalIgnoreCase) ||
+            name.Contains("nunit", StringComparison.OrdinalIgnoreCase) ||
+            name.Contains("mstest", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsTestLikePathSegment(string segment)
+    {
+        if (string.IsNullOrWhiteSpace(segment))
+        {
+            return false;
+        }
+
+        return segment.Equals("_tests", StringComparison.OrdinalIgnoreCase) ||
+            segment.Equals("__tests__", StringComparison.OrdinalIgnoreCase) ||
+            segment.Equals("testdata", StringComparison.OrdinalIgnoreCase) ||
+            segment.Equals("test-data", StringComparison.OrdinalIgnoreCase) ||
+            segment.Equals("testassets", StringComparison.OrdinalIgnoreCase) ||
+            segment.Equals("test-assets", StringComparison.OrdinalIgnoreCase) ||
+            segment.Equals("fixtures", StringComparison.OrdinalIgnoreCase);
     }
 
     private static void AddReferencedProjects(

--- a/src/AgentBlazor.Cli/PACKAGE_README.md
+++ b/src/AgentBlazor.Cli/PACKAGE_README.md
@@ -11,7 +11,7 @@ dotnet tool install --global AgentBlazor.Cli
 If you prefer a pinned install:
 
 ```bash
-dotnet tool install --global AgentBlazor.Cli --version 0.2.8
+dotnet tool install --global AgentBlazor.Cli --version 0.2.9
 ```
 
 Example:
@@ -38,6 +38,8 @@ Version `0.2.7` and later add `--scan-scope solution` for multi-tenant and modul
 
 Version `0.2.8` hardens solution-scope workflow suggestions when multiple projects expose the same service and method names.
 
+Version `0.2.9` excludes test projects and test asset folders from default solution-scope analysis.
+
 Reports filter helper/framework noise, show AgentBlazor action adoption, and call out `RequiresApproval = true` guidance for workflow suggestions that reference mutating methods.
 
 The CLI is an advanced path. The default install story is still `dotnet add package AgentBlazor` plus manual runtime wiring.
@@ -46,7 +48,7 @@ Docs:
 
 - Repository: https://github.com/ashpeterson/AgentBlazor
 - Advanced CLI guide: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/advanced/cli.md
-- 0.2.8 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.8.md
+- 0.2.9 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.9.md
 - 0.2.5 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.5.md
 - 0.2.3 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.3.md
 - 0.2.2 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.2.md

--- a/src/AgentBlazor.Cli/Program.cs
+++ b/src/AgentBlazor.Cli/Program.cs
@@ -7,7 +7,7 @@ var version = typeof(ScaffoldCommand).Assembly
     .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
     ?.InformationalVersion
     ?? typeof(ScaffoldCommand).Assembly.GetName().Version?.ToString()
-    ?? "0.2.8";
+    ?? "0.2.9";
 version = version.Split('+', 2)[0];
 
 app.Configure(config =>

--- a/src/AgentBlazor.Cli/README.md
+++ b/src/AgentBlazor.Cli/README.md
@@ -16,6 +16,8 @@ Version `0.2.7` and later include `--scan-scope solution` for multi-tenant and m
 
 Version `0.2.8` hardens solution-scope workflow suggestions when multiple scanned projects expose the same service and method names.
 
+Version `0.2.9` excludes test projects and test asset folders from default solution-scope analysis.
+
 See:
 
 - `docs/advanced/cli.md`

--- a/tests/AgentBlazor.Cli.Analysis.Tests/Blazor/CliTargetAnalysisTests.cs
+++ b/tests/AgentBlazor.Cli.Analysis.Tests/Blazor/CliTargetAnalysisTests.cs
@@ -81,6 +81,8 @@ public sealed class CliTargetAnalysisTests
             Assert.DoesNotContain(referencesOnly.Model.Services, service => service.TypeName == "TenantBillingService");
             Assert.Contains(fullSolution.Model.Routes, route => route.Template == "/tenant-a/dashboard");
             Assert.Contains(fullSolution.Model.Services, service => service.TypeName == "TenantBillingService");
+            Assert.DoesNotContain(fullSolution.Model.Projects, project => project.Name == "fwCRUD.Tests");
+            Assert.DoesNotContain(fullSolution.Model.Services, service => service.TypeName == "Restore");
         }
         finally
         {

--- a/tests/cli-targets/multitenant-solution/MultiTenantApp.slnx
+++ b/tests/cli-targets/multitenant-solution/MultiTenantApp.slnx
@@ -1,4 +1,5 @@
 <Solution>
   <Project Path="Host/Host.csproj" />
   <Project Path="TenantA/TenantA.csproj" />
+  <Project Path="_tests/Assets/fwCRUD/fwCRUD.Tests.csproj" />
 </Solution>

--- a/tests/cli-targets/multitenant-solution/_tests/Assets/fwCRUD/Restore.cs
+++ b/tests/cli-targets/multitenant-solution/_tests/Assets/fwCRUD/Restore.cs
@@ -1,0 +1,8 @@
+namespace MultiTenantApp.Tests.Assets.fwCRUD;
+
+public sealed class Restore
+{
+    public Task RestoreTest() => Task.CompletedTask;
+
+    public Task BulkRestoreTest() => Task.CompletedTask;
+}

--- a/tests/cli-targets/multitenant-solution/_tests/Assets/fwCRUD/fwCRUD.Tests.csproj
+++ b/tests/cli-targets/multitenant-solution/_tests/Assets/fwCRUD/fwCRUD.Tests.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
## Summary
- Excludes test projects and test asset folders from default solution-scope analysis.
- Keeps the selected Blazor host project even if its name is test-like.
- Adds a regression fixture for a _tests/Assets/fwCRUD/Restore.cs-style project so test utilities do not appear as workflow suggestions.
- Bumps package metadata to 0.2.9 and documents the patch release.

## Verification
- dotnet test tests/AgentBlazor.Cli.Analysis.Tests/AgentBlazor.Cli.Analysis.Tests.csproj --filter FullyQualifiedName~CliTargetAnalysisTests --no-restore -v minimal
- dotnet build src/AgentBlazor.Cli/AgentBlazor.Cli.csproj --no-restore -v minimal
- local dotnet pack/install smoke for AgentBlazor.Cli 0.2.9
- local analyze smoke with --scan-scope solution confirms tenant project is included and _tests/fwCRUD/Restore is excluded