### PR TITLE
fix(cli): rank workflow suggestions by risk

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
 
   <!-- Common package metadata for all AgentBlazor packages -->
   <PropertyGroup>
-    <Version>0.2.9</Version>
+    <Version>0.2.10</Version>
     <Authors>Ash Peterson</Authors>
     <Company>AgentBlazor</Company>
     <Copyright>Copyright (c) 2026 Ash Peterson</Copyright>
@@ -16,7 +16,7 @@
     <RepositoryType>git</RepositoryType>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <PackageIcon>icon.png</PackageIcon>
-    <PackageReleaseNotes>v0.2.9: CLI analysis filtering. Excludes test projects and test asset folders from default solution-scope analysis.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.2.10: CLI recommendation quality. Prioritizes safe read-only workflows, labels suggestion risk, and requires approval for mutating command suggestions.</PackageReleaseNotes>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <Deterministic>true</Deterministic>

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ dotnet run --project samples/AgentBlazor.Starter/AgentBlazor.Starter.csproj
 
 - [Quickstart](docs/quickstart.md)
 - [CLI v1 announcement](docs/cli-v1-analyze-announcement.md)
+- [0.2.10 release notes](docs/releases/0.2.10.md)
 - [0.2.9 release notes](docs/releases/0.2.9.md)
 - [0.2.8 release notes](docs/releases/0.2.8.md)
 - [0.2.7 release notes](docs/releases/0.2.7.md)

--- a/docs/releases/0.2.10.md
+++ b/docs/releases/0.2.10.md
@@ -1,0 +1,32 @@
+# AgentBlazor 0.2.10 Release Notes
+
+Target package line: `0.2.10` stable.
+
+AgentBlazor 0.2.10 is a CLI recommendation-quality patch.
+
+## What Changed
+
+- Static workflow suggestions now prioritize safe read-only actions before approval-gated or high-risk/admin actions.
+- LLM workflow suggestions are displayed safe-first even if the model returns high-risk suggestions first.
+- Reports now label each workflow suggestion with a risk band:
+  - `safe read-only`
+  - `review generated output`
+  - `approval required`
+  - `high-risk/admin`
+- Mutating command suggestions now consistently set `RequiresApproval = true`, fixing cases like `SendEmailAsync` where mutation was detected but approval was not recommended.
+- The LLM prompt now explicitly asks for read-only/status/list/check workflows first and discourages auth, password reset, tenant mutation, message deletion, workflow execution, job execution, database mutation, and permission changes unless no safer workflow exists.
+
+## Why
+
+Full-solution analysis found the right services, but early recommendations were too often broad admin/mutating workflows such as password reset, tenant management, job execution, or message deletion.
+
+For first-run onboarding, the CLI should steer developers toward low-risk workflows they can wire quickly and safely: status snapshots, list/search/find, validation, logs, and read-only diagnostics.
+
+## Test
+
+```powershell
+dotnet tool update --global AgentBlazor.Cli --version 0.2.10
+agentblazor analyze .\YourSolution.slnx --host YourHostProject --scan-scope solution --output .\analysis.md
+```
+
+Use `--static-only` if you want to verify deterministic scanner output without calling the LLM.

--- a/src/AgentBlazor.Cli.Analysis/ActionRisk.cs
+++ b/src/AgentBlazor.Cli.Analysis/ActionRisk.cs
@@ -1,0 +1,114 @@
+using AgentBlazor.Cli.Analysis.Models;
+
+namespace AgentBlazor.Cli.Analysis;
+
+public enum ActionRiskBand
+{
+    SafeReadOnly = 0,
+    ReviewOutput = 1,
+    ApprovalRequired = 2,
+    HighRisk = 3
+}
+
+public static class ActionRisk
+{
+    private static readonly string[] HighRiskServiceTerms =
+    [
+        "Authentication",
+        "Auth",
+        "Email",
+        "Message",
+        "Mongo",
+        "Password",
+        "Permission",
+        "TenantStore",
+        "Transaction",
+        "Workflow"
+    ];
+
+    private static readonly string[] HighRiskMethodTerms =
+    [
+        "Add",
+        "Authenticate",
+        "Create",
+        "Delete",
+        "Drop",
+        "Execute",
+        "Login",
+        "Logout",
+        "Remove",
+        "Reset",
+        "Run",
+        "Send",
+        "Submit",
+        "Update",
+        "Upsert"
+    ];
+
+    public static ActionRiskBand GetRiskBand(ActionModel action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        if (IsHighRisk(action))
+        {
+            return ActionRiskBand.HighRisk;
+        }
+
+        if (action.IsMutationLikely ||
+            action.RequiresApproval ||
+            action.Classification is ActionClassification.Command or ActionClassification.Workflow)
+        {
+            return ActionRiskBand.ApprovalRequired;
+        }
+
+        if (action.Classification == ActionClassification.Export)
+        {
+            return ActionRiskBand.ReviewOutput;
+        }
+
+        return ActionRiskBand.SafeReadOnly;
+    }
+
+    public static bool IsSafeReadOnly(ActionModel action)
+        => GetRiskBand(action) == ActionRiskBand.SafeReadOnly;
+
+    public static string Describe(ActionRiskBand band)
+        => band switch
+        {
+            ActionRiskBand.SafeReadOnly => "safe read-only",
+            ActionRiskBand.ReviewOutput => "review generated output",
+            ActionRiskBand.ApprovalRequired => "approval required",
+            ActionRiskBand.HighRisk => "high-risk/admin",
+            _ => "unknown"
+        };
+
+    private static bool IsHighRisk(ActionModel action)
+    {
+        var serviceName = action.SourceService ?? string.Empty;
+        var methodName = action.MethodName ?? string.Empty;
+        var displayName = action.Name ?? string.Empty;
+
+        if (ContainsAny(serviceName, HighRiskServiceTerms) &&
+            ContainsAny(methodName, HighRiskMethodTerms))
+        {
+            return true;
+        }
+
+        if (ContainsAny(displayName, ["Password", "Tenant", "Permission", "Authenticate"]))
+        {
+            return true;
+        }
+
+        if (methodName.Contains("DropDatabase", StringComparison.OrdinalIgnoreCase) ||
+            methodName.Contains("Delete", StringComparison.OrdinalIgnoreCase) ||
+            methodName.Contains("Remove", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool ContainsAny(string value, IReadOnlyList<string> terms)
+        => terms.Any(term => value.Contains(term, StringComparison.OrdinalIgnoreCase));
+}

--- a/src/AgentBlazor.Cli.Analysis/ActionScorer.cs
+++ b/src/AgentBlazor.Cli.Analysis/ActionScorer.cs
@@ -549,7 +549,7 @@ public sealed class ActionScorer
             MethodName = method.Name,
             FilePath = service.FilePath,
             IsMutationLikely = score.IsMutation,
-            RequiresApproval = score.IsMutation && score.Classification == ActionClassification.Workflow,
+            RequiresApproval = score.IsMutation,
             Classification = score.Classification,
             Score = score.Score,
             Parameters = method.Parameters,

--- a/src/AgentBlazor.Cli.Analysis/ExistingAppScaffoldApplier.cs
+++ b/src/AgentBlazor.Cli.Analysis/ExistingAppScaffoldApplier.cs
@@ -301,7 +301,7 @@ public sealed class ExistingAppScaffoldApplier
             .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
             ?.InformationalVersion
             ?? typeof(ExistingAppScaffoldApplier).Assembly.GetName().Version?.ToString()
-            ?? "0.2.9";
+            ?? "0.2.10";
 
         return version.Split('+', 2)[0];
     }

--- a/src/AgentBlazor.Cli.Analysis/Generation/AnalysisReportGenerator.cs
+++ b/src/AgentBlazor.Cli.Analysis/Generation/AnalysisReportGenerator.cs
@@ -208,13 +208,16 @@ public sealed class AnalysisReportGenerator
 
             if (workflowSuggestions.Suggestions.Count > 0)
             {
-                foreach (var suggestion in workflowSuggestions.Suggestions)
+                foreach (var suggestion in workflowSuggestions.Suggestions
+                    .OrderBy(suggestion => GetSuggestionRiskRank(suggestion, model))
+                    .ThenByDescending(suggestion => suggestion.Confidence))
                 {
                     sb.AppendLine($"### {suggestion.Name}");
                     sb.AppendLine();
                     sb.AppendLine(suggestion.Description);
                     sb.AppendLine();
                     sb.AppendLine($"- Confidence: {suggestion.Confidence.ToString("0.00", CultureInfo.InvariantCulture)}");
+                    sb.AppendLine($"- Risk: {ActionRisk.Describe(GetSuggestionRiskBand(suggestion, model))}");
                     if (!string.IsNullOrWhiteSpace(suggestion.CapabilityClass))
                     {
                         sb.AppendLine($"- Suggested capability class: `{suggestion.CapabilityClass}`");
@@ -280,7 +283,8 @@ public sealed class AnalysisReportGenerator
             .Where(AnalysisModelFilters.IsDeveloperFacingAction)
             .Where(action => !DuplicatesConfirmedAction(action, model))
             .Where(action => action.Score >= 0.7)
-            .OrderByDescending(action => action.Score)
+            .OrderBy(action => (int)ActionRisk.GetRiskBand(action))
+            .ThenByDescending(action => action.Score)
             .ThenBy(action => action.SourceService)
             .GroupBy(action => $"{action.SourceService}.{action.MethodName}", StringComparer.OrdinalIgnoreCase)
             .Select(group => group.First())
@@ -311,6 +315,7 @@ public sealed class AnalysisReportGenerator
             sb.AppendLine();
             sb.AppendLine($"- Existing method: `{action.SourceService}.{action.MethodName}`");
             sb.AppendLine($"- Classification: {action.Classification}");
+            sb.AppendLine($"- Risk: {ActionRisk.Describe(ActionRisk.GetRiskBand(action))}");
             sb.AppendLine($"- Mutation likely: {FormatBool(action.IsMutationLikely)}");
             sb.AppendLine($"- Approval recommended: {FormatBool(action.RequiresApproval)}");
             sb.AppendLine($"- Confidence: {action.Score.ToString("0.00", CultureInfo.InvariantCulture)}");
@@ -365,7 +370,8 @@ public sealed class AnalysisReportGenerator
         foreach (var recommendation in model.Recommendations
             .Where(recommendation => IsDeveloperFacingRecommendation(recommendation, model))
             .Where(recommendation => !DuplicatesConfirmedAction(recommendation, model))
-            .OrderByDescending(item => item.Priority)
+            .OrderBy(item => GetRecommendationRiskRank(item, model))
+            .ThenByDescending(item => item.Priority)
             .GroupBy(item => item.Suggestion, StringComparer.OrdinalIgnoreCase)
             .Select(group => group.First())
             .Take(5))
@@ -451,6 +457,31 @@ public sealed class AnalysisReportGenerator
                 (action.IsMutationLikely ||
                  action.RequiresApproval ||
                  action.Classification is ActionClassification.Command or ActionClassification.Workflow)));
+    }
+
+    private static ActionRiskBand GetSuggestionRiskBand(WorkflowSuggestion suggestion, ProjectModel model)
+    {
+        var actions = suggestion.Methods
+            .SelectMany(method => model.Actions
+                .Where(AnalysisModelFilters.IsDeveloperFacingAction)
+                .Where(action =>
+                    string.Equals(action.SourceService, method.Service, StringComparison.OrdinalIgnoreCase) &&
+                    string.Equals(action.MethodName, method.Method, StringComparison.OrdinalIgnoreCase)))
+            .ToList();
+
+        return actions.Count == 0
+            ? ActionRiskBand.ApprovalRequired
+            : actions.Max(ActionRisk.GetRiskBand);
+    }
+
+    private static int GetSuggestionRiskRank(WorkflowSuggestion suggestion, ProjectModel model)
+        => (int)GetSuggestionRiskBand(suggestion, model);
+
+    private static int GetRecommendationRiskRank(RecommendationModel recommendation, ProjectModel model)
+    {
+        var action = model.Actions.FirstOrDefault(action =>
+            string.Equals($"{action.SourceService}.{action.MethodName}", recommendation.TargetName, StringComparison.OrdinalIgnoreCase));
+        return action is null ? (int)ActionRiskBand.ApprovalRequired : (int)ActionRisk.GetRiskBand(action);
     }
 
     private static string NormalizeName(string value)

--- a/src/AgentBlazor.Cli.Analysis/WorkflowSuggestions/WorkflowSuggestionPromptBuilder.cs
+++ b/src/AgentBlazor.Cli.Analysis/WorkflowSuggestions/WorkflowSuggestionPromptBuilder.cs
@@ -24,6 +24,9 @@ public sealed class WorkflowSuggestionPromptBuilder
         sb.AppendLine("- Suggested C# code must use AgentBlazor CapabilityResult and only call listed methods.");
         sb.AppendLine("- Do not invent DTO or entity types in code. If a type is unclear, use comments rather than fake types.");
         sb.AppendLine("- If a listed method has approvalRecommended=true, the suggested [AgentAction] example must include RequiresApproval = true.");
+        sb.AppendLine("- Prefer safe read-only workflows first: show, get, list, find, check, validate, explain, summarize, and status snapshots.");
+        sb.AppendLine("- Avoid auth, password reset, email sending, tenant mutation, message deletion, workflow execution, job execution, database mutation, and permission changes unless no safer workflow exists.");
+        sb.AppendLine("- If you must suggest a mutating or admin workflow, suggest at most one and explain that it needs human approval.");
         sb.AppendLine();
         sb.AppendLine("JSON shape:");
         sb.AppendLine("""
@@ -122,15 +125,15 @@ public sealed class WorkflowSuggestionPromptBuilder
                 .Where(method => method.IsPublic)
                 .Where(method => AnalysisModelFilters.IsDeveloperFacingMethod(method.Name))
                 .Where(method => candidateActions.ContainsKey((service.TypeName, method.Name)))
-                .OrderBy(method => method.Name)
+                .OrderBy(method => (int)ActionRisk.GetRiskBand(candidateActions[(service.TypeName, method.Name)]))
+                .ThenByDescending(method => candidateActions[(service.TypeName, method.Name)].Score)
+                .ThenBy(method => method.Name)
                 .Take(20)
                 .Select(method =>
                 {
                     var action = candidateActions[(service.TypeName, method.Name)];
-                    var approvalRecommended = action.IsMutationLikely ||
-                        action.RequiresApproval ||
-                        action.Classification is ActionClassification.Command or ActionClassification.Workflow;
-                    return $"{method.Name}({string.Join(", ", method.Parameters.Select(parameter => $"{parameter.TypeName} {parameter.Name}"))}) [mutation={approvalRecommended.ToString().ToLowerInvariant()}, approvalRecommended={approvalRecommended.ToString().ToLowerInvariant()}]";
+                    var approvalRecommended = ActionRisk.GetRiskBand(action) is ActionRiskBand.ApprovalRequired or ActionRiskBand.HighRisk;
+                    return $"{method.Name}({string.Join(", ", method.Parameters.Select(parameter => $"{parameter.TypeName} {parameter.Name}"))}) [risk={ActionRisk.Describe(ActionRisk.GetRiskBand(action))}, mutation={action.IsMutationLikely.ToString().ToLowerInvariant()}, approvalRecommended={approvalRecommended.ToString().ToLowerInvariant()}]";
                 })
                 .ToList();
 

--- a/src/AgentBlazor.Cli/PACKAGE_README.md
+++ b/src/AgentBlazor.Cli/PACKAGE_README.md
@@ -11,7 +11,7 @@ dotnet tool install --global AgentBlazor.Cli
 If you prefer a pinned install:
 
 ```bash
-dotnet tool install --global AgentBlazor.Cli --version 0.2.9
+dotnet tool install --global AgentBlazor.Cli --version 0.2.10
 ```
 
 Example:
@@ -40,6 +40,8 @@ Version `0.2.8` hardens solution-scope workflow suggestions when multiple projec
 
 Version `0.2.9` excludes test projects and test asset folders from default solution-scope analysis.
 
+Version `0.2.10` prioritizes safe read-only workflow suggestions, labels suggestion risk, and requires approval for mutating command suggestions.
+
 Reports filter helper/framework noise, show AgentBlazor action adoption, and call out `RequiresApproval = true` guidance for workflow suggestions that reference mutating methods.
 
 The CLI is an advanced path. The default install story is still `dotnet add package AgentBlazor` plus manual runtime wiring.
@@ -48,7 +50,7 @@ Docs:
 
 - Repository: https://github.com/ashpeterson/AgentBlazor
 - Advanced CLI guide: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/advanced/cli.md
-- 0.2.9 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.9.md
+- 0.2.10 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.10.md
 - 0.2.5 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.5.md
 - 0.2.3 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.3.md
 - 0.2.2 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.2.md

--- a/src/AgentBlazor.Cli/Program.cs
+++ b/src/AgentBlazor.Cli/Program.cs
@@ -7,7 +7,7 @@ var version = typeof(ScaffoldCommand).Assembly
     .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
     ?.InformationalVersion
     ?? typeof(ScaffoldCommand).Assembly.GetName().Version?.ToString()
-    ?? "0.2.9";
+    ?? "0.2.10";
 version = version.Split('+', 2)[0];
 
 app.Configure(config =>

--- a/src/AgentBlazor.Cli/README.md
+++ b/src/AgentBlazor.Cli/README.md
@@ -18,6 +18,8 @@ Version `0.2.8` hardens solution-scope workflow suggestions when multiple scanne
 
 Version `0.2.9` excludes test projects and test asset folders from default solution-scope analysis.
 
+Version `0.2.10` prioritizes safe read-only workflow suggestions, labels suggestion risk, and requires approval for mutating command suggestions.
+
 See:
 
 - `docs/advanced/cli.md`

--- a/tests/AgentBlazor.Cli.Analysis.Tests/ActionScorerTests.cs
+++ b/tests/AgentBlazor.Cli.Analysis.Tests/ActionScorerTests.cs
@@ -207,6 +207,18 @@ public class ActionScorerTests
         Assert.Equal(ActionExposureMode.Ignored, badAction.ExposureMode);
     }
 
+    [Fact]
+    public void ToActionModel_RequiresApproval_ForMutatingCommands()
+    {
+        var method = CreateMethod("SendEmailAsync");
+        var score = _scorer.ScoreMethod(method, "EmailService");
+
+        var action = _scorer.ToActionModel(method, CreateService("EmailService"), score);
+
+        Assert.True(action.IsMutationLikely);
+        Assert.True(action.RequiresApproval);
+    }
+
     #endregion
 
     #region Helpers

--- a/tests/AgentBlazor.Cli.Analysis.Tests/Generation/AnalysisReportGeneratorTests.cs
+++ b/tests/AgentBlazor.Cli.Analysis.Tests/Generation/AnalysisReportGeneratorTests.cs
@@ -486,6 +486,114 @@ public sealed class AnalysisReportGeneratorTests : IDisposable
     }
 
     [Fact]
+    public void GenerateMarkdown_PrioritizesSafeStaticCandidates_BeforeHighRiskAdminActions()
+    {
+        var model = CreateModel() with
+        {
+            Actions =
+            [
+                new ActionModel
+                {
+                    Name = "Reset Password",
+                    SourceService = "UserService",
+                    MethodName = "ResetPasswordAsync",
+                    FilePath = "Services/UserService.cs",
+                    Classification = ActionClassification.Workflow,
+                    IsMutationLikely = true,
+                    RequiresApproval = true,
+                    Score = 1,
+                    ExposureMode = ActionExposureMode.Suggested
+                },
+                new ActionModel
+                {
+                    Name = "Get Status Snapshot",
+                    SourceService = "OriginAIClient",
+                    MethodName = "GetStatusSnapshotAsync",
+                    FilePath = "Services/OriginAIClient.cs",
+                    Classification = ActionClassification.Query,
+                    Score = 0.75,
+                    ExposureMode = ActionExposureMode.Suggested
+                }
+            ],
+            Recommendations = []
+        };
+
+        var content = _generator.GenerateMarkdown(model);
+
+        Assert.True(content.IndexOf("### Get Status Snapshot", StringComparison.Ordinal) <
+            content.IndexOf("### Reset Password", StringComparison.Ordinal));
+        Assert.Contains("- Risk: safe read-only", content);
+        Assert.Contains("- Risk: high-risk/admin", content);
+    }
+
+    [Fact]
+    public void GenerateMarkdown_SortsLlmSuggestions_ByRiskBeforeConfidence()
+    {
+        var model = CreateModel() with
+        {
+            Actions =
+            [
+                new ActionModel
+                {
+                    Name = "Reset Password",
+                    SourceService = "UserService",
+                    MethodName = "ResetPasswordAsync",
+                    FilePath = "Services/UserService.cs",
+                    Classification = ActionClassification.Workflow,
+                    IsMutationLikely = true,
+                    RequiresApproval = true,
+                    Score = 1,
+                    ExposureMode = ActionExposureMode.Suggested
+                },
+                new ActionModel
+                {
+                    Name = "Get Status Snapshot",
+                    SourceService = "OriginAIClient",
+                    MethodName = "GetStatusSnapshotAsync",
+                    FilePath = "Services/OriginAIClient.cs",
+                    Classification = ActionClassification.Query,
+                    Score = 0.75,
+                    ExposureMode = ActionExposureMode.Suggested
+                }
+            ]
+        };
+        var suggestions = new WorkflowSuggestionSet
+        {
+            Model = "test-model",
+            Suggestions =
+            [
+                new WorkflowSuggestion
+                {
+                    Name = "Password reset",
+                    Description = "Reset user passwords.",
+                    Confidence = 0.95,
+                    Methods =
+                    [
+                        new WorkflowMethodReference { Service = "UserService", Method = "ResetPasswordAsync" }
+                    ]
+                },
+                new WorkflowSuggestion
+                {
+                    Name = "Status snapshot",
+                    Description = "Show current AI status.",
+                    Confidence = 0.70,
+                    Methods =
+                    [
+                        new WorkflowMethodReference { Service = "OriginAIClient", Method = "GetStatusSnapshotAsync" }
+                    ]
+                }
+            ]
+        };
+
+        var content = _generator.GenerateMarkdown(model, workflowSuggestions: suggestions);
+
+        Assert.True(content.IndexOf("### Status snapshot", StringComparison.Ordinal) <
+            content.IndexOf("### Password reset", StringComparison.Ordinal));
+        Assert.Contains("- Risk: safe read-only", content);
+        Assert.Contains("- Risk: high-risk/admin", content);
+    }
+
+    [Fact]
     public void GenerateMarkdown_DoesNotShowStaticCandidate_WhenEquivalentConfirmedActionExists()
     {
         var model = CreateModel() with

--- a/tests/AgentBlazor.Cli.Analysis.Tests/WorkflowSuggestions/WorkflowSuggestionPromptBuilderTests.cs
+++ b/tests/AgentBlazor.Cli.Analysis.Tests/WorkflowSuggestions/WorkflowSuggestionPromptBuilderTests.cs
@@ -168,6 +168,9 @@ public sealed class WorkflowSuggestionPromptBuilderTests
         Assert.Contains("approvalRecommended=false", prompt);
         Assert.Contains("CreateOrderAsync", prompt);
         Assert.Contains("approvalRecommended=true", prompt);
+        Assert.Contains("risk=safe read-only", prompt);
+        Assert.Contains("risk=approval required", prompt);
+        Assert.Contains("Prefer safe read-only workflows first", prompt);
         Assert.Contains("RequiresApproval = true", prompt);
         Assert.DoesNotContain("ActivityIdHelper", prompt);
         Assert.DoesNotContain("ToString", prompt);


### PR DESCRIPTION
## Summary
- Adds deterministic risk bands for CLI workflow suggestions.
- Prioritizes safe read-only suggestions before approval-gated or high-risk/admin actions.
- Labels suggestion risk in static and LLM report sections.
- Requires approval for mutating command suggestions, fixing cases like SendEmailAsync.
- Updates the LLM prompt to prefer status/list/find/check workflows and avoid admin/mutating workflows unless necessary.
- Bumps package metadata to 0.2.10 and adds release notes.

## Verification
- dotnet test tests/AgentBlazor.Cli.Analysis.Tests/AgentBlazor.Cli.Analysis.Tests.csproj --filter "FullyQualifiedName~ActionScorerTests|FullyQualifiedName~AnalysisReportGeneratorTests|FullyQualifiedName~WorkflowSuggestionPromptBuilderTests" --no-restore -v minimal
- dotnet build src/AgentBlazor.Cli/AgentBlazor.Cli.csproj --no-restore -v minimal
- local dotnet pack/install smoke for AgentBlazor.Cli 0.2.10
- local static analyze smoke verifies safe workflow appears first and approval-gated suggestions are labeled