### PR TITLE
fix(cli): filter internal services from analysis suggestions

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
 
   <!-- Common package metadata for all AgentBlazor packages -->
   <PropertyGroup>
-    <Version>0.2.10</Version>
+    <Version>0.2.11</Version>
     <Authors>Ash Peterson</Authors>
     <Company>AgentBlazor</Company>
     <Copyright>Copyright (c) 2026 Ash Peterson</Copyright>
@@ -16,7 +16,7 @@
     <RepositoryType>git</RepositoryType>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <PackageIcon>icon.png</PackageIcon>
-    <PackageReleaseNotes>v0.2.10: CLI recommendation quality. Prioritizes safe read-only workflows, labels suggestion risk, and requires approval for mutating command suggestions.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.2.11: CLI analyzer quality. Filters internal chat persistence, state store, runner, scheduler, and tenant store services from workflow suggestions and recommended next steps.</PackageReleaseNotes>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <Deterministic>true</Deterministic>

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ dotnet run --project samples/AgentBlazor.Starter/AgentBlazor.Starter.csproj
 
 - [Quickstart](docs/quickstart.md)
 - [CLI v1 announcement](docs/cli-v1-analyze-announcement.md)
+- [0.2.11 release notes](docs/releases/0.2.11.md)
 - [0.2.10 release notes](docs/releases/0.2.10.md)
 - [0.2.9 release notes](docs/releases/0.2.9.md)
 - [0.2.8 release notes](docs/releases/0.2.8.md)

--- a/docs/releases/0.2.11.md
+++ b/docs/releases/0.2.11.md
@@ -1,0 +1,34 @@
+# AgentBlazor 0.2.11 Release Notes
+
+Target package line: `0.2.11` stable.
+
+AgentBlazor 0.2.11 is a CLI analyzer-quality patch for real multi-project Blazor solutions.
+
+## What Changed
+
+- Filters internal chat persistence services from workflow suggestion prompts and report sections.
+- Filters state store, runner, scheduler, and tenant store services from workflow suggestions and recommended next steps.
+- Reuses the same developer-facing filter in the recommendation engine, so excluded actions do not leak back into the final checklist.
+- Keeps the `0.2.10` risk ranking behavior: safe read-only suggestions remain first, and mutating suggestions still receive approval guidance.
+- Updates scaffold test expectations to the current package version.
+
+## Why
+
+Real solution-scope analysis was correctly scanning sibling projects, but it still treated internal infrastructure such as chat message storage, job runners, schedulers, and tenant stores as candidate workflows. Those methods often looked safe or high-confidence to the LLM while being poor first workflows for a developer to expose.
+
+This release tightens the candidate pool so `agentblazor analyze --scan-scope solution` focuses on application workflows rather than implementation plumbing.
+
+## Verification
+
+Run:
+
+```bash
+dotnet tool update --global AgentBlazor.Cli --version 0.2.11
+agentblazor analyze ./MySolution.slnx --host MyBlazorApp --scan-scope solution --output ./analysis.md
+```
+
+Expected result:
+
+- Internal chat/state/runner/scheduler/store services should not appear as top workflow suggestions.
+- Safe read-only domain workflows should still appear before mutating or admin workflows.
+- Recommended next steps should not suggest adding `[AgentAction]` to filtered infrastructure methods.

--- a/src/AgentBlazor.Cli.Analysis/AnalysisModelFilters.cs
+++ b/src/AgentBlazor.Cli.Analysis/AnalysisModelFilters.cs
@@ -31,8 +31,13 @@ public static class AnalysisModelFilters
         "ExceptionHandler",
         "LayoutService",
         "Cache",
+        "Runner",
+        "Scheduler",
+        "StateStore",
+        "TenantStore",
         "TicketStore",
         "DataSourceService",
+        "MessageAssetService",
         "UserProfileState",
         "ValidationService"
     ];
@@ -60,7 +65,17 @@ public static class AnalysisModelFilters
         "/Services/Caching/",
         "\\Services\\Caching\\",
         "/Services/Identity/",
-        "\\Services\\Identity\\"
+        "\\Services\\Identity\\",
+        "/Services/AI/Chat/",
+        "\\Services\\AI\\Chat\\",
+        "/Services/AI/State/",
+        "\\Services\\AI\\State\\",
+        "/Services/AI/Runner/",
+        "\\Services\\AI\\Runner\\",
+        "/Services/AI/Scheduler/",
+        "\\Services\\AI\\Scheduler\\",
+        "/Tenants/",
+        "\\Tenants\\"
     ];
 
     private static readonly string[] UiStateMethodPrefixes =

--- a/src/AgentBlazor.Cli.Analysis/ExistingAppScaffoldApplier.cs
+++ b/src/AgentBlazor.Cli.Analysis/ExistingAppScaffoldApplier.cs
@@ -301,7 +301,7 @@ public sealed class ExistingAppScaffoldApplier
             .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
             ?.InformationalVersion
             ?? typeof(ExistingAppScaffoldApplier).Assembly.GetName().Version?.ToString()
-            ?? "0.2.10";
+            ?? "0.2.11";
 
         return version.Split('+', 2)[0];
     }

--- a/src/AgentBlazor.Cli.Analysis/RecommendationEngine.cs
+++ b/src/AgentBlazor.Cli.Analysis/RecommendationEngine.cs
@@ -84,6 +84,11 @@ public sealed class RecommendationEngine
             }
             else if (action.ExposureMode == ActionExposureMode.Suggested)
             {
+                if (!AnalysisModelFilters.IsDeveloperFacingAction(action))
+                {
+                    continue;
+                }
+
                 // High-scoring discovered actions should become confirmed
                 if (action.Score >= 0.7 && IsHighValueMethod(action.MethodName))
                 {
@@ -109,6 +114,7 @@ public sealed class RecommendationEngine
             .ToHashSet();
 
         var servicesWithHighValueMethods = model.Actions
+            .Where(AnalysisModelFilters.IsDeveloperFacingAction)
             .Where(a => a.ExposureMode == ActionExposureMode.Suggested && a.Score >= 0.7)
             .GroupBy(a => a.SourceService)
             .Where(g => g.Count() >= 2) // At least 2 high-value methods
@@ -148,6 +154,7 @@ public sealed class RecommendationEngine
     {
         // Exclude infrastructure services from coverage calculations
         var relevantActions = model.Actions
+            .Where(AnalysisModelFilters.IsDeveloperFacingAction)
             .Where(a => !IsExcludedService(a.SourceService))
             .Where(a => !IsInfrastructureService(a.SourceService))
             .ToList();

--- a/src/AgentBlazor.Cli/PACKAGE_README.md
+++ b/src/AgentBlazor.Cli/PACKAGE_README.md
@@ -11,7 +11,7 @@ dotnet tool install --global AgentBlazor.Cli
 If you prefer a pinned install:
 
 ```bash
-dotnet tool install --global AgentBlazor.Cli --version 0.2.10
+dotnet tool install --global AgentBlazor.Cli --version 0.2.11
 ```
 
 Example:
@@ -42,6 +42,8 @@ Version `0.2.9` excludes test projects and test asset folders from default solut
 
 Version `0.2.10` prioritizes safe read-only workflow suggestions, labels suggestion risk, and requires approval for mutating command suggestions.
 
+Version `0.2.11` filters internal chat persistence, state store, runner, scheduler, and tenant store services from workflow suggestions and recommended next steps.
+
 Reports filter helper/framework noise, show AgentBlazor action adoption, and call out `RequiresApproval = true` guidance for workflow suggestions that reference mutating methods.
 
 The CLI is an advanced path. The default install story is still `dotnet add package AgentBlazor` plus manual runtime wiring.
@@ -50,6 +52,7 @@ Docs:
 
 - Repository: https://github.com/ashpeterson/AgentBlazor
 - Advanced CLI guide: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/advanced/cli.md
+- 0.2.11 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.11.md
 - 0.2.10 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.10.md
 - 0.2.5 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.5.md
 - 0.2.3 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.3.md

--- a/src/AgentBlazor.Cli/Program.cs
+++ b/src/AgentBlazor.Cli/Program.cs
@@ -7,7 +7,7 @@ var version = typeof(ScaffoldCommand).Assembly
     .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
     ?.InformationalVersion
     ?? typeof(ScaffoldCommand).Assembly.GetName().Version?.ToString()
-    ?? "0.2.10";
+    ?? "0.2.11";
 version = version.Split('+', 2)[0];
 
 app.Configure(config =>

--- a/src/AgentBlazor.Cli/README.md
+++ b/src/AgentBlazor.Cli/README.md
@@ -20,6 +20,8 @@ Version `0.2.9` excludes test projects and test asset folders from default solut
 
 Version `0.2.10` prioritizes safe read-only workflow suggestions, labels suggestion risk, and requires approval for mutating command suggestions.
 
+Version `0.2.11` filters internal chat persistence, state store, runner, scheduler, and tenant store services from workflow suggestions and recommended next steps.
+
 See:
 
 - `docs/advanced/cli.md`

--- a/tests/AgentBlazor.Cli.Analysis.Tests/ExistingAppScaffoldPlannerTests.cs
+++ b/tests/AgentBlazor.Cli.Analysis.Tests/ExistingAppScaffoldPlannerTests.cs
@@ -250,7 +250,7 @@ public sealed class ExistingAppScaffoldPlannerTests : IDisposable
         Assert.Contains("""<PackageReference Include="MudBlazor" />""", projectText, StringComparison.Ordinal);
         Assert.DoesNotContain("PackageReference Include=\"AgentBlazor\" Version=", projectText, StringComparison.Ordinal);
         Assert.DoesNotContain("PackageReference Include=\"MudBlazor\" Version=", projectText, StringComparison.Ordinal);
-        Assert.Contains("""<PackageVersion Include="AgentBlazor" Version="0.2.5" />""", centralPackagesText, StringComparison.Ordinal);
+        Assert.Contains("""<PackageVersion Include="AgentBlazor" Version="0.2.11" />""", centralPackagesText, StringComparison.Ordinal);
         Assert.Contains("""<PackageVersion Include="MudBlazor" Version="9.0.0" />""", centralPackagesText, StringComparison.Ordinal);
     }
 

--- a/tests/AgentBlazor.Cli.Analysis.Tests/Generation/AnalysisReportGeneratorTests.cs
+++ b/tests/AgentBlazor.Cli.Analysis.Tests/Generation/AnalysisReportGeneratorTests.cs
@@ -232,6 +232,51 @@ public sealed class AnalysisReportGeneratorTests : IDisposable
                             IsPublic = true
                         }
                     ]
+                },
+                new ServiceModel
+                {
+                    TypeName = "AIChatMessageAssetService",
+                    FilePath = "Core/Services/AI/Chat/AIChatMessageAssetService.cs",
+                    Methods =
+                    [
+                        new ServiceMethodModel
+                        {
+                            Name = "GetLatestChatIdAsync",
+                            ReturnType = "Task<string?>",
+                            IsPublic = true,
+                            IsAsync = true
+                        }
+                    ]
+                },
+                new ServiceModel
+                {
+                    TypeName = "AIJobRunnerService",
+                    FilePath = "Core/Services/AI/Runner/AIJobRunnerService.cs",
+                    Methods =
+                    [
+                        new ServiceMethodModel
+                        {
+                            Name = "RunNowAsync",
+                            ReturnType = "Task<JobResult>",
+                            IsPublic = true,
+                            IsAsync = true
+                        }
+                    ]
+                },
+                new ServiceModel
+                {
+                    TypeName = "TenantStore",
+                    FilePath = "Tenants/TenantStore.cs",
+                    Methods =
+                    [
+                        new ServiceMethodModel
+                        {
+                            Name = "GetAllAsync",
+                            ReturnType = "Task<IEnumerable<TenantInfo>>",
+                            IsPublic = true,
+                            IsAsync = true
+                        }
+                    ]
                 }
             ],
             Actions =
@@ -266,6 +311,37 @@ public sealed class AnalysisReportGeneratorTests : IDisposable
                     Score = 0.99,
                     ExposureMode = ActionExposureMode.Suggested,
                     Classification = ActionClassification.Workflow
+                },
+                new ActionModel
+                {
+                    Name = "Get Latest Chat ID",
+                    SourceService = "AIChatMessageAssetService",
+                    MethodName = "GetLatestChatIdAsync",
+                    FilePath = "Core/Services/AI/Chat/AIChatMessageAssetService.cs",
+                    Score = 0.99,
+                    ExposureMode = ActionExposureMode.Suggested,
+                    Classification = ActionClassification.Query
+                },
+                new ActionModel
+                {
+                    Name = "Run Now",
+                    SourceService = "AIJobRunnerService",
+                    MethodName = "RunNowAsync",
+                    FilePath = "Core/Services/AI/Runner/AIJobRunnerService.cs",
+                    Score = 0.99,
+                    ExposureMode = ActionExposureMode.Suggested,
+                    Classification = ActionClassification.Workflow,
+                    IsMutationLikely = true
+                },
+                new ActionModel
+                {
+                    Name = "Get All",
+                    SourceService = "TenantStore",
+                    MethodName = "GetAllAsync",
+                    FilePath = "Tenants/TenantStore.cs",
+                    Score = 0.99,
+                    ExposureMode = ActionExposureMode.Suggested,
+                    Classification = ActionClassification.Query
                 }
             ]
         };
@@ -281,6 +357,11 @@ public sealed class AnalysisReportGeneratorTests : IDisposable
         Assert.DoesNotContain("HubClient", content);
         Assert.DoesNotContain("AccountController", content);
         Assert.DoesNotContain("EmailFactory", content);
+        Assert.DoesNotContain("AIChatMessageAssetService", content);
+        Assert.DoesNotContain("GetLatestChatIdAsync", content);
+        Assert.DoesNotContain("AIJobRunnerService", content);
+        Assert.DoesNotContain("RunNowAsync", content);
+        Assert.DoesNotContain("TenantStore", content);
         Assert.Contains("OrderService", content);
         Assert.Contains("FindOrdersAsync", content);
     }

--- a/tests/AgentBlazor.Cli.Analysis.Tests/WorkflowSuggestions/WorkflowSuggestionPromptBuilderTests.cs
+++ b/tests/AgentBlazor.Cli.Analysis.Tests/WorkflowSuggestions/WorkflowSuggestionPromptBuilderTests.cs
@@ -112,6 +112,51 @@ public sealed class WorkflowSuggestionPromptBuilderTests
                 },
                 new ServiceModel
                 {
+                    TypeName = "AIChatMessageAssetService",
+                    FilePath = "Core/Services/AI/Chat/AIChatMessageAssetService.cs",
+                    Methods =
+                    [
+                        new ServiceMethodModel
+                        {
+                            Name = "GetLatestChatIdAsync",
+                            ReturnType = "Task<string?>",
+                            IsPublic = true,
+                            IsAsync = true
+                        }
+                    ]
+                },
+                new ServiceModel
+                {
+                    TypeName = "AIJobRunnerService",
+                    FilePath = "Core/Services/AI/Runner/AIJobRunnerService.cs",
+                    Methods =
+                    [
+                        new ServiceMethodModel
+                        {
+                            Name = "RunNowAsync",
+                            ReturnType = "Task<JobResult>",
+                            IsPublic = true,
+                            IsAsync = true
+                        }
+                    ]
+                },
+                new ServiceModel
+                {
+                    TypeName = "TenantStore",
+                    FilePath = "Tenants/TenantStore.cs",
+                    Methods =
+                    [
+                        new ServiceMethodModel
+                        {
+                            Name = "GetAllAsync",
+                            ReturnType = "Task<IEnumerable<TenantInfo>>",
+                            IsPublic = true,
+                            IsAsync = true
+                        }
+                    ]
+                },
+                new ServiceModel
+                {
                     TypeName = "OrderCapabilities",
                     FilePath = "Workflows/OrderCapabilities.cs",
                     Methods =
@@ -151,6 +196,37 @@ public sealed class WorkflowSuggestionPromptBuilderTests
                 },
                 new ActionModel
                 {
+                    Name = "Get Latest Chat ID",
+                    SourceService = "AIChatMessageAssetService",
+                    MethodName = "GetLatestChatIdAsync",
+                    FilePath = "Core/Services/AI/Chat/AIChatMessageAssetService.cs",
+                    ExposureMode = ActionExposureMode.Suggested,
+                    Classification = ActionClassification.Query,
+                    Score = 0.95
+                },
+                new ActionModel
+                {
+                    Name = "Run Now",
+                    SourceService = "AIJobRunnerService",
+                    MethodName = "RunNowAsync",
+                    FilePath = "Core/Services/AI/Runner/AIJobRunnerService.cs",
+                    ExposureMode = ActionExposureMode.Suggested,
+                    Classification = ActionClassification.Workflow,
+                    IsMutationLikely = true,
+                    Score = 0.95
+                },
+                new ActionModel
+                {
+                    Name = "Get All",
+                    SourceService = "TenantStore",
+                    MethodName = "GetAllAsync",
+                    FilePath = "Tenants/TenantStore.cs",
+                    ExposureMode = ActionExposureMode.Suggested,
+                    Classification = ActionClassification.Query,
+                    Score = 0.95
+                },
+                new ActionModel
+                {
                     Name = "Show Open Orders",
                     SourceService = "OrderCapabilities",
                     MethodName = "ShowOpenOrdersAsync",
@@ -179,6 +255,11 @@ public sealed class WorkflowSuggestionPromptBuilderTests
         Assert.DoesNotContain("DialogServiceHelper", prompt);
         Assert.DoesNotContain("ShowDialogAsync", prompt);
         Assert.DoesNotContain("AccountController", prompt);
+        Assert.DoesNotContain("AIChatMessageAssetService", prompt);
+        Assert.DoesNotContain("GetLatestChatIdAsync", prompt);
+        Assert.DoesNotContain("AIJobRunnerService", prompt);
+        Assert.DoesNotContain("RunNowAsync", prompt);
+        Assert.DoesNotContain("TenantStore", prompt);
         Assert.Contains("OrderCapabilities.ShowOpenOrdersAsync", prompt);
         Assert.DoesNotContain("- OrderCapabilities [", prompt);
     }


### PR DESCRIPTION
## Summary
- filter internal chat persistence, state store, runner, scheduler, and tenant store services out of CLI workflow suggestions
- apply the same developer-facing filter in the recommendation engine so excluded actions do not leak into recommended next steps
- bump package metadata/docs to 0.2.11 and add release notes

## Verification
- dotnet test tests/AgentBlazor.Cli.Analysis.Tests/AgentBlazor.Cli.Analysis.Tests.csproj --no-restore -v minimal
- dotnet build src/AgentBlazor.Cli/AgentBlazor.Cli.csproj --no-restore -v minimal
- manual local pack/install/analyze smoke for AgentBlazor.Cli 0.2.11