### PR TITLE
fix(cli): improve framework analysis quality

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
 
   <!-- Common package metadata for all AgentBlazor packages -->
   <PropertyGroup>
-    <Version>0.2.12</Version>
+    <Version>0.2.13</Version>
     <Authors>Ash Peterson</Authors>
     <Company>AgentBlazor</Company>
     <Copyright>Copyright (c) 2026 Ash Peterson</Copyright>
@@ -16,7 +16,7 @@
     <RepositoryType>git</RepositoryType>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <PackageIcon>icon.png</PackageIcon>
-    <PackageReleaseNotes>v0.2.12: CLI real-project solution-scan quality. Links injected interfaces to implementation services, filters infrastructure/identity/storage/http plumbing, and reports filtered-empty service sections clearly.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.2.13: CLI analyzer quality for framework-style Blazor apps. Explains component-driven routing, filters manager/state/auth/token/http plumbing, and prefers validated LLM workflow suggestions over static action guesses.</PackageReleaseNotes>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <Deterministic>true</Deterministic>

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ dotnet run --project samples/AgentBlazor.Starter/AgentBlazor.Starter.csproj
 
 - [Quickstart](docs/quickstart.md)
 - [CLI v1 announcement](docs/cli-v1-analyze-announcement.md)
+- [0.2.13 release notes](docs/releases/0.2.13.md)
 - [0.2.12 release notes](docs/releases/0.2.12.md)
 - [0.2.11 release notes](docs/releases/0.2.11.md)
 - [0.2.10 release notes](docs/releases/0.2.10.md)

--- a/docs/releases/0.2.13.md
+++ b/docs/releases/0.2.13.md
@@ -1,0 +1,34 @@
+# AgentBlazor 0.2.13 Release Notes
+
+Target package line: `0.2.13` stable.
+
+AgentBlazor 0.2.13 is a CLI analyzer-quality patch for framework-style and component-routed Blazor applications.
+
+## What Changed
+
+- Explains component-driven or framework-managed routing when a scan finds Razor components but no `@page` routes.
+- Filters `*Manager`, state, JWT/security, generic `HttpService`, token, login, passkey, and password-validation plumbing from developer-facing services, LLM prompts, and static recommendations.
+- Keeps explicitly annotated `[AgentAction]` methods visible even when their type or method name would otherwise match a filter.
+- When validated LLM workflow suggestions are available, the recommended next steps now point developers at those suggestions instead of appending lower-quality static `[AgentAction]` guesses.
+- Updates the scaffold central-package-management test expectation to the current package line.
+
+## Why
+
+Large framework-style Blazor apps such as Oqtane can expose many component modules without conventional `@page` routes. The analyzer was technically correct when it reported zero routes, but the report looked broken because it did not explain that component-driven routing was in use.
+
+The same runs also showed that static recommendations could still surface sensitive or low-level plumbing, such as user validation, token generation, managers, state classes, and generic HTTP wrappers. This release tightens the model so the report stays focused on validated workflow suggestions and avoids recommending internals as first agent actions.
+
+## Verification
+
+Run:
+
+```bash
+dotnet tool update --global AgentBlazor.Cli --version 0.2.13
+agentblazor analyze ./MySolution.slnx --host MyBlazorApp --scan-scope solution --output ./analysis.md
+```
+
+Expected result:
+
+- Component-routed apps with no `@page` routes should explain that route-to-action linking is unavailable rather than rendering a bare "no routes" message.
+- Manager, state, auth/token, generic HTTP, and password-validation methods should not appear as workflow suggestions or static action recommendations.
+- Reports with validated LLM workflow suggestions should end with a next step to review those suggestions, not a separate list of static `[AgentAction]` guesses.

--- a/src/AgentBlazor.Cli.Analysis/AnalysisModelFilters.cs
+++ b/src/AgentBlazor.Cli.Analysis/AnalysisModelFilters.cs
@@ -20,6 +20,7 @@ public static class AnalysisModelFilters
         "DbContextFactory",
         "Factory",
         "Builder",
+        "Manager",
         "Helper",
         "Utility",
         "Provider",
@@ -42,9 +43,11 @@ public static class AnalysisModelFilters
         "HubService",
         "HubConnection",
         "HttpClientService",
+        "HttpService",
         "ExceptionHandler",
         "ExecutionContext",
         "LayoutService",
+        "State",
         "Cache",
         "Runner",
         "Scheduler",
@@ -57,6 +60,7 @@ public static class AnalysisModelFilters
         "DataSourceService",
         "FakeData",
         "FakeStorage",
+        "Jwt",
         "JwtService",
         "MessageAssetService",
         "EmbeddingService",
@@ -101,6 +105,8 @@ public static class AnalysisModelFilters
         "\\Services\\Identity\\",
         "/Identity/",
         "\\Identity\\",
+        "/Security/",
+        "\\Security\\",
         "/Services/AI/Chat/",
         "\\Services\\AI\\Chat\\",
         "/Services/AI/State/",
@@ -150,9 +156,11 @@ public static class AnalysisModelFilters
     [
         "Dispose",
         "DisposeAsync",
+        "Clone",
         "Equals",
         "GetHashCode",
         "GetType",
+        "Hydrate",
         "Load",
         "LoadAsync",
         "OnPropertyChanged",
@@ -161,6 +169,21 @@ public static class AnalysisModelFilters
         "ToString",
         "IsHighlighted",
         "DescribeSignals"
+    ];
+
+    private static readonly string[] SensitiveMethodNameFragments =
+    [
+        "AccessToken",
+        "GenerateToken",
+        "GetToken",
+        "LoginUser",
+        "LogoutUser",
+        "Passkey",
+        "PersonalAccessToken",
+        "RefreshToken",
+        "ValidatePassword",
+        "ValidateUser",
+        "VerifyTwoFactor"
     ];
 
     public static bool IsDeveloperFacingService(ServiceModel service, ProjectModel? model = null)
@@ -202,6 +225,11 @@ public static class AnalysisModelFilters
             return false;
         }
 
+        if (SensitiveMethodNameFragments.Any(fragment => action.MethodName.Contains(fragment, StringComparison.OrdinalIgnoreCase)))
+        {
+            return false;
+        }
+
         if (InfrastructureServiceNameFragments.Any(fragment => action.SourceService.Contains(fragment, StringComparison.OrdinalIgnoreCase)))
         {
             return false;
@@ -223,6 +251,11 @@ public static class AnalysisModelFilters
 
         if (UiStateMethodNames.Contains(methodName, StringComparer.OrdinalIgnoreCase) ||
             UiStateMethodNames.Contains(normalized, StringComparer.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (SensitiveMethodNameFragments.Any(fragment => normalized.Contains(fragment, StringComparison.OrdinalIgnoreCase)))
         {
             return false;
         }

--- a/src/AgentBlazor.Cli.Analysis/ExistingAppScaffoldApplier.cs
+++ b/src/AgentBlazor.Cli.Analysis/ExistingAppScaffoldApplier.cs
@@ -301,7 +301,7 @@ public sealed class ExistingAppScaffoldApplier
             .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
             ?.InformationalVersion
             ?? typeof(ExistingAppScaffoldApplier).Assembly.GetName().Version?.ToString()
-            ?? "0.2.12";
+            ?? "0.2.13";
 
         return version.Split('+', 2)[0];
     }

--- a/src/AgentBlazor.Cli.Analysis/Generation/AnalysisReportGenerator.cs
+++ b/src/AgentBlazor.Cli.Analysis/Generation/AnalysisReportGenerator.cs
@@ -53,7 +53,7 @@ public sealed class AnalysisReportGenerator
             WriteReadiness(sb, readiness);
         }
 
-        WriteNextSteps(sb, model, readiness);
+        WriteNextSteps(sb, model, readiness, workflowSuggestions);
         return sb.ToString();
     }
 
@@ -92,7 +92,15 @@ public sealed class AnalysisReportGenerator
         sb.AppendLine();
         if (model.Routes.Count == 0)
         {
-            sb.AppendLine("No Razor routes were discovered.");
+            if (model.Components.Count > 0)
+            {
+                sb.AppendLine($"No Razor `@page` routes were discovered. {model.Components.Count} Razor components were discovered, so this app likely uses component-driven or framework-managed routing; route-to-action linking is unavailable for those components.");
+            }
+            else
+            {
+                sb.AppendLine("No Razor routes were discovered.");
+            }
+
             sb.AppendLine();
             return;
         }
@@ -355,7 +363,11 @@ public sealed class AnalysisReportGenerator
         sb.AppendLine();
     }
 
-    private static void WriteNextSteps(StringBuilder sb, ProjectModel model, InstallReadinessReport? readiness)
+    private static void WriteNextSteps(
+        StringBuilder sb,
+        ProjectModel model,
+        InstallReadinessReport? readiness,
+        WorkflowSuggestionSet? workflowSuggestions)
     {
         sb.AppendLine("## Recommended Next Steps");
         sb.AppendLine();
@@ -370,17 +382,29 @@ public sealed class AnalysisReportGenerator
             }
         }
 
-        foreach (var recommendation in model.Recommendations
-            .Where(recommendation => IsDeveloperFacingRecommendation(recommendation, model))
-            .Where(recommendation => !DuplicatesConfirmedAction(recommendation, model))
-            .OrderBy(item => GetRecommendationRiskRank(item, model))
-            .ThenByDescending(item => item.Priority)
-            .GroupBy(item => item.Suggestion, StringComparer.OrdinalIgnoreCase)
-            .Select(group => group.First())
-            .Take(5))
+        var includeStaticActionRecommendations = workflowSuggestions is null ||
+            workflowSuggestions.Suggestions.Count == 0;
+
+        if (!includeStaticActionRecommendations && workflowSuggestions?.Suggestions.Count > 0)
         {
             hasSteps = true;
-            sb.AppendLine($"- {recommendation.Suggestion}");
+            sb.AppendLine("- Review the validated workflow suggestions above and choose which ones should become explicit `[AgentAction]` capabilities.");
+        }
+
+        if (includeStaticActionRecommendations)
+        {
+            foreach (var recommendation in model.Recommendations
+                .Where(recommendation => IsDeveloperFacingRecommendation(recommendation, model))
+                .Where(recommendation => !DuplicatesConfirmedAction(recommendation, model))
+                .OrderBy(item => GetRecommendationRiskRank(item, model))
+                .ThenByDescending(item => item.Priority)
+                .GroupBy(item => item.Suggestion, StringComparer.OrdinalIgnoreCase)
+                .Select(group => group.First())
+                .Take(5))
+            {
+                hasSteps = true;
+                sb.AppendLine($"- {recommendation.Suggestion}");
+            }
         }
 
         if (!hasSteps)

--- a/src/AgentBlazor.Cli/PACKAGE_README.md
+++ b/src/AgentBlazor.Cli/PACKAGE_README.md
@@ -11,7 +11,7 @@ dotnet tool install --global AgentBlazor.Cli
 If you prefer a pinned install:
 
 ```bash
-dotnet tool install --global AgentBlazor.Cli --version 0.2.12
+dotnet tool install --global AgentBlazor.Cli --version 0.2.13
 ```
 
 Example:
@@ -46,6 +46,8 @@ Version `0.2.11` filters internal chat persistence, state store, runner, schedul
 
 Version `0.2.12` improves real-project solution scans by linking injected interfaces to implementation services, filtering infrastructure/identity/storage/http plumbing, and clearly reporting when all discovered services were filtered out.
 
+Version `0.2.13` improves framework-style Blazor app analysis by explaining component-driven routing, filtering manager/state/auth/token/http plumbing, and using validated LLM workflow suggestions instead of appending static action guesses when LLM suggestions are available.
+
 Reports filter helper/framework noise, show AgentBlazor action adoption, and call out `RequiresApproval = true` guidance for workflow suggestions that reference mutating methods.
 
 The CLI is an advanced path. The default install story is still `dotnet add package AgentBlazor` plus manual runtime wiring.
@@ -54,6 +56,7 @@ Docs:
 
 - Repository: https://github.com/ashpeterson/AgentBlazor
 - Advanced CLI guide: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/advanced/cli.md
+- 0.2.13 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.13.md
 - 0.2.12 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.12.md
 - 0.2.11 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.11.md
 - 0.2.10 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.10.md

--- a/src/AgentBlazor.Cli/Program.cs
+++ b/src/AgentBlazor.Cli/Program.cs
@@ -7,7 +7,7 @@ var version = typeof(ScaffoldCommand).Assembly
     .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
     ?.InformationalVersion
     ?? typeof(ScaffoldCommand).Assembly.GetName().Version?.ToString()
-    ?? "0.2.12";
+    ?? "0.2.13";
 version = version.Split('+', 2)[0];
 
 app.Configure(config =>

--- a/src/AgentBlazor.Cli/README.md
+++ b/src/AgentBlazor.Cli/README.md
@@ -24,6 +24,8 @@ Version `0.2.11` filters internal chat persistence, state store, runner, schedul
 
 Version `0.2.12` improves real-project solution scans by linking injected interfaces to implementation services, filtering infrastructure/identity/storage/http plumbing, and clearly reporting when all discovered services were filtered out.
 
+Version `0.2.13` improves framework-style Blazor app analysis by explaining component-driven routing, filtering manager/state/auth/token/http plumbing, and using validated LLM workflow suggestions instead of appending static action guesses when LLM suggestions are available.
+
 See:
 
 - `docs/advanced/cli.md`

--- a/tests/AgentBlazor.Cli.Analysis.Tests/ExistingAppScaffoldPlannerTests.cs
+++ b/tests/AgentBlazor.Cli.Analysis.Tests/ExistingAppScaffoldPlannerTests.cs
@@ -250,7 +250,7 @@ public sealed class ExistingAppScaffoldPlannerTests : IDisposable
         Assert.Contains("""<PackageReference Include="MudBlazor" />""", projectText, StringComparison.Ordinal);
         Assert.DoesNotContain("PackageReference Include=\"AgentBlazor\" Version=", projectText, StringComparison.Ordinal);
         Assert.DoesNotContain("PackageReference Include=\"MudBlazor\" Version=", projectText, StringComparison.Ordinal);
-        Assert.Contains("""<PackageVersion Include="AgentBlazor" Version="0.2.11" />""", centralPackagesText, StringComparison.Ordinal);
+        Assert.Contains("""<PackageVersion Include="AgentBlazor" Version="0.2.13" />""", centralPackagesText, StringComparison.Ordinal);
         Assert.Contains("""<PackageVersion Include="MudBlazor" Version="9.0.0" />""", centralPackagesText, StringComparison.Ordinal);
     }
 

--- a/tests/AgentBlazor.Cli.Analysis.Tests/Generation/AnalysisReportGeneratorTests.cs
+++ b/tests/AgentBlazor.Cli.Analysis.Tests/Generation/AnalysisReportGeneratorTests.cs
@@ -400,6 +400,21 @@ public sealed class AnalysisReportGeneratorTests : IDisposable
                 },
                 new ServiceModel
                 {
+                    TypeName = "HttpService",
+                    FilePath = "Blazor.Modules/Core/Services/HttpService.cs",
+                    Methods =
+                    [
+                        new ServiceMethodModel
+                        {
+                            Name = "GetAccessToken",
+                            ReturnType = "Task<string>",
+                            IsPublic = true,
+                            IsAsync = true
+                        }
+                    ]
+                },
+                new ServiceModel
+                {
                     TypeName = "EFCoreConfigurationValidator",
                     FilePath = "Shared/Features/EFCore/Configuration/EFCoreConfigurationValidator.cs",
                     Methods =
@@ -438,6 +453,71 @@ public sealed class AnalysisReportGeneratorTests : IDisposable
                             Name = "CreateInstance",
                             ReturnType = "ServerExecutionContext",
                             IsPublic = true
+                        }
+                    ]
+                },
+                new ServiceModel
+                {
+                    TypeName = "UserManager",
+                    FilePath = "Oqtane.Server/Managers/UserManager.cs",
+                    Methods =
+                    [
+                        new ServiceMethodModel
+                        {
+                            Name = "ValidateUser",
+                            ReturnType = "Task<UserValidateResult>",
+                            IsPublic = true,
+                            IsAsync = true
+                        }
+                    ]
+                },
+                new ServiceModel
+                {
+                    TypeName = "JwtManager",
+                    FilePath = "Oqtane.Server/Security/JwtManager.cs",
+                    Methods =
+                    [
+                        new ServiceMethodModel
+                        {
+                            Name = "GenerateToken",
+                            ReturnType = "string",
+                            IsPublic = true
+                        }
+                    ]
+                },
+                new ServiceModel
+                {
+                    TypeName = "PageState",
+                    FilePath = "Oqtane.Client/UI/PageState.cs",
+                    Methods =
+                    [
+                        new ServiceMethodModel
+                        {
+                            Name = "Clone",
+                            ReturnType = "PageState",
+                            IsPublic = true
+                        }
+                    ]
+                },
+                new ServiceModel
+                {
+                    TypeName = "UserService",
+                    FilePath = "Services/UserService.cs",
+                    Methods =
+                    [
+                        new ServiceMethodModel
+                        {
+                            Name = "ValidateUserAsync",
+                            ReturnType = "Task<UserValidateResult>",
+                            IsPublic = true,
+                            IsAsync = true
+                        },
+                        new ServiceMethodModel
+                        {
+                            Name = "GetTokenAsync",
+                            ReturnType = "Task<string>",
+                            IsPublic = true,
+                            IsAsync = true
                         }
                     ]
                 }
@@ -590,6 +670,16 @@ public sealed class AnalysisReportGeneratorTests : IDisposable
                 },
                 new ActionModel
                 {
+                    Name = "Get Access Token",
+                    SourceService = "HttpService",
+                    MethodName = "GetAccessToken",
+                    FilePath = "Blazor.Modules/Core/Services/HttpService.cs",
+                    Score = 0.99,
+                    ExposureMode = ActionExposureMode.Suggested,
+                    Classification = ActionClassification.Query
+                },
+                new ActionModel
+                {
                     Name = "Validate",
                     SourceService = "EFCoreConfigurationValidator",
                     MethodName = "Validate",
@@ -618,6 +708,56 @@ public sealed class AnalysisReportGeneratorTests : IDisposable
                     Score = 0.99,
                     ExposureMode = ActionExposureMode.Suggested,
                     Classification = ActionClassification.Command
+                },
+                new ActionModel
+                {
+                    Name = "Validate User",
+                    SourceService = "UserManager",
+                    MethodName = "ValidateUser",
+                    FilePath = "Oqtane.Server/Managers/UserManager.cs",
+                    Score = 0.99,
+                    ExposureMode = ActionExposureMode.Suggested,
+                    Classification = ActionClassification.Validation
+                },
+                new ActionModel
+                {
+                    Name = "Generate Token",
+                    SourceService = "JwtManager",
+                    MethodName = "GenerateToken",
+                    FilePath = "Oqtane.Server/Security/JwtManager.cs",
+                    Score = 0.99,
+                    ExposureMode = ActionExposureMode.Suggested,
+                    Classification = ActionClassification.Export
+                },
+                new ActionModel
+                {
+                    Name = "Clone",
+                    SourceService = "PageState",
+                    MethodName = "Clone",
+                    FilePath = "Oqtane.Client/UI/PageState.cs",
+                    Score = 0.99,
+                    ExposureMode = ActionExposureMode.Suggested,
+                    Classification = ActionClassification.Command
+                },
+                new ActionModel
+                {
+                    Name = "Validate User",
+                    SourceService = "UserService",
+                    MethodName = "ValidateUserAsync",
+                    FilePath = "Services/UserService.cs",
+                    Score = 0.99,
+                    ExposureMode = ActionExposureMode.Suggested,
+                    Classification = ActionClassification.Validation
+                },
+                new ActionModel
+                {
+                    Name = "Get Token",
+                    SourceService = "UserService",
+                    MethodName = "GetTokenAsync",
+                    FilePath = "Services/UserService.cs",
+                    Score = 0.99,
+                    ExposureMode = ActionExposureMode.Suggested,
+                    Classification = ActionClassification.Query
                 }
             ]
         };
@@ -652,14 +792,51 @@ public sealed class AnalysisReportGeneratorTests : IDisposable
         Assert.DoesNotContain("Find By Email", content);
         Assert.DoesNotContain("AuthorizedHttpClientService", content);
         Assert.DoesNotContain("Get From A P I", content);
+        Assert.DoesNotContain("HttpService", content);
+        Assert.DoesNotContain("Get Access Token", content);
         Assert.DoesNotContain("EFCoreConfigurationValidator", content);
         Assert.DoesNotContain("ValidateOptionsResult", content);
         Assert.DoesNotContain("NotificationHubService", content);
         Assert.DoesNotContain("Send Notification", content);
         Assert.DoesNotContain("ServerExecutionContext", content);
         Assert.DoesNotContain("Create Instance", content);
+        Assert.DoesNotContain("UserManager", content);
+        Assert.DoesNotContain("Validate User", content);
+        Assert.DoesNotContain("JwtManager", content);
+        Assert.DoesNotContain("Generate Token", content);
+        Assert.DoesNotContain("PageState", content);
+        Assert.DoesNotContain("ValidateUserAsync", content);
+        Assert.DoesNotContain("Validate User", content);
+        Assert.DoesNotContain("GetTokenAsync", content);
+        Assert.DoesNotContain("Get Token", content);
         Assert.Contains("OrderService", content);
         Assert.Contains("FindOrdersAsync", content);
+    }
+
+    [Fact]
+    public void GenerateMarkdown_ExplainsComponentDrivenRouting_WhenComponentsHaveNoPageRoutes()
+    {
+        var model = CreateModel() with
+        {
+            Routes = [],
+            Pages = [],
+            Components =
+            [
+                new ComponentModel
+                {
+                    Id = "admin_users_index",
+                    Name = "Index",
+                    FilePath = "Modules/Admin/Users/Index.razor",
+                    IsPage = false
+                }
+            ]
+        };
+
+        var content = _generator.GenerateMarkdown(model);
+
+        Assert.Contains("No Razor `@page` routes were discovered.", content);
+        Assert.Contains("component-driven or framework-managed routing", content);
+        Assert.Contains("route-to-action linking is unavailable", content);
     }
 
     [Fact]
@@ -692,6 +869,46 @@ public sealed class AnalysisReportGeneratorTests : IDisposable
 
         Assert.Contains("No developer-facing service-like classes were discovered.", content);
         Assert.DoesNotContain("### `AuthorizedHttpClientService`", content);
+    }
+
+    [Fact]
+    public void GenerateMarkdown_UsesValidatedWorkflowSuggestions_InsteadOfStaticActionRecommendations()
+    {
+        var model = CreateModel() with
+        {
+            Recommendations =
+            [
+                new RecommendationModel
+                {
+                    Type = RecommendationType.AddAgentAction,
+                    TargetName = "OrderService.FindOrdersAsync",
+                    Suggestion = """Add `[AgentAction("Find Orders")]`""",
+                    Priority = 0.9
+                }
+            ]
+        };
+        var suggestions = new WorkflowSuggestionSet
+        {
+            Model = "test-model",
+            Suggestions =
+            [
+                new WorkflowSuggestion
+                {
+                    Name = "Find orders",
+                    Description = "Find open orders.",
+                    Methods =
+                    [
+                        new WorkflowMethodReference { Service = "OrderService", Method = "FindOrdersAsync" }
+                    ],
+                    Confidence = 0.9
+                }
+            ]
+        };
+
+        var content = _generator.GenerateMarkdown(model, workflowSuggestions: suggestions);
+
+        Assert.Contains("Review the validated workflow suggestions above", content);
+        Assert.DoesNotContain("""Add `[AgentAction("Find Orders")]`""", content);
     }
 
     [Fact]

--- a/tests/AgentBlazor.Cli.Analysis.Tests/WorkflowSuggestions/WorkflowSuggestionParserTests.cs
+++ b/tests/AgentBlazor.Cli.Analysis.Tests/WorkflowSuggestions/WorkflowSuggestionParserTests.cs
@@ -155,10 +155,10 @@ public sealed class WorkflowSuggestionParserTests
             [
                 new ActionModel
                 {
-                    Name = "Get Access Token",
-                    SourceService = "AccessTokenService",
-                    MethodName = "GetAccessTokenAsync",
-                    FilePath = "Services/AccessTokenService.cs",
+                    Name = "Get Products",
+                    SourceService = "ProductCatalogService",
+                    MethodName = "GetProductsAsync",
+                    FilePath = "Services/ProductCatalogService.cs",
                     ExposureMode = ActionExposureMode.Suggested,
                     Classification = ActionClassification.Query,
                     Score = 0.8
@@ -172,7 +172,7 @@ public sealed class WorkflowSuggestionParserTests
               "name": "Role assignment",
               "description": "Assign roles to users.",
               "methods": [
-                { "service": "AccessTokenService", "method": "GetAccessTokenAsync" }
+                { "service": "ProductCatalogService", "method": "GetProductsAsync" }
               ],
               "confidence": 0.82
             }
@@ -185,7 +185,7 @@ public sealed class WorkflowSuggestionParserTests
         Assert.Empty(result.Suggestions);
         var rejected = Assert.Single(result.Rejected);
         Assert.Contains("do not align", rejected.Reason);
-        Assert.Contains("AccessTokenService.GetAccessTokenAsync", rejected.Reason);
+        Assert.Contains("ProductCatalogService.GetProductsAsync", rejected.Reason);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- explains component-driven/framework-managed routing when no @page routes are found
- filters manager, state, auth/token, generic HTTP and password-validation plumbing from analyzer output and prompts
- prefers validated LLM workflow suggestions over static action guesses in recommended next steps
- bumps package metadata/docs to 0.2.13

## Verification
- dotnet test tests/AgentBlazor.Cli.Analysis.Tests/AgentBlazor.Cli.Analysis.Tests.csproj --no-restore -v minimal
- dotnet build src/AgentBlazor.Cli/AgentBlazor.Cli.csproj --no-restore -v minimal
- local pack/install smoke for AgentBlazor.Cli 0.2.13, then analyze tests/cli-targets/realistic-blazor-app/RealisticBlazorApp.csproj --static-only
- real LLM scans: Oqtane 44 services / 233 actions / 5 accepted / 0 rejected with component-routing explanation; eShop 6 services / 51 actions / 5 accepted / 0 rejected; Practical 6 services / 40 actions / 5 accepted / 0 rejected
