### PR TITLE
feat(cli): prioritize analysis report output

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
 
   <!-- Common package metadata for all AgentBlazor packages -->
   <PropertyGroup>
-    <Version>0.2.13</Version>
+    <Version>0.2.14</Version>
     <Authors>Ash Peterson</Authors>
     <Company>AgentBlazor</Company>
     <Copyright>Copyright (c) 2026 Ash Peterson</Copyright>
@@ -16,7 +16,7 @@
     <RepositoryType>git</RepositoryType>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <PackageIcon>icon.png</PackageIcon>
-    <PackageReleaseNotes>v0.2.13: CLI analyzer quality for framework-style Blazor apps. Explains component-driven routing, filters manager/state/auth/token/http plumbing, and prefers validated LLM workflow suggestions over static action guesses.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.2.14: CLI report prioritisation. Puts top workflow recommendations and install blockers first, adds route quality notes, and classifies service inventory by likely agent fit.</PackageReleaseNotes>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <Deterministic>true</Deterministic>

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ dotnet run --project samples/AgentBlazor.Starter/AgentBlazor.Starter.csproj
 
 - [Quickstart](docs/quickstart.md)
 - [CLI v1 announcement](docs/cli-v1-analyze-announcement.md)
+- [0.2.14 release notes](docs/releases/0.2.14.md)
 - [0.2.13 release notes](docs/releases/0.2.13.md)
 - [0.2.12 release notes](docs/releases/0.2.12.md)
 - [0.2.11 release notes](docs/releases/0.2.11.md)

--- a/docs/advanced/cli.md
+++ b/docs/advanced/cli.md
@@ -47,15 +47,20 @@ Readiness checks still apply to the host project only, because `Program.cs`, she
 
 The report includes:
 
+- top workflow recommendations first, so you do not have to read the full service inventory to find useful candidates
+- compact install blockers before the detailed readiness table
 - discovered routes and pages
+- route-to-action mapping notes when dynamic or multi-tenant routing means most routes cannot be linked to candidate actions
 - existing `[AgentCapability]` / `[AgentAction]` methods
-- developer-facing services and public methods, with framework/helper noise filtered out
+- developer-facing services and public methods, with framework/helper noise filtered out and remaining services classified by likely agent fit
 - LLM workflow suggestions validated against the static analysis model
 - approval guidance for suggestions that reference mutating methods
 - install-readiness checks
 - recommended next steps
 
 The summary uses "AgentBlazor action adoption" to show how many actions are already confirmed with AgentBlazor attributes versus how many candidate actions were discovered but are not exposed yet.
+
+The service inventory is deliberately a supporting section. Start with Top Recommendations and Install Blockers, then use Service Inventory to audit the scanned model. Service classifications are guidance only: data-access, admin/sensitive, and integration surfaces should usually be wrapped in narrower business capabilities rather than exposed directly.
 
 Run static analysis only when you do not want an LLM call:
 

--- a/docs/releases/0.2.14.md
+++ b/docs/releases/0.2.14.md
@@ -1,0 +1,40 @@
+# AgentBlazor 0.2.14 Release Notes
+
+Target package line: `0.2.14` stable.
+
+AgentBlazor 0.2.14 is a CLI analyzer report-usability patch. It does not change the scanner's broad model collection; it changes how `agentblazor analyze` guides developers through the results.
+
+## What's Changed
+
+- Adds a `Top Recommendations` section near the top of analysis reports, before routes and the detailed service inventory.
+- Adds a compact `Install Blockers` section before the full install-readiness table.
+- Adds route quality notes when most routes cannot be linked to candidate actions, which is common in dynamic, component-composed, and multi-tenant Blazor apps.
+- Moves the full service dump into `Service Inventory` so it reads as supporting audit detail rather than the primary output.
+- Classifies services by likely agent fit: business/read-only, operational workflow, integration/messaging, data access, admin/sensitive, and needs review.
+- Keeps validated LLM workflow suggestions as the primary signal when available, while retaining static candidates for `--static-only` runs.
+
+## Why This Matters
+
+Large real Blazor solutions can expose dozens of services and hundreds of public methods. The analyzer already had enough signal, but the report made developers read too much raw inventory before seeing what to do.
+
+This release makes the report more action-oriented:
+
+- Start with the top workflow candidates.
+- Fix install blockers.
+- Use service inventory to audit and refine, not as the first decision surface.
+- Treat data-access and admin/sensitive services as surfaces to wrap in narrower business capabilities rather than expose directly.
+
+## Verify
+
+```bash
+dotnet tool update --global AgentBlazor.Cli --version 0.2.14
+agentblazor --version
+agentblazor analyze ./MySolution.slnx --host MyBlazorApp --scan-scope solution --output ./analysis.md
+```
+
+Expected:
+
+- `agentblazor --version` reports `0.2.14`.
+- The report starts with `Summary`, `Top Recommendations`, and `Install Blockers`.
+- `Service Inventory` appears after workflow/readiness sections.
+- Service inventory includes classification counts and per-service agent-fit guidance.

--- a/src/AgentBlazor.Cli.Analysis/ExistingAppScaffoldApplier.cs
+++ b/src/AgentBlazor.Cli.Analysis/ExistingAppScaffoldApplier.cs
@@ -301,7 +301,7 @@ public sealed class ExistingAppScaffoldApplier
             .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
             ?.InformationalVersion
             ?? typeof(ExistingAppScaffoldApplier).Assembly.GetName().Version?.ToString()
-            ?? "0.2.13";
+            ?? "0.2.14";
 
         return version.Split('+', 2)[0];
     }

--- a/src/AgentBlazor.Cli.Analysis/Generation/AnalysisReportGenerator.cs
+++ b/src/AgentBlazor.Cli.Analysis/Generation/AnalysisReportGenerator.cs
@@ -44,15 +44,17 @@ public sealed class AnalysisReportGenerator
         sb.AppendLine();
 
         WriteSummary(sb, model, readiness);
+        WriteTopRecommendations(sb, model, workflowSuggestions);
+        WriteInstallBlockers(sb, readiness);
         WriteRoutes(sb, model);
         WriteCapabilities(sb, model);
-        WriteServices(sb, model);
         WriteWorkflowSuggestions(sb, model, workflowSuggestions);
         if (readiness is not null)
         {
             WriteReadiness(sb, readiness);
         }
 
+        WriteServices(sb, model);
         WriteNextSteps(sb, model, readiness, workflowSuggestions);
         return sb.ToString();
     }
@@ -81,6 +83,93 @@ public sealed class AnalysisReportGenerator
         if (adoptionTotal > 0)
         {
             sb.AppendLine($"- AgentBlazor action adoption: {confirmedCount} confirmed, {discoveredCount} candidate actions not yet exposed");
+        }
+
+        sb.AppendLine();
+    }
+
+    private static void WriteTopRecommendations(
+        StringBuilder sb,
+        ProjectModel model,
+        WorkflowSuggestionSet? workflowSuggestions)
+    {
+        sb.AppendLine("## Top Recommendations");
+        sb.AppendLine();
+
+        if (workflowSuggestions?.Suggestions.Count > 0)
+        {
+            sb.AppendLine("These are the highest-signal workflow candidates. Start here before reading the full service inventory.");
+            sb.AppendLine();
+            sb.AppendLine("| Workflow | Risk | Confidence | Existing methods | Why it matters |");
+            sb.AppendLine("| --- | --- | --- | --- | --- |");
+            foreach (var suggestion in workflowSuggestions.Suggestions
+                .OrderBy(suggestion => GetSuggestionRiskRank(suggestion, model))
+                .ThenByDescending(suggestion => suggestion.Confidence)
+                .Take(5))
+            {
+                var methods = suggestion.Methods.Count == 0
+                    ? "-"
+                    : string.Join("<br>", suggestion.Methods.Select(method => $"`{EscapeTableCell(method.Service)}.{EscapeTableCell(method.Method)}`"));
+                var reasoning = string.IsNullOrWhiteSpace(suggestion.Reasoning)
+                    ? suggestion.Description
+                    : suggestion.Reasoning;
+                sb.AppendLine($"| {EscapeTableCell(suggestion.Name)} | {ActionRisk.Describe(GetSuggestionRiskBand(suggestion, model))} | {suggestion.Confidence.ToString("0.00", CultureInfo.InvariantCulture)} | {methods} | {EscapeTableCell(TrimForTable(reasoning, 180))} |");
+            }
+
+            sb.AppendLine();
+            return;
+        }
+
+        var candidates = GetStaticWorkflowCandidates(model, take: 5);
+        if (candidates.Count == 0)
+        {
+            sb.AppendLine("No high-confidence workflow candidates were discovered yet.");
+            sb.AppendLine();
+            return;
+        }
+
+        sb.AppendLine("LLM workflow suggestions were not requested. These are the highest-confidence static candidates.");
+        sb.AppendLine();
+        sb.AppendLine("| Candidate | Risk | Confidence | Existing method | Why it matters |");
+        sb.AppendLine("| --- | --- | --- | --- | --- |");
+        foreach (var action in candidates)
+        {
+            var reasoning = string.IsNullOrWhiteSpace(action.Summary)
+                ? action.Classification.ToString()
+                : action.Summary;
+            sb.AppendLine($"| {EscapeTableCell(action.Name)} | {ActionRisk.Describe(ActionRisk.GetRiskBand(action))} | {action.Score.ToString("0.00", CultureInfo.InvariantCulture)} | `{EscapeTableCell(action.SourceService)}.{EscapeTableCell(action.MethodName)}` | {EscapeTableCell(TrimForTable(reasoning, 180))} |");
+        }
+
+        sb.AppendLine();
+    }
+
+    private static void WriteInstallBlockers(StringBuilder sb, InstallReadinessReport? readiness)
+    {
+        if (readiness is null)
+        {
+            return;
+        }
+
+        sb.AppendLine("## Install Blockers");
+        sb.AppendLine();
+
+        var blockers = readiness.Checks
+            .Where(check => check.Status != InstallReadinessStatus.Pass)
+            .ToList();
+        if (blockers.Count == 0)
+        {
+            sb.AppendLine("No install blockers were found.");
+            sb.AppendLine();
+            return;
+        }
+
+        sb.AppendLine($"Fix these {blockers.Count} setup item(s) before wiring generated workflows into the app.");
+        sb.AppendLine();
+        sb.AppendLine("| Status | Check | Fix |");
+        sb.AppendLine("| --- | --- | --- |");
+        foreach (var check in blockers)
+        {
+            sb.AppendLine($"| {check.Status} | {EscapeTableCell(check.Title)} | {EscapeTableCell(check.SuggestedFix ?? check.Message)} |");
         }
 
         sb.AppendLine();
@@ -125,6 +214,19 @@ public sealed class AnalysisReportGenerator
             sb.AppendLine($"| `{EscapeTableCell(route.Template)}` | `{EscapeTableCell(route.ComponentName)}` | `{EscapeTableCell(route.ComponentFile)}` | {actions} |");
         }
 
+        var linkedRouteCount = model.Pages
+            .Where(page => page.SuggestedActions.Any(actionId => model.Actions.Any(action =>
+                action.Id == actionId &&
+                AnalysisModelFilters.IsDeveloperFacingAction(action))))
+            .Select(page => page.Route)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Count();
+        if (model.Routes.Count > 5 && linkedRouteCount * 2 < model.Routes.Count)
+        {
+            sb.AppendLine();
+            sb.AppendLine($"> Route quality note: only {linkedRouteCount} of {model.Routes.Count} route(s) mapped to candidate actions. This can be normal for dynamic, multi-tenant, or component-composed apps; use the workflow recommendations above as the primary signal.");
+        }
+
         sb.AppendLine();
     }
 
@@ -159,7 +261,7 @@ public sealed class AnalysisReportGenerator
 
     private static void WriteServices(StringBuilder sb, ProjectModel model)
     {
-        sb.AppendLine("## Services");
+        sb.AppendLine("## Service Inventory");
         sb.AppendLine();
         var developerFacingServices = model.Services
             .Where(service => AnalysisModelFilters.IsDeveloperFacingService(service, model))
@@ -173,12 +275,31 @@ public sealed class AnalysisReportGenerator
             return;
         }
 
+        var classifications = developerFacingServices
+            .Select(service => ClassifyService(service, model))
+            .ToList();
+        sb.AppendLine($"Detailed inventory for {developerFacingServices.Count} service-like classes. Use this section to audit the model; use Top Recommendations for what to build first.");
+        sb.AppendLine();
+        sb.AppendLine("| Classification | Count | Guidance |");
+        sb.AppendLine("| --- | ---: | --- |");
+        foreach (var group in classifications
+            .GroupBy(classification => classification.Category)
+            .OrderBy(group => GetServiceCategoryRank(group.Key)))
+        {
+            sb.AppendLine($"| {ServiceCategoryLabel(group.Key)} | {group.Count()} | {EscapeTableCell(ServiceCategoryGuidance(group.Key))} |");
+        }
+
+        sb.AppendLine();
+
         foreach (var service in developerFacingServices)
         {
+            var classification = ClassifyService(service, model);
             sb.AppendLine($"### `{service.TypeName}`");
             sb.AppendLine();
             sb.AppendLine($"- Lifetime: {service.Lifetime}");
             sb.AppendLine($"- File: `{service.FilePath}`");
+            sb.AppendLine($"- Classification: {ServiceCategoryLabel(classification.Category)}");
+            sb.AppendLine($"- Agent fit: {classification.AgentFit}");
             if (service.Methods.Count == 0)
             {
                 sb.AppendLine("- Public methods: none discovered");
@@ -289,18 +410,7 @@ public sealed class AnalysisReportGenerator
             return;
         }
 
-        var candidates = model.Actions
-            .Where(action => action.ExposureMode == ActionExposureMode.Suggested)
-            .Where(AnalysisModelFilters.IsDeveloperFacingAction)
-            .Where(action => !DuplicatesConfirmedAction(action, model))
-            .Where(action => action.Score >= 0.7)
-            .OrderBy(action => (int)ActionRisk.GetRiskBand(action))
-            .ThenByDescending(action => action.Score)
-            .ThenBy(action => action.SourceService)
-            .GroupBy(action => $"{action.SourceService}.{action.MethodName}", StringComparer.OrdinalIgnoreCase)
-            .Select(group => group.First())
-            .Take(10)
-            .ToList();
+        var candidates = GetStaticWorkflowCandidates(model, take: 10);
         var duplicateCandidateNames = candidates
             .GroupBy(action => NormalizeName(action.Name))
             .Where(group => group.Count() > 1)
@@ -428,6 +538,109 @@ public sealed class AnalysisReportGenerator
         => value.Replace("\\", "\\\\", StringComparison.Ordinal)
             .Replace("\"", "\\\"", StringComparison.Ordinal);
 
+    private static string TrimForTable(string value, int maxLength)
+    {
+        var normalized = value.ReplaceLineEndings(" ").Trim();
+        return normalized.Length <= maxLength
+            ? normalized
+            : string.Concat(normalized.AsSpan(0, maxLength - 3), "...");
+    }
+
+    private static IReadOnlyList<ActionModel> GetStaticWorkflowCandidates(ProjectModel model, int take)
+    {
+        return model.Actions
+            .Where(action => action.ExposureMode == ActionExposureMode.Suggested)
+            .Where(AnalysisModelFilters.IsDeveloperFacingAction)
+            .Where(action => !DuplicatesConfirmedAction(action, model))
+            .Where(action => action.Score >= 0.7)
+            .OrderBy(action => (int)ActionRisk.GetRiskBand(action))
+            .ThenByDescending(action => action.Score)
+            .ThenBy(action => action.SourceService)
+            .GroupBy(action => $"{action.SourceService}.{action.MethodName}", StringComparer.OrdinalIgnoreCase)
+            .Select(group => group.First())
+            .Take(take)
+            .ToList();
+    }
+
+    private static ServiceClassification ClassifyService(ServiceModel service, ProjectModel model)
+    {
+        var name = service.TypeName;
+        var path = service.FilePath;
+        var methods = service.Methods.Select(method => method.Name).ToList();
+        var actions = model.Actions
+            .Where(action => string.Equals(action.SourceService, service.TypeName, StringComparison.OrdinalIgnoreCase))
+            .Where(AnalysisModelFilters.IsDeveloperFacingAction)
+            .ToList();
+
+        if (ContainsAny(name, "Permission", "Password", "User", "Setup", "Cookie", "Auth", "Tenant") ||
+            ContainsAny(path, "\\Permissions\\", "/Permissions/", "\\Users\\", "/Users/", "\\Setup\\", "/Setup/", "\\Cookies\\", "/Cookies/") ||
+            methods.Any(method => ContainsAny(method, "ResetPassword", "SendPasswordReset", "AddPermission", "CheckPermission", "AddTenant", "CreateSystemUser", "DeleteCookie")))
+        {
+            return new ServiceClassification(ServiceCategory.AdminOrSensitive, "Use cautiously; likely needs explicit approval policy and tenant/user context before exposing.");
+        }
+
+        if (ContainsAny(name, "Mongo", "Database", "Sql", "Db", "Repository", "Store", "Transaction") ||
+            ContainsAny(path, "\\MongoDb\\", "/MongoDb/", "\\Data\\", "/Data/"))
+        {
+            return new ServiceClassification(ServiceCategory.DataAccess, "Supporting data access surface; usually wrap it in a narrower business capability.");
+        }
+
+        if (ContainsAny(name, "Email", "Message", "Notification", "Chat", "Client", "Upload", "File", "Link"))
+        {
+            return new ServiceClassification(ServiceCategory.IntegrationOrMessaging, "Useful integration surface, but review side effects and external delivery before exposing.");
+        }
+
+        if (actions.Any(action => ActionRisk.GetRiskBand(action) is ActionRiskBand.HighRisk or ActionRiskBand.ApprovalRequired) ||
+            methods.Any(method => ContainsAny(method, "Submit", "Promote", "Upload", "Save", "Add", "Remove", "Delete", "Update", "Create", "Run", "Execute")))
+        {
+            return new ServiceClassification(ServiceCategory.OperationalWorkflow, "Potential workflow candidate; prefer explicit approval for mutating operations.");
+        }
+
+        if (actions.Any(action => action.Classification is ActionClassification.Query or ActionClassification.Validation or ActionClassification.Export) ||
+            methods.Any(method => ContainsAny(method, "Get", "Find", "List", "Check", "Validate", "Generate", "Translate")))
+        {
+            return new ServiceClassification(ServiceCategory.BusinessReadOnly, "Good candidate for a first read-only agent workflow if the data is safe to show.");
+        }
+
+        return new ServiceClassification(ServiceCategory.Unknown, "Review manually; the analyzer found public methods but could not infer a strong workflow role.");
+    }
+
+    private static bool ContainsAny(string value, params string[] fragments)
+        => fragments.Any(fragment => value.Contains(fragment, StringComparison.OrdinalIgnoreCase));
+
+    private static string ServiceCategoryLabel(ServiceCategory category)
+        => category switch
+        {
+            ServiceCategory.BusinessReadOnly => "Business/read-only",
+            ServiceCategory.OperationalWorkflow => "Operational workflow",
+            ServiceCategory.IntegrationOrMessaging => "Integration/messaging",
+            ServiceCategory.DataAccess => "Data access",
+            ServiceCategory.AdminOrSensitive => "Admin/sensitive",
+            _ => "Needs review"
+        };
+
+    private static string ServiceCategoryGuidance(ServiceCategory category)
+        => category switch
+        {
+            ServiceCategory.BusinessReadOnly => "Best starting point for first agent actions.",
+            ServiceCategory.OperationalWorkflow => "Candidate workflow surface; check mutation and approval requirements.",
+            ServiceCategory.IntegrationOrMessaging => "Useful, but external effects or delivery need policy review.",
+            ServiceCategory.DataAccess => "Prefer wrapping in business capabilities rather than exposing directly.",
+            ServiceCategory.AdminOrSensitive => "Do not expose directly without explicit approval, auth, and tenant policy.",
+            _ => "Inspect manually before exposing."
+        };
+
+    private static int GetServiceCategoryRank(ServiceCategory category)
+        => category switch
+        {
+            ServiceCategory.BusinessReadOnly => 0,
+            ServiceCategory.OperationalWorkflow => 1,
+            ServiceCategory.IntegrationOrMessaging => 2,
+            ServiceCategory.DataAccess => 3,
+            ServiceCategory.AdminOrSensitive => 4,
+            _ => 5
+        };
+
     private static bool DuplicatesConfirmedAction(RecommendationModel recommendation, ProjectModel model)
     {
         if (recommendation.Type is not RecommendationType.AddAgentAction)
@@ -528,4 +741,16 @@ public sealed class AnalysisReportGenerator
 
         return sb.ToString();
     }
+}
+
+internal sealed record ServiceClassification(ServiceCategory Category, string AgentFit);
+
+internal enum ServiceCategory
+{
+    BusinessReadOnly,
+    OperationalWorkflow,
+    IntegrationOrMessaging,
+    DataAccess,
+    AdminOrSensitive,
+    Unknown
 }

--- a/src/AgentBlazor.Cli/PACKAGE_README.md
+++ b/src/AgentBlazor.Cli/PACKAGE_README.md
@@ -11,7 +11,7 @@ dotnet tool install --global AgentBlazor.Cli
 If you prefer a pinned install:
 
 ```bash
-dotnet tool install --global AgentBlazor.Cli --version 0.2.13
+dotnet tool install --global AgentBlazor.Cli --version 0.2.14
 ```
 
 Example:
@@ -48,7 +48,9 @@ Version `0.2.12` improves real-project solution scans by linking injected interf
 
 Version `0.2.13` improves framework-style Blazor app analysis by explaining component-driven routing, filtering manager/state/auth/token/http plumbing, and using validated LLM workflow suggestions instead of appending static action guesses when LLM suggestions are available.
 
-Reports filter helper/framework noise, show AgentBlazor action adoption, and call out `RequiresApproval = true` guidance for workflow suggestions that reference mutating methods.
+Version `0.2.14` improves report usability by putting top workflow recommendations and install blockers before the detailed inventory, adding route quality notes, and classifying services by likely agent fit.
+
+Reports put top workflow recommendations and install blockers before the detailed inventory, filter helper/framework noise, classify remaining services by likely agent fit, show AgentBlazor action adoption, and call out `RequiresApproval = true` guidance for workflow suggestions that reference mutating methods.
 
 The CLI is an advanced path. The default install story is still `dotnet add package AgentBlazor` plus manual runtime wiring.
 
@@ -56,6 +58,7 @@ Docs:
 
 - Repository: https://github.com/ashpeterson/AgentBlazor
 - Advanced CLI guide: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/advanced/cli.md
+- 0.2.14 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.14.md
 - 0.2.13 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.13.md
 - 0.2.12 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.12.md
 - 0.2.11 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.11.md

--- a/src/AgentBlazor.Cli/Program.cs
+++ b/src/AgentBlazor.Cli/Program.cs
@@ -7,7 +7,7 @@ var version = typeof(ScaffoldCommand).Assembly
     .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
     ?.InformationalVersion
     ?? typeof(ScaffoldCommand).Assembly.GetName().Version?.ToString()
-    ?? "0.2.13";
+    ?? "0.2.14";
 version = version.Split('+', 2)[0];
 
 app.Configure(config =>

--- a/src/AgentBlazor.Cli/README.md
+++ b/src/AgentBlazor.Cli/README.md
@@ -26,6 +26,10 @@ Version `0.2.12` improves real-project solution scans by linking injected interf
 
 Version `0.2.13` improves framework-style Blazor app analysis by explaining component-driven routing, filtering manager/state/auth/token/http plumbing, and using validated LLM workflow suggestions instead of appending static action guesses when LLM suggestions are available.
 
+Version `0.2.14` improves report usability by putting top workflow recommendations and install blockers before the detailed inventory, adding route quality notes, and classifying services by likely agent fit.
+
+Current reports put top workflow recommendations and install blockers before the detailed inventory. The service inventory is classified by agent fit so data-access, admin/sensitive, integration, and workflow surfaces are easier to review without treating every public service as an equal first action candidate.
+
 See:
 
 - `docs/advanced/cli.md`

--- a/tests/AgentBlazor.Cli.Analysis.Tests/ExistingAppScaffoldPlannerTests.cs
+++ b/tests/AgentBlazor.Cli.Analysis.Tests/ExistingAppScaffoldPlannerTests.cs
@@ -250,7 +250,7 @@ public sealed class ExistingAppScaffoldPlannerTests : IDisposable
         Assert.Contains("""<PackageReference Include="MudBlazor" />""", projectText, StringComparison.Ordinal);
         Assert.DoesNotContain("PackageReference Include=\"AgentBlazor\" Version=", projectText, StringComparison.Ordinal);
         Assert.DoesNotContain("PackageReference Include=\"MudBlazor\" Version=", projectText, StringComparison.Ordinal);
-        Assert.Contains("""<PackageVersion Include="AgentBlazor" Version="0.2.13" />""", centralPackagesText, StringComparison.Ordinal);
+        Assert.Contains("""<PackageVersion Include="AgentBlazor" Version="0.2.14" />""", centralPackagesText, StringComparison.Ordinal);
         Assert.Contains("""<PackageVersion Include="MudBlazor" Version="9.0.0" />""", centralPackagesText, StringComparison.Ordinal);
     }
 

--- a/tests/AgentBlazor.Cli.Analysis.Tests/Generation/AnalysisReportGeneratorTests.cs
+++ b/tests/AgentBlazor.Cli.Analysis.Tests/Generation/AnalysisReportGeneratorTests.cs
@@ -125,6 +125,227 @@ public sealed class AnalysisReportGeneratorTests : IDisposable
     }
 
     [Fact]
+    public void GenerateMarkdown_PutsPrioritizedGuidance_BeforeDetailedInventory()
+    {
+        var model = CreateModel();
+        var suggestions = new WorkflowSuggestionSet
+        {
+            Model = "test-model",
+            Suggestions =
+            [
+                new WorkflowSuggestion
+                {
+                    Name = "Find orders",
+                    Description = "Find open orders.",
+                    Methods =
+                    [
+                        new WorkflowMethodReference { Service = "OrderService", Method = "FindOrdersAsync" }
+                    ],
+                    Reasoning = "The orders page has a safe lookup method.",
+                    Confidence = 0.9
+                }
+            ]
+        };
+
+        var content = _generator.GenerateMarkdown(model, workflowSuggestions: suggestions);
+
+        Assert.True(content.IndexOf("## Top Recommendations", StringComparison.Ordinal) <
+            content.IndexOf("## Routes And Pages", StringComparison.Ordinal));
+        Assert.True(content.IndexOf("## Workflow Suggestions", StringComparison.Ordinal) <
+            content.IndexOf("## Service Inventory", StringComparison.Ordinal));
+        Assert.Contains("| Find orders | safe read-only | 0.90 | `OrderService.FindOrdersAsync` |", content);
+    }
+
+    [Fact]
+    public void GenerateMarkdown_IncludesCompactInstallBlockers_BeforeDetailedReadiness()
+    {
+        var readiness = new InstallReadinessReport
+        {
+            HostProjectName = "TestApp",
+            HostProjectPath = "/tmp/TestApp/TestApp.csproj",
+            HostShape = new HostShapeAssessment { Title = "Standard Blazor Web App" },
+            Checks =
+            [
+                new InstallReadinessCheck
+                {
+                    Id = "package-references",
+                    Title = "Package references",
+                    Status = InstallReadinessStatus.Missing,
+                    Message = "The host project does not reference AgentBlazor yet.",
+                    SuggestedFix = "Add the AgentBlazor package."
+                },
+                new InstallReadinessCheck
+                {
+                    Id = "mud-services",
+                    Title = "MudBlazor service registration",
+                    Status = InstallReadinessStatus.Pass,
+                    Message = "Found AddMudServices()."
+                }
+            ]
+        };
+
+        var content = _generator.GenerateMarkdown(CreateModel(), readiness);
+
+        Assert.True(content.IndexOf("## Install Blockers", StringComparison.Ordinal) <
+            content.IndexOf("## Routes And Pages", StringComparison.Ordinal));
+        Assert.True(content.IndexOf("## Install Blockers", StringComparison.Ordinal) <
+            content.IndexOf("## Install Readiness", StringComparison.Ordinal));
+        Assert.Contains("| Missing | Package references | Add the AgentBlazor package. |", content);
+        Assert.DoesNotContain("| Pass | MudBlazor service registration | Found AddMudServices(). |", content[..content.IndexOf("## Routes And Pages", StringComparison.Ordinal)]);
+    }
+
+    [Fact]
+    public void GenerateMarkdown_WarnsWhenMostRoutesDoNotMapToActions()
+    {
+        var model = CreateModel() with
+        {
+            Routes =
+            [
+                .. Enumerable.Range(1, 8).Select(index => new RouteModel
+                {
+                    Template = $"/page-{index}",
+                    ComponentName = $"Page{index}",
+                    ComponentFile = $"Pages/Page{index}.razor"
+                })
+            ],
+            Pages =
+            [
+                new PageModel
+                {
+                    Route = "/page-1",
+                    ComponentName = "Page1",
+                    SuggestedActions = ["order_service.find_orders"]
+                }
+            ],
+            Actions =
+            [
+                new ActionModel
+                {
+                    Id = "order_service.find_orders",
+                    Name = "Find Orders",
+                    SourceService = "OrderService",
+                    MethodName = "FindOrdersAsync",
+                    FilePath = "Services/OrderService.cs",
+                    Classification = ActionClassification.Query,
+                    Score = 0.92,
+                    ExposureMode = ActionExposureMode.Suggested
+                }
+            ]
+        };
+
+        var content = _generator.GenerateMarkdown(model);
+
+        Assert.Contains("Route quality note: only 1 of 8 route(s) mapped to candidate actions", content);
+        Assert.Contains("dynamic, multi-tenant, or component-composed apps", content);
+    }
+
+    [Fact]
+    public void GenerateMarkdown_ClassifiesServiceInventory_ByAgentFit()
+    {
+        var model = CreateModel() with
+        {
+            Services =
+            [
+                .. CreateModel().Services,
+                new ServiceModel
+                {
+                    TypeName = "MongoService",
+                    FilePath = "Services/MongoDb/MongoService.cs",
+                    Methods =
+                    [
+                        new ServiceMethodModel
+                        {
+                            Name = "AggregateAsync",
+                            ReturnType = "Task<List<T>>",
+                            IsPublic = true,
+                            IsAsync = true
+                        }
+                    ]
+                },
+                new ServiceModel
+                {
+                    TypeName = "PermissionsService",
+                    FilePath = "Services/Permissions/PermissionsService.cs",
+                    Methods =
+                    [
+                        new ServiceMethodModel
+                        {
+                            Name = "AddPermission",
+                            ReturnType = "Task",
+                            IsPublic = true,
+                            IsAsync = true
+                        }
+                    ]
+                },
+                new ServiceModel
+                {
+                    TypeName = "EmailService",
+                    FilePath = "Services/Email/EmailService.cs",
+                    Methods =
+                    [
+                        new ServiceMethodModel
+                        {
+                            Name = "SendEmailAsync",
+                            ReturnType = "Task",
+                            IsPublic = true,
+                            IsAsync = true
+                        }
+                    ]
+                }
+            ],
+            Actions =
+            [
+                .. CreateModel().Actions,
+                new ActionModel
+                {
+                    Name = "Aggregate",
+                    SourceService = "MongoService",
+                    MethodName = "AggregateAsync",
+                    FilePath = "Services/MongoDb/MongoService.cs",
+                    Classification = ActionClassification.Query,
+                    Score = 0.8,
+                    ExposureMode = ActionExposureMode.Suggested
+                },
+                new ActionModel
+                {
+                    Name = "Add Permission",
+                    SourceService = "PermissionsService",
+                    MethodName = "AddPermission",
+                    FilePath = "Services/Permissions/PermissionsService.cs",
+                    Classification = ActionClassification.Command,
+                    IsMutationLikely = true,
+                    Score = 0.8,
+                    ExposureMode = ActionExposureMode.Suggested
+                },
+                new ActionModel
+                {
+                    Name = "Send Email",
+                    SourceService = "EmailService",
+                    MethodName = "SendEmailAsync",
+                    FilePath = "Services/Email/EmailService.cs",
+                    Classification = ActionClassification.Command,
+                    IsMutationLikely = true,
+                    Score = 0.8,
+                    ExposureMode = ActionExposureMode.Suggested
+                }
+            ]
+        };
+
+        var content = _generator.GenerateMarkdown(model);
+
+        Assert.Contains("| Business/read-only | 1 | Best starting point for first agent actions. |", content);
+        Assert.Contains("| Integration/messaging | 1 | Useful, but external effects or delivery need policy review. |", content);
+        Assert.Contains("| Data access | 1 | Prefer wrapping in business capabilities rather than exposing directly. |", content);
+        Assert.Contains("| Admin/sensitive | 1 | Do not expose directly without explicit approval, auth, and tenant policy. |", content);
+        Assert.Contains("### `MongoService`", content);
+        Assert.Contains("- Classification: Data access", content);
+        Assert.Contains("### `PermissionsService`", content);
+        Assert.Contains("- Classification: Admin/sensitive", content);
+        Assert.Contains("### `EmailService`", content);
+        Assert.Contains("- Classification: Integration/messaging", content);
+    }
+
+    [Fact]
     public void GenerateMarkdown_FiltersFrameworkServicesAndUiStateActions_FromDeveloperFacingSections()
     {
         var model = CreateModel() with


### PR DESCRIPTION
## Summary
- adds Top Recommendations and compact Install Blockers ahead of the detailed analyzer inventory
- adds route quality notes for dynamic/multi-tenant apps with low route-to-action mapping
- moves the detailed service dump to Service Inventory and classifies services by likely agent fit
- bumps package metadata/docs to 0.2.14

## Verification
- dotnet test tests/AgentBlazor.Cli.Analysis.Tests/AgentBlazor.Cli.Analysis.Tests.csproj --no-restore -v minimal
- dotnet build src/AgentBlazor.Cli/AgentBlazor.Cli.csproj --no-restore -v minimal
- local static analyze smoke against tests/cli-targets/realistic-blazor-app
- real LLM scan against Oqtane: report starts with top recommendations/install blockers, explains component-driven routing, and groups 44 services by classification
