### PR TITLE
feat(cli): frame map suggestions as map layers

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
 
   <!-- Common package metadata for all AgentBlazor packages -->
   <PropertyGroup>
-    <Version>0.2.14</Version>
+    <Version>0.2.15</Version>
     <Authors>Ash Peterson</Authors>
     <Company>AgentBlazor</Company>
     <Copyright>Copyright (c) 2026 Ash Peterson</Copyright>
@@ -16,7 +16,7 @@
     <RepositoryType>git</RepositoryType>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <PackageIcon>icon.png</PackageIcon>
-    <PackageReleaseNotes>v0.2.14: CLI report prioritisation. Puts top workflow recommendations and install blockers first, adds route quality notes, and classifies service inventory by likely agent fit.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.2.15: CLI map-layer suggestion framing. Guides LLM workflow suggestions toward map-layer workflows for map, marker, geo chart, ESG, supplier, and asset geography services, and normalizes generic validated map suggestions into map-layer report output.</PackageReleaseNotes>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <Deterministic>true</Deterministic>

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ dotnet run --project samples/AgentBlazor.Starter/AgentBlazor.Starter.csproj
 
 - [Quickstart](docs/quickstart.md)
 - [CLI v1 announcement](docs/cli-v1-analyze-announcement.md)
+- [0.2.15 release notes](docs/releases/0.2.15.md)
 - [0.2.14 release notes](docs/releases/0.2.14.md)
 - [0.2.13 release notes](docs/releases/0.2.13.md)
 - [0.2.12 release notes](docs/releases/0.2.12.md)

--- a/docs/releases/0.2.15.md
+++ b/docs/releases/0.2.15.md
@@ -1,0 +1,36 @@
+# AgentBlazor 0.2.15 Release Notes
+
+Target package line: `0.2.15` stable.
+
+AgentBlazor 0.2.15 is a CLI analyzer report-quality patch for map-heavy Blazor applications.
+
+## What's Changed
+
+- Guides LLM workflow suggestions to name map, marker, geo chart, ESG, supplier, and asset geography workflows as map-layer workflows rather than generic data fetches.
+- Normalizes validated generic map suggestions in report output, so suggestions like `Get Asset Markers` become `Show Asset Markers Map Layer`.
+- Preserves non-map read suggestions unchanged, so ordinary service workflows are not over-framed as map UI.
+- Keeps hallucination filtering in place before applying domain framing; only suggestions that reference real static-analysis methods are rewritten.
+
+## Why This Matters
+
+In multi-tenant and component-composed Blazor apps, the important user workflow can be a UI layer rather than a raw service method. A method named `GetAssetMarkersAsync` is not just a data fetch if it feeds a map surface.
+
+This release makes reports more useful for those apps:
+
+- Map-related recommendations should describe the visible layer users interact with.
+- Read-only geographic workflows remain good first AgentBlazor candidates.
+- The service inventory still exists for audit detail, but top recommendations should better match the app's actual UX.
+
+## Verify
+
+```bash
+dotnet tool update --global AgentBlazor.Cli --version 0.2.15
+agentblazor --version
+agentblazor analyze ./MySolution.slnx --host MyBlazorApp --scan-scope solution --output ./analysis.md
+```
+
+Expected:
+
+- `agentblazor --version` reports `0.2.15`.
+- Map, marker, geo chart, ESG, supplier, and asset geography suggestions are framed as map-layer workflows where applicable.
+- Non-map read-only suggestions keep their normal workflow names.

--- a/src/AgentBlazor.Cli.Analysis/ExistingAppScaffoldApplier.cs
+++ b/src/AgentBlazor.Cli.Analysis/ExistingAppScaffoldApplier.cs
@@ -301,7 +301,7 @@ public sealed class ExistingAppScaffoldApplier
             .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
             ?.InformationalVersion
             ?? typeof(ExistingAppScaffoldApplier).Assembly.GetName().Version?.ToString()
-            ?? "0.2.14";
+            ?? "0.2.15";
 
         return version.Split('+', 2)[0];
     }

--- a/src/AgentBlazor.Cli.Analysis/WorkflowSuggestions/WorkflowSuggestionParser.cs
+++ b/src/AgentBlazor.Cli.Analysis/WorkflowSuggestions/WorkflowSuggestionParser.cs
@@ -86,7 +86,7 @@ public sealed class WorkflowSuggestionParser
                 continue;
             }
 
-            suggestions.Add(SanitizeSuggestionCode(suggestion));
+            suggestions.Add(ContextualizeSuggestion(SanitizeSuggestionCode(suggestion), model));
         }
 
         return new WorkflowSuggestionSet
@@ -122,6 +122,152 @@ public sealed class WorkflowSuggestionParser
             ? suggestion
             : suggestion with { Code = string.Empty };
     }
+
+    private static WorkflowSuggestion ContextualizeSuggestion(WorkflowSuggestion suggestion, ProjectModel model)
+    {
+        var mapMethods = suggestion.Methods
+            .Select(method => new
+            {
+                Reference = method,
+                Service = model.Services.FirstOrDefault(service =>
+                    string.Equals(service.TypeName, method.Service, StringComparison.OrdinalIgnoreCase))
+            })
+            .Where(item => item.Service is not null && IsMapLayerSurface(item.Service, item.Reference.Method))
+            .ToList();
+
+        if (mapMethods.Count == 0)
+        {
+            return suggestion;
+        }
+
+        var primary = mapMethods[0];
+        var subject = BuildMapLayerSubject(primary.Reference.Method, primary.Service!.TypeName);
+        var name = $"Show {subject} Map Layer";
+        var description = $"Shows {subject.ToLowerInvariant()} as a map layer so users can inspect the spatial view directly.";
+        var reasoning = string.IsNullOrWhiteSpace(suggestion.Reasoning)
+            ? $"The referenced {primary.Service.TypeName}.{primary.Reference.Method} method belongs to a map/geography surface, so the workflow should be framed as a map layer rather than a raw data fetch."
+            : suggestion.Reasoning + " The referenced service is map/geography-oriented, so this is best framed as a map layer workflow.";
+
+        return suggestion with
+        {
+            Name = IsGenericReadName(suggestion.Name) ? name : suggestion.Name,
+            Description = IsGenericReadDescription(suggestion.Description) ? description : suggestion.Description,
+            Reasoning = reasoning,
+            CapabilityClass = IsGenericCapabilityClass(suggestion.CapabilityClass)
+                ? ToIdentifier(name) + "Capability"
+                : suggestion.CapabilityClass
+        };
+    }
+
+    private static bool IsMapLayerSurface(ServiceModel service, string methodName)
+    {
+        return ContainsAny(service.TypeName, "Map", "Marker", "Geo", "Chart") ||
+            ContainsAny(service.FilePath, "/Maps/", "\\Maps\\", "/Geo", "\\Geo") ||
+            ContainsAny(methodName, "Marker", "Geometry", "CountryESG", "CountryRating", "Supplier");
+    }
+
+    private static string BuildMapLayerSubject(string methodName, string serviceName)
+    {
+        var normalized = StripKnownSuffix(methodName, "Async");
+        normalized = StripKnownPrefix(normalized, "Get");
+        normalized = StripKnownPrefix(normalized, "List");
+        normalized = StripKnownPrefix(normalized, "Find");
+        normalized = StripKnownPrefix(normalized, "Fetch");
+        normalized = StripKnownPrefix(normalized, "Show");
+
+        if (string.IsNullOrWhiteSpace(normalized))
+        {
+            normalized = StripKnownSuffix(serviceName, "Service");
+        }
+
+        return string.Join(' ', MergeKnownAcronyms(SplitIdentifier(normalized)).Select(FormatDomainWord));
+    }
+
+    private static string FormatDomainWord(string word)
+        => word switch
+        {
+            "esg" => "ESG",
+            "geo" => "Geo",
+            "ai" => "AI",
+            "ui" => "UI",
+            _ => char.ToUpperInvariant(word[0]) + word[1..]
+        };
+
+    private static bool IsGenericReadName(string value)
+    {
+        var normalized = value.Trim();
+        return normalized.StartsWith("Get ", StringComparison.OrdinalIgnoreCase) ||
+            normalized.StartsWith("List ", StringComparison.OrdinalIgnoreCase) ||
+            normalized.StartsWith("Fetch ", StringComparison.OrdinalIgnoreCase) ||
+            normalized.StartsWith("Retrieve ", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsGenericReadDescription(string value)
+        => string.IsNullOrWhiteSpace(value) ||
+            value.Contains("retrieve", StringComparison.OrdinalIgnoreCase) ||
+            value.Contains("fetch", StringComparison.OrdinalIgnoreCase) ||
+            value.Contains("get ", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsGenericCapabilityClass(string value)
+        => string.IsNullOrWhiteSpace(value) ||
+            value.StartsWith("Get", StringComparison.OrdinalIgnoreCase) ||
+            value.StartsWith("List", StringComparison.OrdinalIgnoreCase) ||
+            value.StartsWith("Fetch", StringComparison.OrdinalIgnoreCase);
+
+    private static string ToIdentifier(string value)
+    {
+        var words = MergeKnownAcronyms(SplitIdentifier(value));
+        return string.Concat(words.Select(FormatDomainWord));
+    }
+
+    private static IReadOnlyList<string> MergeKnownAcronyms(IReadOnlyList<string> words)
+    {
+        var merged = new List<string>();
+        for (var i = 0; i < words.Count; i++)
+        {
+            if (i + 2 < words.Count &&
+                words[i] == "e" &&
+                words[i + 1] == "s" &&
+                words[i + 2] == "g")
+            {
+                merged.Add("esg");
+                i += 2;
+                continue;
+            }
+
+            if (i + 1 < words.Count &&
+                words[i] == "a" &&
+                words[i + 1] == "i")
+            {
+                merged.Add("ai");
+                i++;
+                continue;
+            }
+
+            if (i + 1 < words.Count &&
+                words[i] == "u" &&
+                words[i + 1] == "i")
+            {
+                merged.Add("ui");
+                i++;
+                continue;
+            }
+
+            merged.Add(words[i]);
+        }
+
+        return merged;
+    }
+
+    private static string StripKnownPrefix(string value, string prefix)
+        => value.StartsWith(prefix, StringComparison.Ordinal)
+            ? value[prefix.Length..]
+            : value;
+
+    private static string StripKnownSuffix(string value, string suffix)
+        => value.EndsWith(suffix, StringComparison.Ordinal)
+            ? value[..^suffix.Length]
+            : value;
 
     private static bool ReferencesOnlyAlreadyExposedMethods(WorkflowSuggestion suggestion, ProjectModel model)
     {
@@ -212,6 +358,9 @@ public sealed class WorkflowSuggestionParser
         => new(value
             .Select(character => char.IsLetterOrDigit(character) ? char.ToLowerInvariant(character) : ' ')
             .ToArray());
+
+    private static bool ContainsAny(string value, params string[] fragments)
+        => fragments.Any(fragment => value.Contains(fragment, StringComparison.OrdinalIgnoreCase));
 
     private static readonly HashSet<string> IgnoredMethodWords = new(StringComparer.Ordinal)
     {

--- a/src/AgentBlazor.Cli.Analysis/WorkflowSuggestions/WorkflowSuggestionPromptBuilder.cs
+++ b/src/AgentBlazor.Cli.Analysis/WorkflowSuggestions/WorkflowSuggestionPromptBuilder.cs
@@ -25,6 +25,8 @@ public sealed class WorkflowSuggestionPromptBuilder
         sb.AppendLine("- Do not invent DTO or entity types in code. If a type is unclear, use comments rather than fake types.");
         sb.AppendLine("- If a listed method has approvalRecommended=true, the suggested [AgentAction] example must include RequiresApproval = true.");
         sb.AppendLine("- Prefer safe read-only workflows first: show, get, list, find, check, validate, explain, summarize, and status snapshots.");
+        sb.AppendLine("- Name workflows for the user's UI/domain goal, not the raw method verb. For example, map/geo/marker/chart services should become map-layer workflows, not generic get/list data workflows.");
+        sb.AppendLine("- If routes or services indicate maps, markers, geo charts, ESG country data, suppliers, or asset geography, frame the workflow as showing or managing a map layer.");
         sb.AppendLine("- Avoid auth, password reset, email sending, tenant mutation, message deletion, workflow execution, job execution, database mutation, and permission changes unless no safer workflow exists.");
         sb.AppendLine("- If you must suggest a mutating or admin workflow, suggest at most one and explain that it needs human approval.");
         sb.AppendLine();

--- a/src/AgentBlazor.Cli/PACKAGE_README.md
+++ b/src/AgentBlazor.Cli/PACKAGE_README.md
@@ -11,7 +11,7 @@ dotnet tool install --global AgentBlazor.Cli
 If you prefer a pinned install:
 
 ```bash
-dotnet tool install --global AgentBlazor.Cli --version 0.2.14
+dotnet tool install --global AgentBlazor.Cli --version 0.2.15
 ```
 
 Example:
@@ -50,7 +50,9 @@ Version `0.2.13` improves framework-style Blazor app analysis by explaining comp
 
 Version `0.2.14` improves report usability by putting top workflow recommendations and install blockers before the detailed inventory, adding route quality notes, and classifying services by likely agent fit.
 
-Reports put top workflow recommendations and install blockers before the detailed inventory, filter helper/framework noise, classify remaining services by likely agent fit, show AgentBlazor action adoption, and call out `RequiresApproval = true` guidance for workflow suggestions that reference mutating methods.
+Version `0.2.15` improves map-heavy app reports by framing map, marker, geo chart, ESG, supplier, and asset geography suggestions as map-layer workflows instead of generic data fetches.
+
+Reports put top workflow recommendations and install blockers before the detailed inventory, filter helper/framework noise, classify remaining services by likely agent fit, show AgentBlazor action adoption, and call out `RequiresApproval = true` guidance for workflow suggestions that reference mutating methods. Map-related recommendations are framed around the visible map layer users interact with.
 
 The CLI is an advanced path. The default install story is still `dotnet add package AgentBlazor` plus manual runtime wiring.
 
@@ -58,6 +60,7 @@ Docs:
 
 - Repository: https://github.com/ashpeterson/AgentBlazor
 - Advanced CLI guide: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/advanced/cli.md
+- 0.2.15 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.15.md
 - 0.2.14 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.14.md
 - 0.2.13 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.13.md
 - 0.2.12 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.12.md

--- a/src/AgentBlazor.Cli/Program.cs
+++ b/src/AgentBlazor.Cli/Program.cs
@@ -7,7 +7,7 @@ var version = typeof(ScaffoldCommand).Assembly
     .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
     ?.InformationalVersion
     ?? typeof(ScaffoldCommand).Assembly.GetName().Version?.ToString()
-    ?? "0.2.14";
+    ?? "0.2.15";
 version = version.Split('+', 2)[0];
 
 app.Configure(config =>

--- a/src/AgentBlazor.Cli/README.md
+++ b/src/AgentBlazor.Cli/README.md
@@ -28,7 +28,9 @@ Version `0.2.13` improves framework-style Blazor app analysis by explaining comp
 
 Version `0.2.14` improves report usability by putting top workflow recommendations and install blockers before the detailed inventory, adding route quality notes, and classifying services by likely agent fit.
 
-Current reports put top workflow recommendations and install blockers before the detailed inventory. The service inventory is classified by agent fit so data-access, admin/sensitive, integration, and workflow surfaces are easier to review without treating every public service as an equal first action candidate.
+Version `0.2.15` improves map-heavy app reports by framing map, marker, geo chart, ESG, supplier, and asset geography suggestions as map-layer workflows instead of generic data fetches.
+
+Current reports put top workflow recommendations and install blockers before the detailed inventory. The service inventory is classified by agent fit so data-access, admin/sensitive, integration, and workflow surfaces are easier to review without treating every public service as an equal first action candidate. Map-related recommendations are framed around the visible map layer users interact with.
 
 See:
 

--- a/tests/AgentBlazor.Cli.Analysis.Tests/ExistingAppScaffoldPlannerTests.cs
+++ b/tests/AgentBlazor.Cli.Analysis.Tests/ExistingAppScaffoldPlannerTests.cs
@@ -250,7 +250,7 @@ public sealed class ExistingAppScaffoldPlannerTests : IDisposable
         Assert.Contains("""<PackageReference Include="MudBlazor" />""", projectText, StringComparison.Ordinal);
         Assert.DoesNotContain("PackageReference Include=\"AgentBlazor\" Version=", projectText, StringComparison.Ordinal);
         Assert.DoesNotContain("PackageReference Include=\"MudBlazor\" Version=", projectText, StringComparison.Ordinal);
-        Assert.Contains("""<PackageVersion Include="AgentBlazor" Version="0.2.14" />""", centralPackagesText, StringComparison.Ordinal);
+        Assert.Contains("""<PackageVersion Include="AgentBlazor" Version="0.2.15" />""", centralPackagesText, StringComparison.Ordinal);
         Assert.Contains("""<PackageVersion Include="MudBlazor" Version="9.0.0" />""", centralPackagesText, StringComparison.Ordinal);
     }
 

--- a/tests/AgentBlazor.Cli.Analysis.Tests/WorkflowSuggestions/WorkflowSuggestionParserTests.cs
+++ b/tests/AgentBlazor.Cli.Analysis.Tests/WorkflowSuggestions/WorkflowSuggestionParserTests.cs
@@ -231,6 +231,102 @@ public sealed class WorkflowSuggestionParserTests
     }
 
     [Fact]
+    public void ParseAndValidate_FramesGenericMapSuggestionsAsMapLayerWorkflows()
+    {
+        var parser = new WorkflowSuggestionParser();
+        var model = CreateModel() with
+        {
+            Services =
+            [
+                new ServiceModel
+                {
+                    TypeName = "AssetMarkersService",
+                    FilePath = "Core/Services/Maps/AssetMarkersService.cs",
+                    Methods =
+                    [
+                        new ServiceMethodModel
+                        {
+                            Name = "GetAssetMarkersAsync",
+                            ReturnType = "Task<List<AssetMarker>>",
+                            IsPublic = true,
+                            IsAsync = true
+                        }
+                    ]
+                }
+            ],
+            Actions =
+            [
+                new ActionModel
+                {
+                    Name = "Get Asset Markers",
+                    SourceService = "AssetMarkersService",
+                    MethodName = "GetAssetMarkersAsync",
+                    FilePath = "Core/Services/Maps/AssetMarkersService.cs",
+                    ExposureMode = ActionExposureMode.Suggested,
+                    Classification = ActionClassification.Query,
+                    Score = 0.9
+                }
+            ]
+        };
+        var json = """
+        {
+          "workflows": [
+            {
+              "name": "Get Asset Markers",
+              "description": "Retrieve asset markers.",
+              "methods": [
+                { "service": "AssetMarkersService", "method": "GetAssetMarkersAsync" }
+              ],
+              "capabilityClass": "GetAssetMarkersCapability",
+              "code": "public sealed class GetAssetMarkersCapability { public async Task<CapabilityResult> RunAsync() { return CapabilityResult.Success(\"Done.\"); } }",
+              "reasoning": "Safe read-only marker fetch.",
+              "confidence": 0.90
+            }
+          ]
+        }
+        """;
+
+        var result = parser.ParseAndValidate(json, model, "test-model");
+
+        var suggestion = Assert.Single(result.Suggestions);
+        Assert.Equal("Show Asset Markers Map Layer", suggestion.Name);
+        Assert.Contains("map layer", suggestion.Description);
+        Assert.Contains("map layer workflow", suggestion.Reasoning);
+        Assert.Equal("ShowAssetMarkersMapLayerCapability", suggestion.CapabilityClass);
+        Assert.Empty(result.Rejected);
+    }
+
+    [Fact]
+    public void ParseAndValidate_DoesNotRewriteGenericReadSuggestionsForNonMapServices()
+    {
+        var parser = new WorkflowSuggestionParser();
+        var model = CreateModel();
+        var json = """
+        {
+          "workflows": [
+            {
+              "name": "Get Orders",
+              "description": "Retrieve orders.",
+              "methods": [
+                { "service": "OrderService", "method": "FindOrdersAsync" }
+              ],
+              "capabilityClass": "GetOrdersCapability",
+              "reasoning": "Safe read-only order lookup.",
+              "confidence": 0.80
+            }
+          ]
+        }
+        """;
+
+        var result = parser.ParseAndValidate(json, model, "test-model");
+
+        var suggestion = Assert.Single(result.Suggestions);
+        Assert.Equal("Get Orders", suggestion.Name);
+        Assert.Equal("GetOrdersCapability", suggestion.CapabilityClass);
+        Assert.Empty(result.Rejected);
+    }
+
+    [Fact]
     public void ParseAndValidate_AcceptsMethodReferencesThatIncludeParameterLists()
     {
         var parser = new WorkflowSuggestionParser();

--- a/tests/AgentBlazor.Cli.Analysis.Tests/WorkflowSuggestions/WorkflowSuggestionPromptBuilderTests.cs
+++ b/tests/AgentBlazor.Cli.Analysis.Tests/WorkflowSuggestions/WorkflowSuggestionPromptBuilderTests.cs
@@ -248,6 +248,8 @@ public sealed class WorkflowSuggestionPromptBuilderTests
         Assert.Contains("risk=approval required", prompt);
         Assert.Contains("Prefer safe read-only workflows first", prompt);
         Assert.Contains("RequiresApproval = true", prompt);
+        Assert.Contains("map-layer workflows", prompt);
+        Assert.Contains("frame the workflow as showing or managing a map layer", prompt);
         Assert.DoesNotContain("ActivityIdHelper", prompt);
         Assert.DoesNotContain("ToString", prompt);
         Assert.DoesNotContain("AgentBlazorBuilder", prompt);


### PR DESCRIPTION
## Summary
- frame generic validated map/geo/marker workflow suggestions as map-layer workflows
- add prompt guidance for map-heavy Blazor apps
- bump package/docs to 0.2.15

## Verification
- dotnet test tests/AgentBlazor.Cli.Analysis.Tests/AgentBlazor.Cli.Analysis.Tests.csproj --no-restore -v minimal
- dotnet build src/AgentBlazor.Cli/AgentBlazor.Cli.csproj -v minimal

Note: full solution restore/test is currently blocked locally by demo/sample restore failure for Microsoft.NETCore.App.Host.ubuntu.24.04-x64.