### PR TITLE
fix(cli): demote data view suggestions

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
 
   <!-- Common package metadata for all AgentBlazor packages -->
   <PropertyGroup>
-    <Version>0.2.16</Version>
+    <Version>0.2.17</Version>
     <Authors>Ash Peterson</Authors>
     <Company>AgentBlazor</Company>
     <Copyright>Copyright (c) 2026 Ash Peterson</Copyright>
@@ -16,7 +16,7 @@
     <RepositoryType>git</RepositoryType>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <PackageIcon>icon.png</PackageIcon>
-    <PackageReleaseNotes>v0.2.16: CLI workflow relevance correction. Removes the map-layer workflow framing from 0.2.15 and filters UI layer applier, renderer, styling, and map-layer infrastructure from workflow suggestion inputs.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.2.17: CLI workflow relevance correction. Demotes pure read-only data/view suggestions from Top Recommendations when process-oriented workflow candidates exist, includes action classification in the LLM prompt, and ranks workflow/process actions ahead of simple query methods.</PackageReleaseNotes>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <Deterministic>true</Deterministic>

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ dotnet run --project samples/AgentBlazor.Starter/AgentBlazor.Starter.csproj
 
 - [Quickstart](docs/quickstart.md)
 - [CLI v1 announcement](docs/cli-v1-analyze-announcement.md)
+- [0.2.17 release notes](docs/releases/0.2.17.md)
 - [0.2.16 release notes](docs/releases/0.2.16.md)
 - [0.2.15 release notes](docs/releases/0.2.15.md)
 - [0.2.14 release notes](docs/releases/0.2.14.md)

--- a/docs/releases/0.2.17.md
+++ b/docs/releases/0.2.17.md
@@ -1,0 +1,33 @@
+# AgentBlazor 0.2.17 Release Notes
+
+Target package line: `0.2.17` stable.
+
+AgentBlazor 0.2.17 is a CLI analyzer workflow-relevance patch.
+
+## What's Changed
+
+- Demotes pure read-only data/view suggestions from `Top Recommendations` when process-oriented workflow candidates exist.
+- Keeps read-only LLM suggestions visible in `Workflow Suggestions` for audit, but no longer presents them as first workflow work.
+- Ranks workflow/process actions ahead of simple query methods in both LLM-backed and static-only reports.
+- Adds action classification to the LLM prompt so the model can distinguish `Workflow`, `Command`, `Export`, `Validation`, and `Query` methods.
+- Tightens prompt guidance: one-method getters/lists/views are usually data surfaces, not workflows.
+
+## Why This Matters
+
+Read-only methods like `GetAssetMarkersAsync` and `GetCountryESGDataAsync` can be useful context, but they are not usually workflows. A first agent workflow should normally represent a user/business process, task, or decision flow.
+
+This release makes the report less likely to tell developers to start with data views when a real process method, such as a submission/review workflow, exists.
+
+## Verify
+
+```bash
+dotnet tool update --global AgentBlazor.Cli --version 0.2.17
+agentblazor --version
+agentblazor analyze ./MySolution.slnx --host MyBlazorApp --scan-scope solution --output ./analysis.md
+```
+
+Expected:
+
+- `agentblazor --version` reports `0.2.17`.
+- `Top Recommendations` promotes process-oriented workflow candidates first.
+- Pure read-only data/view suggestions remain available below for review but are not treated as first workflow work when process candidates exist.

--- a/src/AgentBlazor.Cli.Analysis/ExistingAppScaffoldApplier.cs
+++ b/src/AgentBlazor.Cli.Analysis/ExistingAppScaffoldApplier.cs
@@ -301,7 +301,7 @@ public sealed class ExistingAppScaffoldApplier
             .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
             ?.InformationalVersion
             ?? typeof(ExistingAppScaffoldApplier).Assembly.GetName().Version?.ToString()
-            ?? "0.2.16";
+            ?? "0.2.17";
 
         return version.Split('+', 2)[0];
     }

--- a/src/AgentBlazor.Cli.Analysis/Generation/AnalysisReportGenerator.cs
+++ b/src/AgentBlazor.Cli.Analysis/Generation/AnalysisReportGenerator.cs
@@ -98,14 +98,34 @@ public sealed class AnalysisReportGenerator
 
         if (workflowSuggestions?.Suggestions.Count > 0)
         {
-            sb.AppendLine("These are the highest-signal workflow candidates. Start here before reading the full service inventory.");
+            var promotedSuggestions = workflowSuggestions.Suggestions
+                .Where(suggestion => IsProcessWorkflowSuggestion(suggestion, model))
+                .OrderBy(suggestion => GetSuggestionWorkflowRank(suggestion, model))
+                .ThenBy(suggestion => GetSuggestionRiskRank(suggestion, model))
+                .ThenByDescending(suggestion => suggestion.Confidence)
+                .Take(5)
+                .ToList();
+
+            if (promotedSuggestions.Count == 0)
+            {
+                sb.AppendLine("No process-oriented workflow candidates were found. The validated LLM suggestions are read-only data surfaces; review them below, but treat them as supporting context rather than first workflow work.");
+                sb.AppendLine();
+                return;
+            }
+
+            var readOnlySuggestionCount = workflowSuggestions.Suggestions.Count -
+                workflowSuggestions.Suggestions.Count(suggestion => IsProcessWorkflowSuggestion(suggestion, model));
+
+            sb.AppendLine("These are the highest-signal process-oriented workflow candidates. Start here before reading the full service inventory.");
+            if (readOnlySuggestionCount > 0)
+            {
+                sb.AppendLine($"{readOnlySuggestionCount} read-only data/view suggestion(s) were not promoted to top recommendations.");
+            }
+
             sb.AppendLine();
             sb.AppendLine("| Workflow | Risk | Confidence | Existing methods | Why it matters |");
             sb.AppendLine("| --- | --- | --- | --- | --- |");
-            foreach (var suggestion in workflowSuggestions.Suggestions
-                .OrderBy(suggestion => GetSuggestionRiskRank(suggestion, model))
-                .ThenByDescending(suggestion => suggestion.Confidence)
-                .Take(5))
+            foreach (var suggestion in promotedSuggestions)
             {
                 var methods = suggestion.Methods.Count == 0
                     ? "-"
@@ -341,7 +361,8 @@ public sealed class AnalysisReportGenerator
             if (workflowSuggestions.Suggestions.Count > 0)
             {
                 foreach (var suggestion in workflowSuggestions.Suggestions
-                    .OrderBy(suggestion => GetSuggestionRiskRank(suggestion, model))
+                    .OrderBy(suggestion => GetSuggestionWorkflowRank(suggestion, model))
+                    .ThenBy(suggestion => GetSuggestionRiskRank(suggestion, model))
                     .ThenByDescending(suggestion => suggestion.Confidence))
                 {
                     sb.AppendLine($"### {suggestion.Name}");
@@ -553,7 +574,8 @@ public sealed class AnalysisReportGenerator
             .Where(AnalysisModelFilters.IsDeveloperFacingAction)
             .Where(action => !DuplicatesConfirmedAction(action, model))
             .Where(action => action.Score >= 0.7)
-            .OrderBy(action => (int)ActionRisk.GetRiskBand(action))
+            .OrderBy(GetActionWorkflowRank)
+            .ThenBy(action => (int)ActionRisk.GetRiskBand(action))
             .ThenByDescending(action => action.Score)
             .ThenBy(action => action.SourceService)
             .GroupBy(action => $"{action.SourceService}.{action.MethodName}", StringComparer.OrdinalIgnoreCase)
@@ -716,6 +738,61 @@ public sealed class AnalysisReportGenerator
 
     private static int GetSuggestionRiskRank(WorkflowSuggestion suggestion, ProjectModel model)
         => (int)GetSuggestionRiskBand(suggestion, model);
+
+    private static bool IsProcessWorkflowSuggestion(WorkflowSuggestion suggestion, ProjectModel model)
+    {
+        return GetReferencedActions(suggestion, model)
+            .Any(action => action.Classification is
+                ActionClassification.Workflow or
+                ActionClassification.Command or
+                ActionClassification.Export);
+    }
+
+    private static int GetSuggestionWorkflowRank(WorkflowSuggestion suggestion, ProjectModel model)
+    {
+        var actions = GetReferencedActions(suggestion, model).ToList();
+        if (actions.Any(action => action.Classification == ActionClassification.Workflow))
+        {
+            return 0;
+        }
+
+        if (actions.Any(action => action.Classification == ActionClassification.Command))
+        {
+            return 1;
+        }
+
+        if (actions.Any(action => action.Classification == ActionClassification.Export))
+        {
+            return 2;
+        }
+
+        if (actions.Any(action => action.Classification == ActionClassification.Validation))
+        {
+            return 3;
+        }
+
+        return 4;
+    }
+
+    private static int GetActionWorkflowRank(ActionModel action)
+        => action.Classification switch
+        {
+            ActionClassification.Workflow => 0,
+            ActionClassification.Command => 1,
+            ActionClassification.Export => 2,
+            ActionClassification.Validation => 3,
+            ActionClassification.Query => 4,
+            _ => 5
+        };
+
+    private static IEnumerable<ActionModel> GetReferencedActions(WorkflowSuggestion suggestion, ProjectModel model)
+    {
+        return suggestion.Methods.SelectMany(method => model.Actions
+            .Where(AnalysisModelFilters.IsDeveloperFacingAction)
+            .Where(action =>
+                string.Equals(action.SourceService, method.Service, StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(action.MethodName, method.Method, StringComparison.OrdinalIgnoreCase)));
+    }
 
     private static int GetRecommendationRiskRank(RecommendationModel recommendation, ProjectModel model)
     {

--- a/src/AgentBlazor.Cli.Analysis/WorkflowSuggestions/WorkflowSuggestionPromptBuilder.cs
+++ b/src/AgentBlazor.Cli.Analysis/WorkflowSuggestions/WorkflowSuggestionPromptBuilder.cs
@@ -24,7 +24,9 @@ public sealed class WorkflowSuggestionPromptBuilder
         sb.AppendLine("- Suggested C# code must use AgentBlazor CapabilityResult and only call listed methods.");
         sb.AppendLine("- Do not invent DTO or entity types in code. If a type is unclear, use comments rather than fake types.");
         sb.AppendLine("- If a listed method has approvalRecommended=true, the suggested [AgentAction] example must include RequiresApproval = true.");
-        sb.AppendLine("- Prefer safe read-only workflows first: show, get, list, find, check, validate, explain, summarize, and status snapshots.");
+        sb.AppendLine("- A workflow is a user/business process, task, or decision flow. A one-method getter/list/view is usually a data surface, not a workflow.");
+        sb.AppendLine("- Prefer methods classified as Workflow first. Prefer Command or Export only when the user-facing process is clear and approval guidance is included.");
+        sb.AppendLine("- Use simple Query methods as supporting context for workflows, but do not suggest pure data-view workflows when process-oriented methods are available.");
         sb.AppendLine("- Name workflows for the user's business outcome, not the raw method verb or UI/rendering mechanism.");
         sb.AppendLine("- Avoid suggesting UI rendering, map layer application, chart drawing, styling, layout, or component state plumbing unless the method clearly represents a business workflow.");
         sb.AppendLine("- Avoid auth, password reset, email sending, tenant mutation, message deletion, workflow execution, job execution, database mutation, and permission changes unless no safer workflow exists.");
@@ -135,7 +137,7 @@ public sealed class WorkflowSuggestionPromptBuilder
                 {
                     var action = candidateActions[(service.TypeName, method.Name)];
                     var approvalRecommended = ActionRisk.GetRiskBand(action) is ActionRiskBand.ApprovalRequired or ActionRiskBand.HighRisk;
-                    return $"{method.Name}({string.Join(", ", method.Parameters.Select(parameter => $"{parameter.TypeName} {parameter.Name}"))}) [risk={ActionRisk.Describe(ActionRisk.GetRiskBand(action))}, mutation={action.IsMutationLikely.ToString().ToLowerInvariant()}, approvalRecommended={approvalRecommended.ToString().ToLowerInvariant()}]";
+                    return $"{method.Name}({string.Join(", ", method.Parameters.Select(parameter => $"{parameter.TypeName} {parameter.Name}"))}) [classification={action.Classification}, risk={ActionRisk.Describe(ActionRisk.GetRiskBand(action))}, mutation={action.IsMutationLikely.ToString().ToLowerInvariant()}, approvalRecommended={approvalRecommended.ToString().ToLowerInvariant()}]";
                 })
                 .ToList();
 

--- a/src/AgentBlazor.Cli/PACKAGE_README.md
+++ b/src/AgentBlazor.Cli/PACKAGE_README.md
@@ -11,7 +11,7 @@ dotnet tool install --global AgentBlazor.Cli
 If you prefer a pinned install:
 
 ```bash
-dotnet tool install --global AgentBlazor.Cli --version 0.2.16
+dotnet tool install --global AgentBlazor.Cli --version 0.2.17
 ```
 
 Example:
@@ -54,6 +54,8 @@ Version `0.2.15` was superseded by `0.2.16`.
 
 Version `0.2.16` removes the `0.2.15` map-layer workflow framing and filters UI layer applier, renderer, styling, and map-layer infrastructure from workflow suggestion inputs.
 
+Version `0.2.17` improves workflow relevance by demoting pure read-only data/view suggestions from top recommendations when process-oriented workflow candidates exist.
+
 Reports put top workflow recommendations and install blockers before the detailed inventory, filter helper/framework noise, classify remaining services by likely agent fit, show AgentBlazor action adoption, and call out `RequiresApproval = true` guidance for workflow suggestions that reference mutating methods.
 
 The CLI is an advanced path. The default install story is still `dotnet add package AgentBlazor` plus manual runtime wiring.
@@ -62,6 +64,7 @@ Docs:
 
 - Repository: https://github.com/ashpeterson/AgentBlazor
 - Advanced CLI guide: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/advanced/cli.md
+- 0.2.17 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.17.md
 - 0.2.16 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.16.md
 - 0.2.15 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.15.md
 - 0.2.14 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.14.md

--- a/src/AgentBlazor.Cli/Program.cs
+++ b/src/AgentBlazor.Cli/Program.cs
@@ -7,7 +7,7 @@ var version = typeof(ScaffoldCommand).Assembly
     .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
     ?.InformationalVersion
     ?? typeof(ScaffoldCommand).Assembly.GetName().Version?.ToString()
-    ?? "0.2.16";
+    ?? "0.2.17";
 version = version.Split('+', 2)[0];
 
 app.Configure(config =>

--- a/src/AgentBlazor.Cli/README.md
+++ b/src/AgentBlazor.Cli/README.md
@@ -32,6 +32,8 @@ Version `0.2.15` was superseded by `0.2.16`.
 
 Version `0.2.16` removes the `0.2.15` map-layer workflow framing and filters UI layer applier, renderer, styling, and map-layer infrastructure from workflow suggestion inputs.
 
+Version `0.2.17` improves workflow relevance by demoting pure read-only data/view suggestions from top recommendations when process-oriented workflow candidates exist.
+
 Current reports put top workflow recommendations and install blockers before the detailed inventory. The service inventory is classified by agent fit so data-access, admin/sensitive, integration, and workflow surfaces are easier to review without treating every public service as an equal first action candidate.
 
 See:

--- a/tests/AgentBlazor.Cli.Analysis.Tests/ExistingAppScaffoldPlannerTests.cs
+++ b/tests/AgentBlazor.Cli.Analysis.Tests/ExistingAppScaffoldPlannerTests.cs
@@ -250,7 +250,7 @@ public sealed class ExistingAppScaffoldPlannerTests : IDisposable
         Assert.Contains("""<PackageReference Include="MudBlazor" />""", projectText, StringComparison.Ordinal);
         Assert.DoesNotContain("PackageReference Include=\"AgentBlazor\" Version=", projectText, StringComparison.Ordinal);
         Assert.DoesNotContain("PackageReference Include=\"MudBlazor\" Version=", projectText, StringComparison.Ordinal);
-        Assert.Contains("""<PackageVersion Include="AgentBlazor" Version="0.2.16" />""", centralPackagesText, StringComparison.Ordinal);
+        Assert.Contains("""<PackageVersion Include="AgentBlazor" Version="0.2.17" />""", centralPackagesText, StringComparison.Ordinal);
         Assert.Contains("""<PackageVersion Include="MudBlazor" Version="9.0.0" />""", centralPackagesText, StringComparison.Ordinal);
     }
 

--- a/tests/AgentBlazor.Cli.Analysis.Tests/Generation/AnalysisReportGeneratorTests.cs
+++ b/tests/AgentBlazor.Cli.Analysis.Tests/Generation/AnalysisReportGeneratorTests.cs
@@ -157,6 +157,104 @@ public sealed class AnalysisReportGeneratorTests : IDisposable
     }
 
     [Fact]
+    public void GenerateMarkdown_DemotesReadOnlyDataSuggestions_FromTopRecommendations_WhenProcessWorkflowExists()
+    {
+        var model = CreateModel() with
+        {
+            Actions =
+            [
+                .. CreateModel().Actions,
+                new ActionModel
+                {
+                    Name = "Submit Asset",
+                    SourceService = "RevisionSubmissionService",
+                    MethodName = "SubmitAsync",
+                    FilePath = "Services/RevisionSubmissionService.cs",
+                    ExposureMode = ActionExposureMode.Suggested,
+                    Classification = ActionClassification.Workflow,
+                    IsMutationLikely = true,
+                    RequiresApproval = true,
+                    Score = 0.9
+                },
+                new ActionModel
+                {
+                    Name = "Get Asset Markers",
+                    SourceService = "AssetMarkersService",
+                    MethodName = "GetAssetMarkersAsync",
+                    FilePath = "Services/AssetMarkersService.cs",
+                    ExposureMode = ActionExposureMode.Suggested,
+                    Classification = ActionClassification.Query,
+                    Score = 0.95
+                }
+            ]
+        };
+        var suggestions = new WorkflowSuggestionSet
+        {
+            Model = "test-model",
+            Suggestions =
+            [
+                new WorkflowSuggestion
+                {
+                    Name = "View Asset Markers",
+                    Description = "View asset markers.",
+                    Methods =
+                    [
+                        new WorkflowMethodReference { Service = "AssetMarkersService", Method = "GetAssetMarkersAsync" }
+                    ],
+                    Confidence = 0.95
+                },
+                new WorkflowSuggestion
+                {
+                    Name = "Submit Asset for Review",
+                    Description = "Submit an asset for review.",
+                    Methods =
+                    [
+                        new WorkflowMethodReference { Service = "RevisionSubmissionService", Method = "SubmitAsync" }
+                    ],
+                    Confidence = 0.75
+                }
+            ]
+        };
+
+        var content = _generator.GenerateMarkdown(model, workflowSuggestions: suggestions);
+        var topRecommendations = ExtractSection(content, "## Top Recommendations", "## Install Blockers");
+
+        Assert.Contains("Submit Asset for Review", topRecommendations);
+        Assert.DoesNotContain("View Asset Markers", topRecommendations);
+        Assert.Contains("1 read-only data/view suggestion(s) were not promoted", topRecommendations);
+        Assert.Contains("### View Asset Markers", content);
+    }
+
+    [Fact]
+    public void GenerateMarkdown_DoesNotPromotePureReadOnlySuggestions_ToTopRecommendations()
+    {
+        var suggestions = new WorkflowSuggestionSet
+        {
+            Model = "test-model",
+            Suggestions =
+            [
+                new WorkflowSuggestion
+                {
+                    Name = "View Asset Markers",
+                    Description = "View asset markers.",
+                    Methods =
+                    [
+                        new WorkflowMethodReference { Service = "OrderService", Method = "FindOrdersAsync" }
+                    ],
+                    Confidence = 0.95
+                }
+            ]
+        };
+
+        var content = _generator.GenerateMarkdown(CreateModel(), workflowSuggestions: suggestions);
+        var topRecommendations = ExtractSection(content, "## Top Recommendations", "## Install Blockers");
+
+        Assert.Contains("No process-oriented workflow candidates were found", topRecommendations);
+        Assert.DoesNotContain("| View Asset Markers |", topRecommendations);
+        Assert.Contains("### View Asset Markers", content);
+    }
+
+    [Fact]
     public void GenerateMarkdown_IncludesCompactInstallBlockers_BeforeDetailedReadiness()
     {
         var readiness = new InstallReadinessReport
@@ -1434,8 +1532,8 @@ public sealed class AnalysisReportGeneratorTests : IDisposable
 
         var content = _generator.GenerateMarkdown(model, workflowSuggestions: suggestions);
 
-        Assert.True(content.IndexOf("### Status snapshot", StringComparison.Ordinal) <
-            content.IndexOf("### Password reset", StringComparison.Ordinal));
+        Assert.True(content.IndexOf("### Password reset", StringComparison.Ordinal) <
+            content.IndexOf("### Status snapshot", StringComparison.Ordinal));
         Assert.Contains("- Risk: safe read-only", content);
         Assert.Contains("- Risk: high-risk/admin", content);
     }
@@ -1484,6 +1582,15 @@ public sealed class AnalysisReportGeneratorTests : IDisposable
 
         Assert.DoesNotContain("Existing method: `SupportTicketService.ShowOpenTicketsAsync`", content);
         Assert.Contains("Existing method: `InventoryService.PrepareRestockPlanAsync`", content);
+    }
+
+    private static string ExtractSection(string content, string startHeading, string endHeading)
+    {
+        var start = content.IndexOf(startHeading, StringComparison.Ordinal);
+        Assert.True(start >= 0, $"Could not find section start `{startHeading}`.");
+        var end = content.IndexOf(endHeading, start + startHeading.Length, StringComparison.Ordinal);
+        Assert.True(end > start, $"Could not find section end `{endHeading}`.");
+        return content[start..end];
     }
 
     private static ProjectModel CreateModel() => new()

--- a/tests/AgentBlazor.Cli.Analysis.Tests/WorkflowSuggestions/WorkflowSuggestionPromptBuilderTests.cs
+++ b/tests/AgentBlazor.Cli.Analysis.Tests/WorkflowSuggestions/WorkflowSuggestionPromptBuilderTests.cs
@@ -246,7 +246,10 @@ public sealed class WorkflowSuggestionPromptBuilderTests
         Assert.Contains("approvalRecommended=true", prompt);
         Assert.Contains("risk=safe read-only", prompt);
         Assert.Contains("risk=approval required", prompt);
-        Assert.Contains("Prefer safe read-only workflows first", prompt);
+        Assert.Contains("one-method getter/list/view is usually a data surface", prompt);
+        Assert.Contains("Prefer methods classified as Workflow first", prompt);
+        Assert.Contains("classification=Workflow", prompt);
+        Assert.Contains("classification=Query", prompt);
         Assert.Contains("RequiresApproval = true", prompt);
         Assert.Contains("business outcome", prompt);
         Assert.Contains("Avoid suggesting UI rendering, map layer application, chart drawing, styling, layout, or component state plumbing", prompt);


### PR DESCRIPTION
## Summary
- demote pure read-only data/view LLM suggestions from Top Recommendations when process workflow candidates exist
- rank process/workflow actions ahead of simple query methods in LLM and static reports
- include action classification in the LLM prompt and clarify that one-method getters are data surfaces, not workflows
- bump package/docs to 0.2.17

## Verification
- dotnet test tests/AgentBlazor.Cli.Analysis.Tests/AgentBlazor.Cli.Analysis.Tests.csproj --no-restore -v minimal
- dotnet build src/AgentBlazor.Cli/AgentBlazor.Cli.csproj --no-restore -v minimal