### PR TITLE
fix(cli): demote plumbing recommendations

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
 
   <!-- Common package metadata for all AgentBlazor packages -->
   <PropertyGroup>
-    <Version>0.2.17</Version>
+    <Version>0.2.18</Version>
     <Authors>Ash Peterson</Authors>
     <Company>AgentBlazor</Company>
     <Copyright>Copyright (c) 2026 Ash Peterson</Copyright>
@@ -16,7 +16,7 @@
     <RepositoryType>git</RepositoryType>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <PackageIcon>icon.png</PackageIcon>
-    <PackageReleaseNotes>v0.2.17: CLI workflow relevance correction. Demotes pure read-only data/view suggestions from Top Recommendations when process-oriented workflow candidates exist, includes action classification in the LLM prompt, and ranks workflow/process actions ahead of simple query methods.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.2.18: CLI top recommendation quality patch. Demotes raw integration, admin/sensitive, data-access, and infrastructure suggestions from Top Recommendations so reports prioritize real business/process workflows instead of plumbing such as chat-session starts, file-upload primitives, cache clearing, or direct database operations.</PackageReleaseNotes>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <Deterministic>true</Deterministic>

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ dotnet run --project samples/AgentBlazor.Starter/AgentBlazor.Starter.csproj
 
 - [Quickstart](docs/quickstart.md)
 - [CLI v1 announcement](docs/cli-v1-analyze-announcement.md)
+- [0.2.18 release notes](docs/releases/0.2.18.md)
 - [0.2.17 release notes](docs/releases/0.2.17.md)
 - [0.2.16 release notes](docs/releases/0.2.16.md)
 - [0.2.15 release notes](docs/releases/0.2.15.md)

--- a/docs/releases/0.2.18.md
+++ b/docs/releases/0.2.18.md
@@ -1,0 +1,33 @@
+# AgentBlazor 0.2.18 Release Notes
+
+Target package line: `0.2.18` stable.
+
+AgentBlazor 0.2.18 is a CLI analyzer top-recommendation quality patch.
+
+## What's Changed
+
+- Demotes raw integration, admin/sensitive, data-access, and infrastructure suggestions from `Top Recommendations`.
+- Keeps demoted suggestions visible in `Workflow Suggestions` for audit, but no longer presents them as first workflow work.
+- Treats service category as part of top recommendation ranking, not just method verb/classification.
+- Tightens LLM prompt guidance to avoid raw chat-session starts, email/file-upload plumbing, message transport, cache clearing, direct database mutation, and similar plumbing unless part of a larger business process.
+- Preserves real process workflow promotion, such as submission/review workflows, when the referenced service is a business workflow surface.
+
+## Why This Matters
+
+Method names like `StartAsync`, `UploadFileAsync`, `AddFavouriteCountryAsync`, and `ClearCache` can look workflow-like from verbs alone. In real applications, they are often client primitives, integration plumbing, personalization mutations, or admin/data-access operations.
+
+This release makes `Top Recommendations` focus on actionable business/process workflows instead of telling developers to start with low-level plumbing.
+
+## Verify
+
+```bash
+dotnet tool update --global AgentBlazor.Cli --version 0.2.18
+agentblazor --version
+agentblazor analyze ./MySolution.slnx --host MyBlazorApp --scan-scope solution --output ./analysis.md
+```
+
+Expected:
+
+- `agentblazor --version` reports `0.2.18`.
+- `Top Recommendations` promotes real process workflow candidates first.
+- Raw integration, admin/sensitive, data-access, and infrastructure suggestions remain available below for review but are not treated as first workflow work.

--- a/src/AgentBlazor.Cli.Analysis/ExistingAppScaffoldApplier.cs
+++ b/src/AgentBlazor.Cli.Analysis/ExistingAppScaffoldApplier.cs
@@ -301,7 +301,7 @@ public sealed class ExistingAppScaffoldApplier
             .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
             ?.InformationalVersion
             ?? typeof(ExistingAppScaffoldApplier).Assembly.GetName().Version?.ToString()
-            ?? "0.2.17";
+            ?? "0.2.18";
 
         return version.Split('+', 2)[0];
     }

--- a/src/AgentBlazor.Cli.Analysis/Generation/AnalysisReportGenerator.cs
+++ b/src/AgentBlazor.Cli.Analysis/Generation/AnalysisReportGenerator.cs
@@ -108,18 +108,18 @@ public sealed class AnalysisReportGenerator
 
             if (promotedSuggestions.Count == 0)
             {
-                sb.AppendLine("No process-oriented workflow candidates were found. The validated LLM suggestions are read-only data surfaces; review them below, but treat them as supporting context rather than first workflow work.");
+                sb.AppendLine("No process-oriented workflow candidates were found. The validated LLM suggestions are data, integration, admin, or infrastructure surfaces; review them below, but treat them as supporting context rather than first workflow work.");
                 sb.AppendLine();
                 return;
             }
 
-            var readOnlySuggestionCount = workflowSuggestions.Suggestions.Count -
+            var demotedSuggestionCount = workflowSuggestions.Suggestions.Count -
                 workflowSuggestions.Suggestions.Count(suggestion => IsProcessWorkflowSuggestion(suggestion, model));
 
             sb.AppendLine("These are the highest-signal process-oriented workflow candidates. Start here before reading the full service inventory.");
-            if (readOnlySuggestionCount > 0)
+            if (demotedSuggestionCount > 0)
             {
-                sb.AppendLine($"{readOnlySuggestionCount} read-only data/view suggestion(s) were not promoted to top recommendations.");
+                sb.AppendLine($"{demotedSuggestionCount} supporting data, integration, admin, or infrastructure suggestion(s) were not promoted to top recommendations.");
             }
 
             sb.AppendLine();
@@ -573,6 +573,7 @@ public sealed class AnalysisReportGenerator
             .Where(action => action.ExposureMode == ActionExposureMode.Suggested)
             .Where(AnalysisModelFilters.IsDeveloperFacingAction)
             .Where(action => !DuplicatesConfirmedAction(action, model))
+            .Where(action => IsTopRecommendationAction(action, model))
             .Where(action => action.Score >= 0.7)
             .OrderBy(GetActionWorkflowRank)
             .ThenBy(action => (int)ActionRisk.GetRiskBand(action))
@@ -742,10 +743,35 @@ public sealed class AnalysisReportGenerator
     private static bool IsProcessWorkflowSuggestion(WorkflowSuggestion suggestion, ProjectModel model)
     {
         return GetReferencedActions(suggestion, model)
-            .Any(action => action.Classification is
-                ActionClassification.Workflow or
-                ActionClassification.Command or
-                ActionClassification.Export);
+            .Any(action => IsTopRecommendationAction(action, model));
+    }
+
+    private static bool IsTopRecommendationAction(ActionModel action, ProjectModel model)
+    {
+        if (action.Classification is not (
+            ActionClassification.Workflow or
+            ActionClassification.Command or
+            ActionClassification.Export))
+        {
+            return false;
+        }
+
+        var service = model.Services.FirstOrDefault(service =>
+            string.Equals(service.TypeName, action.SourceService, StringComparison.OrdinalIgnoreCase));
+        if (service is null)
+        {
+            return action.Classification == ActionClassification.Workflow;
+        }
+
+        var serviceCategory = ClassifyService(service, model).Category;
+        if (serviceCategory is ServiceCategory.IntegrationOrMessaging or ServiceCategory.DataAccess or ServiceCategory.AdminOrSensitive)
+        {
+            return false;
+        }
+
+        return action.Classification == ActionClassification.Workflow ||
+            serviceCategory is ServiceCategory.OperationalWorkflow or ServiceCategory.Unknown ||
+            (action.Classification == ActionClassification.Export && serviceCategory == ServiceCategory.BusinessReadOnly);
     }
 
     private static int GetSuggestionWorkflowRank(WorkflowSuggestion suggestion, ProjectModel model)

--- a/src/AgentBlazor.Cli.Analysis/WorkflowSuggestions/WorkflowSuggestionPromptBuilder.cs
+++ b/src/AgentBlazor.Cli.Analysis/WorkflowSuggestions/WorkflowSuggestionPromptBuilder.cs
@@ -29,7 +29,8 @@ public sealed class WorkflowSuggestionPromptBuilder
         sb.AppendLine("- Use simple Query methods as supporting context for workflows, but do not suggest pure data-view workflows when process-oriented methods are available.");
         sb.AppendLine("- Name workflows for the user's business outcome, not the raw method verb or UI/rendering mechanism.");
         sb.AppendLine("- Avoid suggesting UI rendering, map layer application, chart drawing, styling, layout, or component state plumbing unless the method clearly represents a business workflow.");
-        sb.AppendLine("- Avoid auth, password reset, email sending, tenant mutation, message deletion, workflow execution, job execution, database mutation, and permission changes unless no safer workflow exists.");
+        sb.AppendLine("- Avoid raw integration/client primitives such as starting chat sessions, sending email, file upload plumbing, or message transport unless they are part of a larger listed business process.");
+        sb.AppendLine("- Avoid auth, password reset, tenant mutation, message deletion, workflow execution, job execution, cache clearing, database mutation, and permission changes unless no safer workflow exists.");
         sb.AppendLine("- If you must suggest a mutating or admin workflow, suggest at most one and explain that it needs human approval.");
         sb.AppendLine();
         sb.AppendLine("JSON shape:");

--- a/src/AgentBlazor.Cli/PACKAGE_README.md
+++ b/src/AgentBlazor.Cli/PACKAGE_README.md
@@ -11,7 +11,7 @@ dotnet tool install --global AgentBlazor.Cli
 If you prefer a pinned install:
 
 ```bash
-dotnet tool install --global AgentBlazor.Cli --version 0.2.17
+dotnet tool install --global AgentBlazor.Cli --version 0.2.18
 ```
 
 Example:
@@ -56,6 +56,8 @@ Version `0.2.16` removes the `0.2.15` map-layer workflow framing and filters UI 
 
 Version `0.2.17` improves workflow relevance by demoting pure read-only data/view suggestions from top recommendations when process-oriented workflow candidates exist.
 
+Version `0.2.18` improves top recommendation quality by demoting raw integration, admin/sensitive, data-access, and infrastructure suggestions so reports prioritize real business/process workflows instead of plumbing.
+
 Reports put top workflow recommendations and install blockers before the detailed inventory, filter helper/framework noise, classify remaining services by likely agent fit, show AgentBlazor action adoption, and call out `RequiresApproval = true` guidance for workflow suggestions that reference mutating methods.
 
 The CLI is an advanced path. The default install story is still `dotnet add package AgentBlazor` plus manual runtime wiring.
@@ -64,6 +66,7 @@ Docs:
 
 - Repository: https://github.com/ashpeterson/AgentBlazor
 - Advanced CLI guide: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/advanced/cli.md
+- 0.2.18 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.18.md
 - 0.2.17 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.17.md
 - 0.2.16 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.16.md
 - 0.2.15 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.15.md

--- a/src/AgentBlazor.Cli/Program.cs
+++ b/src/AgentBlazor.Cli/Program.cs
@@ -7,7 +7,7 @@ var version = typeof(ScaffoldCommand).Assembly
     .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
     ?.InformationalVersion
     ?? typeof(ScaffoldCommand).Assembly.GetName().Version?.ToString()
-    ?? "0.2.17";
+    ?? "0.2.18";
 version = version.Split('+', 2)[0];
 
 app.Configure(config =>

--- a/src/AgentBlazor.Cli/README.md
+++ b/src/AgentBlazor.Cli/README.md
@@ -34,6 +34,8 @@ Version `0.2.16` removes the `0.2.15` map-layer workflow framing and filters UI 
 
 Version `0.2.17` improves workflow relevance by demoting pure read-only data/view suggestions from top recommendations when process-oriented workflow candidates exist.
 
+Version `0.2.18` improves top recommendation quality by demoting raw integration, admin/sensitive, data-access, and infrastructure suggestions so reports prioritize real business/process workflows instead of plumbing.
+
 Current reports put top workflow recommendations and install blockers before the detailed inventory. The service inventory is classified by agent fit so data-access, admin/sensitive, integration, and workflow surfaces are easier to review without treating every public service as an equal first action candidate.
 
 See:

--- a/tests/AgentBlazor.Cli.Analysis.Tests/ExistingAppScaffoldPlannerTests.cs
+++ b/tests/AgentBlazor.Cli.Analysis.Tests/ExistingAppScaffoldPlannerTests.cs
@@ -250,7 +250,7 @@ public sealed class ExistingAppScaffoldPlannerTests : IDisposable
         Assert.Contains("""<PackageReference Include="MudBlazor" />""", projectText, StringComparison.Ordinal);
         Assert.DoesNotContain("PackageReference Include=\"AgentBlazor\" Version=", projectText, StringComparison.Ordinal);
         Assert.DoesNotContain("PackageReference Include=\"MudBlazor\" Version=", projectText, StringComparison.Ordinal);
-        Assert.Contains("""<PackageVersion Include="AgentBlazor" Version="0.2.17" />""", centralPackagesText, StringComparison.Ordinal);
+        Assert.Contains("""<PackageVersion Include="AgentBlazor" Version="0.2.18" />""", centralPackagesText, StringComparison.Ordinal);
         Assert.Contains("""<PackageVersion Include="MudBlazor" Version="9.0.0" />""", centralPackagesText, StringComparison.Ordinal);
     }
 

--- a/tests/AgentBlazor.Cli.Analysis.Tests/Generation/AnalysisReportGeneratorTests.cs
+++ b/tests/AgentBlazor.Cli.Analysis.Tests/Generation/AnalysisReportGeneratorTests.cs
@@ -221,7 +221,7 @@ public sealed class AnalysisReportGeneratorTests : IDisposable
 
         Assert.Contains("Submit Asset for Review", topRecommendations);
         Assert.DoesNotContain("View Asset Markers", topRecommendations);
-        Assert.Contains("1 read-only data/view suggestion(s) were not promoted", topRecommendations);
+        Assert.Contains("1 supporting data, integration, admin, or infrastructure suggestion(s) were not promoted", topRecommendations);
         Assert.Contains("### View Asset Markers", content);
     }
 
@@ -252,6 +252,153 @@ public sealed class AnalysisReportGeneratorTests : IDisposable
         Assert.Contains("No process-oriented workflow candidates were found", topRecommendations);
         Assert.DoesNotContain("| View Asset Markers |", topRecommendations);
         Assert.Contains("### View Asset Markers", content);
+    }
+
+    [Fact]
+    public void GenerateMarkdown_DemotesIntegrationAdminAndDataAccessSuggestions_FromTopRecommendations()
+    {
+        var model = CreateModel() with
+        {
+            Services =
+            [
+                new ServiceModel
+                {
+                    TypeName = "RevisionSubmissionService",
+                    FilePath = "Services/RevisionSubmissionService.cs",
+                    Lifetime = "Scoped",
+                    Methods =
+                    [
+                        new ServiceMethodModel { Name = "SubmitAsync", ReturnType = "Task<SubmissionResult>", IsAsync = true, IsPublic = true }
+                    ]
+                },
+                new ServiceModel
+                {
+                    TypeName = "OriginAIChatClient",
+                    FilePath = "Services/AI/Clients/OriginAIChatClient.cs",
+                    Lifetime = "Scoped",
+                    Methods =
+                    [
+                        new ServiceMethodModel { Name = "StartAsync", ReturnType = "Task<AIChatSession>", IsAsync = true, IsPublic = true }
+                    ]
+                },
+                new ServiceModel
+                {
+                    TypeName = "FileUploaderService",
+                    FilePath = "Services/Files/FileUploaderService.cs",
+                    Lifetime = "Singleton",
+                    Methods =
+                    [
+                        new ServiceMethodModel { Name = "UploadFileAsync", ReturnType = "Task", IsAsync = true, IsPublic = true }
+                    ]
+                },
+                new ServiceModel
+                {
+                    TypeName = "ESGUserService",
+                    FilePath = "Plugins/ESG/Services/ESGUserService.cs",
+                    Lifetime = "Scoped",
+                    Methods =
+                    [
+                        new ServiceMethodModel { Name = "AddFavouriteCountryAsync", ReturnType = "Task<ESGUserWrapper>", IsAsync = true, IsPublic = true }
+                    ]
+                },
+                new ServiceModel
+                {
+                    TypeName = "MongoService",
+                    FilePath = "Services/MongoDb/MongoService.cs",
+                    Lifetime = "Scoped",
+                    Methods =
+                    [
+                        new ServiceMethodModel { Name = "ClearCache", ReturnType = "void", IsPublic = true }
+                    ]
+                }
+            ],
+            Actions =
+            [
+                new ActionModel
+                {
+                    Name = "Submit ESG Rating Package",
+                    SourceService = "RevisionSubmissionService",
+                    MethodName = "SubmitAsync",
+                    FilePath = "Services/RevisionSubmissionService.cs",
+                    ExposureMode = ActionExposureMode.Suggested,
+                    Classification = ActionClassification.Workflow,
+                    IsMutationLikely = true,
+                    RequiresApproval = true,
+                    Score = 0.9
+                },
+                new ActionModel
+                {
+                    Name = "Start AI Chat Session",
+                    SourceService = "OriginAIChatClient",
+                    MethodName = "StartAsync",
+                    FilePath = "Services/AI/Clients/OriginAIChatClient.cs",
+                    ExposureMode = ActionExposureMode.Suggested,
+                    Classification = ActionClassification.Workflow,
+                    IsMutationLikely = true,
+                    RequiresApproval = true,
+                    Score = 0.85
+                },
+                new ActionModel
+                {
+                    Name = "Upload File for Review",
+                    SourceService = "FileUploaderService",
+                    MethodName = "UploadFileAsync",
+                    FilePath = "Services/Files/FileUploaderService.cs",
+                    ExposureMode = ActionExposureMode.Suggested,
+                    Classification = ActionClassification.Command,
+                    IsMutationLikely = true,
+                    RequiresApproval = true,
+                    Score = 0.8
+                },
+                new ActionModel
+                {
+                    Name = "Add Favourite Country",
+                    SourceService = "ESGUserService",
+                    MethodName = "AddFavouriteCountryAsync",
+                    FilePath = "Plugins/ESG/Services/ESGUserService.cs",
+                    ExposureMode = ActionExposureMode.Suggested,
+                    Classification = ActionClassification.Command,
+                    IsMutationLikely = true,
+                    RequiresApproval = true,
+                    Score = 0.75
+                },
+                new ActionModel
+                {
+                    Name = "Clear Cache",
+                    SourceService = "MongoService",
+                    MethodName = "ClearCache",
+                    FilePath = "Services/MongoDb/MongoService.cs",
+                    ExposureMode = ActionExposureMode.Suggested,
+                    Classification = ActionClassification.Command,
+                    IsMutationLikely = true,
+                    RequiresApproval = true,
+                    Score = 0.7
+                }
+            ]
+        };
+        var suggestions = new WorkflowSuggestionSet
+        {
+            Model = "test-model",
+            Suggestions =
+            [
+                CreateSuggestion("Submit ESG Rating Package", "RevisionSubmissionService", "SubmitAsync", 0.90),
+                CreateSuggestion("Start AI Chat Session", "OriginAIChatClient", "StartAsync", 0.85),
+                CreateSuggestion("Upload File for Review", "FileUploaderService", "UploadFileAsync", 0.80),
+                CreateSuggestion("Add Favourite Country", "ESGUserService", "AddFavouriteCountryAsync", 0.75),
+                CreateSuggestion("Clear Cache", "MongoService", "ClearCache", 0.70)
+            ]
+        };
+
+        var content = _generator.GenerateMarkdown(model, workflowSuggestions: suggestions);
+        var topRecommendations = ExtractSection(content, "## Top Recommendations", "## Install Blockers");
+
+        Assert.Contains("Submit ESG Rating Package", topRecommendations);
+        Assert.DoesNotContain("Start AI Chat Session", topRecommendations);
+        Assert.DoesNotContain("Upload File for Review", topRecommendations);
+        Assert.DoesNotContain("Add Favourite Country", topRecommendations);
+        Assert.DoesNotContain("Clear Cache", topRecommendations);
+        Assert.Contains("4 supporting data, integration, admin, or infrastructure suggestion(s) were not promoted", topRecommendations);
+        Assert.Contains("### Clear Cache", content);
     }
 
     [Fact]
@@ -1591,6 +1738,21 @@ public sealed class AnalysisReportGeneratorTests : IDisposable
         var end = content.IndexOf(endHeading, start + startHeading.Length, StringComparison.Ordinal);
         Assert.True(end > start, $"Could not find section end `{endHeading}`.");
         return content[start..end];
+    }
+
+    private static WorkflowSuggestion CreateSuggestion(string name, string service, string method, double confidence)
+    {
+        return new WorkflowSuggestion
+        {
+            Name = name,
+            Description = $"{name}.",
+            Reasoning = $"{name}.",
+            Confidence = confidence,
+            Methods =
+            [
+                new WorkflowMethodReference { Service = service, Method = method }
+            ]
+        };
     }
 
     private static ProjectModel CreateModel() => new()


### PR DESCRIPTION
## Summary

- release AgentBlazor 0.2.18
- demote raw integration, admin/sensitive, data-access, and infrastructure suggestions from Top Recommendations
- tighten LLM prompt guidance for chat/file/email/cache/database plumbing
- add regression coverage for the 0.2.17 fw10 report shape

## Verification

- dotnet test tests/AgentBlazor.Cli.Analysis.Tests/AgentBlazor.Cli.Analysis.Tests.csproj --no-restore -v minimal
- dotnet build src/AgentBlazor.Cli/AgentBlazor.Cli.csproj --no-restore -v minimal
