### PR TITLE
Release 0.2.19 workflow clustering

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
 
   <!-- Common package metadata for all AgentBlazor packages -->
   <PropertyGroup>
-    <Version>0.2.18</Version>
+    <Version>0.2.19</Version>
     <Authors>Ash Peterson</Authors>
     <Company>AgentBlazor</Company>
     <Copyright>Copyright (c) 2026 Ash Peterson</Copyright>
@@ -16,7 +16,7 @@
     <RepositoryType>git</RepositoryType>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <PackageIcon>icon.png</PackageIcon>
-    <PackageReleaseNotes>v0.2.18: CLI top recommendation quality patch. Demotes raw integration, admin/sensitive, data-access, and infrastructure suggestions from Top Recommendations so reports prioritize real business/process workflows instead of plumbing such as chat-session starts, file-upload primitives, cache clearing, or direct database operations.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.2.19: CLI analysis workflow clustering. Adds a static pre-pass that groups lifecycle, route-correlated, and domain-correlated methods into multi-step workflow clusters before prompting the model, so reports can surface real pipelines instead of renaming isolated service methods.</PackageReleaseNotes>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <Deterministic>true</Deterministic>

--- a/docs/releases/0.2.19.md
+++ b/docs/releases/0.2.19.md
@@ -1,0 +1,13 @@
+# AgentBlazor.Cli 0.2.19
+
+`0.2.19` improves `agentblazor analyze` workflow suggestion quality by adding static workflow clustering before the LLM prompt is built.
+
+The analyzer now groups related methods into workflow clusters when it finds:
+
+- same-service lifecycle pipelines, such as generate -> upload -> submit -> status -> promote
+- route-correlated methods used from the same page or route
+- domain-correlated methods that share business terms across services
+
+Reports now include a `Workflow Clusters` section before LLM workflow suggestions, showing the cluster origin, risk, confidence, route hints, methods, roles, and evidence. The LLM prompt receives those clusters before the flat service inventory, so models can suggest multi-step process workflows instead of renaming isolated service methods.
+
+This release keeps the `0.2.18` recommendation-quality guardrails that demote raw integration, admin/sensitive, data-access, and infrastructure suggestions from top recommendations.

--- a/src/AgentBlazor.Cli.Analysis/ExistingAppScaffoldApplier.cs
+++ b/src/AgentBlazor.Cli.Analysis/ExistingAppScaffoldApplier.cs
@@ -301,7 +301,7 @@ public sealed class ExistingAppScaffoldApplier
             .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
             ?.InformationalVersion
             ?? typeof(ExistingAppScaffoldApplier).Assembly.GetName().Version?.ToString()
-            ?? "0.2.18";
+            ?? "0.2.19";
 
         return version.Split('+', 2)[0];
     }

--- a/src/AgentBlazor.Cli.Analysis/Generation/AnalysisReportGenerator.cs
+++ b/src/AgentBlazor.Cli.Analysis/Generation/AnalysisReportGenerator.cs
@@ -48,6 +48,7 @@ public sealed class AnalysisReportGenerator
         WriteInstallBlockers(sb, readiness);
         WriteRoutes(sb, model);
         WriteCapabilities(sb, model);
+        WriteWorkflowClusters(sb, model);
         WriteWorkflowSuggestions(sb, model, workflowSuggestions);
         if (readiness is not null)
         {
@@ -73,6 +74,7 @@ public sealed class AnalysisReportGenerator
         sb.AppendLine($"- Developer-facing services discovered: {reportableServiceCount}");
         sb.AppendLine($"- Confirmed actions: {confirmedCount}");
         sb.AppendLine($"- Discovered candidate actions: {discoveredCount}");
+        sb.AppendLine($"- Workflow clusters discovered: {model.WorkflowClusters.Count}");
         if (readiness is not null)
         {
             sb.AppendLine($"- Install readiness: {readiness.PassCount} passed, {readiness.WarningCount} warnings, {readiness.MissingCount} missing");
@@ -163,10 +165,52 @@ public sealed class AnalysisReportGenerator
         sb.AppendLine();
     }
 
+    private static void WriteWorkflowClusters(StringBuilder sb, ProjectModel model)
+    {
+        sb.AppendLine("## Workflow Clusters");
+        sb.AppendLine();
+
+        if (model.WorkflowClusters.Count == 0)
+        {
+            sb.AppendLine("No multi-method workflow clusters were inferred from the static analysis model.");
+            sb.AppendLine();
+            return;
+        }
+
+        sb.AppendLine("Static pre-pass clusters that are sent to the workflow-suggestion model as multi-step process context.");
+        sb.AppendLine();
+        sb.AppendLine("| Cluster | Origin | Risk | Confidence | Routes | Methods | Evidence |");
+        sb.AppendLine("| --- | --- | --- | --- | --- | --- | --- |");
+
+        foreach (var cluster in model.WorkflowClusters
+            .OrderByDescending(cluster => cluster.Confidence)
+            .ThenBy(cluster => cluster.Name, StringComparer.OrdinalIgnoreCase)
+            .Take(12))
+        {
+            var routes = cluster.RouteHints.Count == 0
+                ? "-"
+                : string.Join("<br>", cluster.RouteHints.Select(route => $"`{EscapeTableCell(route)}`"));
+            var methods = cluster.Methods.Count == 0
+                ? "-"
+                : string.Join("<br>", cluster.Methods.Select(method => $"`{EscapeTableCell(method.Service)}.{EscapeTableCell(method.Method)}` ({EscapeTableCell(method.Role)})"));
+            var evidence = cluster.Evidence.Count == 0
+                ? "-"
+                : string.Join("<br>", cluster.Evidence.Take(3).Select(item => EscapeTableCell(TrimForTable(item, 120))));
+
+            sb.AppendLine($"| {EscapeTableCell(cluster.Name)} | {EscapeTableCell(cluster.Origin)} | {EscapeTableCell(cluster.Risk)} | {cluster.Confidence.ToString("0.00", CultureInfo.InvariantCulture)} | {routes} | {methods} | {evidence} |");
+        }
+
+        sb.AppendLine();
+    }
+
     private static void WriteInstallBlockers(StringBuilder sb, InstallReadinessReport? readiness)
     {
         if (readiness is null)
         {
+            sb.AppendLine("## Install Blockers");
+            sb.AppendLine();
+            sb.AppendLine("Install readiness was not evaluated for this analysis run.");
+            sb.AppendLine();
             return;
         }
 
@@ -597,7 +641,8 @@ public sealed class AnalysisReportGenerator
 
         if (ContainsAny(name, "Permission", "Password", "User", "Setup", "Cookie", "Auth", "Tenant") ||
             ContainsAny(path, "\\Permissions\\", "/Permissions/", "\\Users\\", "/Users/", "\\Setup\\", "/Setup/", "\\Cookies\\", "/Cookies/") ||
-            methods.Any(method => ContainsAny(method, "ResetPassword", "SendPasswordReset", "AddPermission", "CheckPermission", "AddTenant", "CreateSystemUser", "DeleteCookie")))
+            methods.Any(method => ContainsAny(method, "ResetPassword", "SendPasswordReset", "AddPermission", "CheckPermission", "AddTenant", "CreateSystemUser", "DeleteCookie")) ||
+            IsGenericWorkflowEngineService(name, methods))
         {
             return new ServiceClassification(ServiceCategory.AdminOrSensitive, "Use cautiously; likely needs explicit approval policy and tenant/user context before exposing.");
         }
@@ -630,6 +675,12 @@ public sealed class AnalysisReportGenerator
 
     private static bool ContainsAny(string value, params string[] fragments)
         => fragments.Any(fragment => value.Contains(fragment, StringComparison.OrdinalIgnoreCase));
+
+    private static bool IsGenericWorkflowEngineService(string serviceName, IReadOnlyCollection<string> methodNames)
+    {
+        return ContainsAny(serviceName, "Workflow") &&
+            methodNames.Any(method => ContainsAny(method, "ExecuteWorkflow", "RunWorkflow", "LoadWorkflow", "RunWorkflowFromJson"));
+    }
 
     private static string ServiceCategoryLabel(ServiceCategory category)
         => category switch

--- a/src/AgentBlazor.Cli.Analysis/ModelBuilder.cs
+++ b/src/AgentBlazor.Cli.Analysis/ModelBuilder.cs
@@ -17,6 +17,7 @@ public sealed class ModelBuilder
     private readonly AttributeAnalyzer _attributeAnalyzer = new();
     private readonly DiRegistrationAnalyzer _diAnalyzer = new();
     private readonly RecommendationEngine _recommendationEngine = new();
+    private readonly WorkflowClusterAnalyzer _workflowClusterAnalyzer = new();
 
     public event Action<string>? OnProgress;
     public event Action<string>? OnWarning;
@@ -347,7 +348,7 @@ public sealed class ModelBuilder
             relativeBaseDir,
             ct);
 
-        // 11. Build initial model for recommendations analysis
+        // 11. Build initial model and derive workflow clusters before prompting/reporting.
         var initialModel = new ProjectModel
         {
             SchemaVersion = "1",
@@ -364,6 +365,11 @@ public sealed class ModelBuilder
             Pages = pages,
             DiRegistrations = diRegistrations,
             FileHashes = fileHashes
+        };
+        var workflowClusters = _workflowClusterAnalyzer.Analyze(initialModel);
+        initialModel = initialModel with
+        {
+            WorkflowClusters = workflowClusters
         };
 
         // 12. Generate recommendations and coverage stats

--- a/src/AgentBlazor.Cli.Analysis/Models/ProjectModel.cs
+++ b/src/AgentBlazor.Cli.Analysis/Models/ProjectModel.cs
@@ -17,6 +17,7 @@ public sealed record ProjectModel
     public IReadOnlyList<ComponentModel> Components { get; init; } = [];
     public IReadOnlyList<ServiceModel> Services { get; init; } = [];
     public IReadOnlyList<ActionModel> Actions { get; init; } = [];
+    public IReadOnlyList<WorkflowClusterModel> WorkflowClusters { get; init; } = [];
     public IReadOnlyList<PageModel> Pages { get; init; } = [];
     public IReadOnlyList<DiRegistrationModel> DiRegistrations { get; init; } = [];
     public IReadOnlyList<RecommendationModel> Recommendations { get; init; } = [];
@@ -138,6 +139,34 @@ public enum ActionExposureMode
     Suggested,  // CLI suggests exposing
     Confirmed,  // Developer confirmed
     Ignored     // Developer chose to ignore
+}
+
+public sealed record WorkflowClusterModel
+{
+    public string Id { get; init; } = "";
+    public string Name { get; init; } = "";
+    public string SourceService { get; init; } = "";
+    public string FilePath { get; init; } = "";
+    public string Summary { get; init; } = "";
+    public double Confidence { get; init; }
+    public bool RequiresApproval { get; init; }
+    public string Risk { get; init; } = "";
+    public string Origin { get; init; } = "";
+    public IReadOnlyList<string> DomainTerms { get; init; } = [];
+    public IReadOnlyList<string> RelatedServices { get; init; } = [];
+    public IReadOnlyList<string> Evidence { get; init; } = [];
+    public IReadOnlyList<WorkflowClusterMethodModel> Methods { get; init; } = [];
+    public IReadOnlyList<string> RouteHints { get; init; } = [];
+}
+
+public sealed record WorkflowClusterMethodModel
+{
+    public string Service { get; init; } = "";
+    public string Method { get; init; } = "";
+    public string Role { get; init; } = "";
+    public ActionClassification Classification { get; init; }
+    public string Risk { get; init; } = "";
+    public string Summary { get; init; } = "";
 }
 
 public sealed record PageModel

--- a/src/AgentBlazor.Cli.Analysis/WorkflowClusterAnalyzer.cs
+++ b/src/AgentBlazor.Cli.Analysis/WorkflowClusterAnalyzer.cs
@@ -1,0 +1,579 @@
+using System.Text.RegularExpressions;
+using AgentBlazor.Cli.Analysis.Models;
+
+namespace AgentBlazor.Cli.Analysis;
+
+public sealed partial class WorkflowClusterAnalyzer
+{
+    private static readonly IReadOnlyDictionary<string, int> RoleOrder = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
+    {
+        ["prepare"] = 10,
+        ["generate"] = 20,
+        ["validate"] = 25,
+        ["upload"] = 30,
+        ["submit"] = 40,
+        ["status"] = 50,
+        ["promote"] = 60,
+        ["notify"] = 70
+    };
+
+    private static readonly string[] GenericWorkflowMethodTerms =
+    [
+        "ExecuteWorkflow",
+        "RunWorkflow",
+        "LoadWorkflow",
+        "RunWorkflowFromJson"
+    ];
+
+    private static readonly HashSet<string> IgnoredDomainTerms = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "Async",
+        "Service",
+        "Services",
+        "Task",
+        "Tasks",
+        "Model",
+        "Models",
+        "Data",
+        "Client",
+        "Clients",
+        "Request",
+        "Response",
+        "Result",
+        "Results",
+        "Status",
+        "Workflow",
+        "Workflows",
+        "Check",
+        "User",
+        "Users",
+        "Admin",
+        "System",
+        "Item",
+        "Items",
+        "Entity",
+        "Entities",
+        "Object",
+        "Objects"
+    };
+
+    public IReadOnlyList<WorkflowClusterModel> Analyze(ProjectModel model)
+    {
+        ArgumentNullException.ThrowIfNull(model);
+
+        var candidates = BuildCandidateActions(model);
+        var clusters = new List<WorkflowClusterModel>();
+
+        clusters.AddRange(BuildSameServiceLifecycleClusters(model, candidates));
+        clusters.AddRange(BuildRouteCorrelatedClusters(model, candidates));
+        clusters.AddRange(BuildDomainCorrelatedClusters(model, candidates));
+
+        return clusters
+            .GroupBy(cluster => BuildClusterKey(cluster), StringComparer.OrdinalIgnoreCase)
+            .Select(group => group.OrderByDescending(cluster => cluster.Confidence).First())
+            .OrderByDescending(cluster => cluster.Confidence)
+            .ThenByDescending(cluster => cluster.Methods.Count)
+            .ThenBy(cluster => cluster.Name, StringComparer.OrdinalIgnoreCase)
+            .Take(12)
+            .ToList();
+    }
+
+    private static IReadOnlyList<ActionModel> BuildCandidateActions(ProjectModel model)
+    {
+        var servicesByName = model.Services.ToDictionary(service => service.TypeName, StringComparer.OrdinalIgnoreCase);
+
+        return model.Actions
+            .Where(action => action.ExposureMode is ActionExposureMode.Suggested or ActionExposureMode.Confirmed)
+            .Where(AnalysisModelFilters.IsDeveloperFacingAction)
+            .Where(action => servicesByName.TryGetValue(action.SourceService, out var service) &&
+                AnalysisModelFilters.IsDeveloperFacingService(service, model) &&
+                !IsGenericWorkflowEngineService(service, [action]))
+            .GroupBy(action => (action.SourceService, action.MethodName), new MethodKeyComparer())
+            .Select(group => group
+                .OrderByDescending(action => action.ExposureMode == ActionExposureMode.Confirmed)
+                .ThenByDescending(action => action.Score)
+                .First())
+            .ToList();
+    }
+
+    private static IEnumerable<WorkflowClusterModel> BuildSameServiceLifecycleClusters(
+        ProjectModel model,
+        IReadOnlyList<ActionModel> candidates)
+    {
+        var servicesByName = model.Services.ToDictionary(service => service.TypeName, StringComparer.OrdinalIgnoreCase);
+
+        foreach (var actionGroup in candidates.GroupBy(action => action.SourceService, StringComparer.OrdinalIgnoreCase))
+        {
+            if (!servicesByName.TryGetValue(actionGroup.Key, out var service) ||
+                IsGenericWorkflowEngineService(service, actionGroup))
+            {
+                continue;
+            }
+
+            var methods = BuildOrderedMethodSteps(actionGroup);
+            if (!HasEnoughProcessShape(methods, minimumMethods: 3, minimumRoles: 3))
+            {
+                continue;
+            }
+
+            var domainTerms = ExtractDominantDomainTerms(methods.Select(method => method.Action), [service.TypeName]);
+            yield return BuildCluster(
+                origin: "same-service lifecycle",
+                serviceName: service.TypeName,
+                servicePath: service.FilePath,
+                methods: methods,
+                routeHints: BuildRouteHints(model, methods.Select(method => method.Action)),
+                domainTerms: domainTerms,
+                evidence:
+                [
+                    $"same service contains {methods.Count} lifecycle methods",
+                    "method names form an ordered process sequence"
+                ]);
+        }
+    }
+
+    private static IEnumerable<WorkflowClusterModel> BuildRouteCorrelatedClusters(
+        ProjectModel model,
+        IReadOnlyList<ActionModel> candidates)
+    {
+        var actionsById = candidates.ToDictionary(action => action.Id, StringComparer.OrdinalIgnoreCase);
+        var actionsByRoute = new Dictionary<string, List<ActionModel>>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var action in candidates)
+        {
+            foreach (var route in action.RelevantRoutes.Where(route => !string.IsNullOrWhiteSpace(route)))
+            {
+                AddAction(actionsByRoute, route, action);
+            }
+        }
+
+        foreach (var page in model.Pages)
+        {
+            foreach (var actionId in page.SuggestedActions)
+            {
+                if (!string.IsNullOrWhiteSpace(page.Route) &&
+                    actionsById.TryGetValue(actionId, out var action))
+                {
+                    AddAction(actionsByRoute, page.Route, action);
+                }
+            }
+        }
+
+        foreach (var routeGroup in actionsByRoute)
+        {
+            var route = routeGroup.Key;
+            var routeActions = routeGroup.Value
+                .GroupBy(action => (action.SourceService, action.MethodName), new MethodKeyComparer())
+                .Select(group => group.OrderByDescending(action => action.Score).First())
+                .ToList();
+
+            var methods = BuildOrderedMethodSteps(routeActions)
+                .Where(method => IsProcessAction(method.Action))
+                .ToList();
+
+            if (!HasEnoughProcessShape(methods, minimumMethods: 2, minimumRoles: 2))
+            {
+                continue;
+            }
+
+            var routeTerms = ExtractDomainTerms(route);
+            var domainTerms = ExtractDominantDomainTerms(methods.Select(method => method.Action), routeTerms);
+            if (domainTerms.Count == 0 && methods.Select(method => method.Action.SourceService).Distinct(StringComparer.OrdinalIgnoreCase).Count() > 1)
+            {
+                continue;
+            }
+
+            var component = model.Pages.FirstOrDefault(page => string.Equals(page.Route, route, StringComparison.OrdinalIgnoreCase))?.ComponentName;
+            yield return BuildCluster(
+                origin: "route-correlated workflow",
+                serviceName: BuildRouteClusterName(component, route, domainTerms),
+                servicePath: "",
+                methods: methods,
+                routeHints: [route],
+                domainTerms: domainTerms,
+                evidence:
+                [
+                    $"methods are used or linked from route {route}",
+                    methods.Select(method => method.Action.SourceService).Distinct(StringComparer.OrdinalIgnoreCase).Count() > 1
+                        ? "route correlates multiple services"
+                        : "route correlates multiple lifecycle methods"
+                ]);
+        }
+    }
+
+    private static IEnumerable<WorkflowClusterModel> BuildDomainCorrelatedClusters(
+        ProjectModel model,
+        IReadOnlyList<ActionModel> candidates)
+    {
+        var termGroups = candidates
+            .SelectMany(action => ExtractDomainTerms(action.SourceService, action.MethodName)
+                .Select(term => (Term: term, Action: action)))
+            .Where(item => !IgnoredDomainTerms.Contains(item.Term))
+            .GroupBy(item => item.Term, StringComparer.OrdinalIgnoreCase);
+
+        foreach (var termGroup in termGroups)
+        {
+            var actions = termGroup
+                .Select(item => item.Action)
+                .DistinctBy(action => $"{action.SourceService}.{action.MethodName}", StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            if (actions.Select(action => action.SourceService).Distinct(StringComparer.OrdinalIgnoreCase).Count() < 2)
+            {
+                continue;
+            }
+
+            var methods = BuildOrderedMethodSteps(actions)
+                .Where(method => IsProcessAction(method.Action))
+                .ToList();
+
+            if (!HasEnoughProcessShape(methods, minimumMethods: 3, minimumRoles: 3))
+            {
+                continue;
+            }
+
+            yield return BuildCluster(
+                origin: "domain-correlated workflow",
+                serviceName: $"{termGroup.Key} Pipeline",
+                servicePath: "",
+                methods: methods,
+                routeHints: BuildRouteHints(model, methods.Select(method => method.Action)),
+                domainTerms: [termGroup.Key],
+                evidence:
+                [
+                    $"multiple services share the domain term '{termGroup.Key}'",
+                    "shared domain methods form a lifecycle sequence"
+                ]);
+        }
+    }
+
+    private static WorkflowClusterModel BuildCluster(
+        string origin,
+        string serviceName,
+        string servicePath,
+        IReadOnlyList<(ActionModel Action, string Role)> methods,
+        IReadOnlyList<string> routeHints,
+        IReadOnlyList<string> domainTerms,
+        IReadOnlyList<string> evidence)
+    {
+        var highestRisk = methods
+            .Select(method => ActionRisk.GetRiskBand(method.Action))
+            .DefaultIfEmpty(ActionRiskBand.SafeReadOnly)
+            .OrderByDescending(risk => (int)risk)
+            .First();
+        var displayName = BuildDisplayName(serviceName, methods.Select(method => method.Action.MethodName), domainTerms);
+        var relatedServices = methods
+            .Select(method => method.Action.SourceService)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(service => service, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        return new WorkflowClusterModel
+        {
+            Id = NormalizeId($"{origin}-{displayName}"),
+            Name = displayName,
+            SourceService = relatedServices.Count == 1 ? relatedServices[0] : serviceName,
+            FilePath = servicePath,
+            Summary = BuildSummary(displayName, methods),
+            Confidence = CalculateConfidence(methods, routeHints, domainTerms, origin),
+            RequiresApproval = methods.Any(method =>
+                method.Action.RequiresApproval ||
+                method.Action.IsMutationLikely ||
+                ActionRisk.GetRiskBand(method.Action) is ActionRiskBand.ApprovalRequired or ActionRiskBand.HighRisk),
+            Risk = ActionRisk.Describe(highestRisk),
+            Origin = origin,
+            DomainTerms = domainTerms,
+            RelatedServices = relatedServices,
+            Evidence = evidence,
+            RouteHints = routeHints,
+            Methods = methods
+                .Select(method => new WorkflowClusterMethodModel
+                {
+                    Service = method.Action.SourceService,
+                    Method = method.Action.MethodName,
+                    Role = method.Role,
+                    Classification = method.Action.Classification,
+                    Risk = ActionRisk.Describe(ActionRisk.GetRiskBand(method.Action)),
+                    Summary = method.Action.Summary
+                })
+                .ToList()
+        };
+    }
+
+    private static IReadOnlyList<(ActionModel Action, string Role)> BuildOrderedMethodSteps(IEnumerable<ActionModel> actions)
+    {
+        return actions
+            .Select(action => (Action: action, Role: GetLifecycleRole(action.MethodName)))
+            .Where(item => item.Role is not null)
+            .Select(item => (item.Action, Role: item.Role!))
+            .GroupBy(item => (item.Action.SourceService, item.Action.MethodName), new MethodKeyComparer())
+            .Select(group => group
+                .OrderByDescending(item => item.Action.ExposureMode == ActionExposureMode.Confirmed)
+                .ThenByDescending(item => item.Action.Score)
+                .First())
+            .OrderBy(item => RoleOrder[item.Role])
+            .ThenByDescending(item => IsProcessAction(item.Action))
+            .ThenBy(item => item.Action.SourceService, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(item => item.Action.MethodName, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private static IReadOnlyList<string> BuildRouteHints(ProjectModel model, IEnumerable<ActionModel> actions)
+    {
+        var actionKeys = actions
+            .Select(action => (action.SourceService, action.MethodName))
+            .ToHashSet(new MethodKeyComparer());
+        var routes = actions
+            .SelectMany(action => action.RelevantRoutes)
+            .Where(route => !string.IsNullOrWhiteSpace(route))
+            .ToList();
+
+        foreach (var page in model.Pages)
+        {
+            if (string.IsNullOrWhiteSpace(page.Route))
+            {
+                continue;
+            }
+
+            var pageMatches = model.Actions
+                .Where(action => page.SuggestedActions.Contains(action.Id, StringComparer.OrdinalIgnoreCase))
+                .Any(action => actionKeys.Contains((action.SourceService, action.MethodName)));
+            if (pageMatches)
+            {
+                routes.Add(page.Route);
+            }
+        }
+
+        return routes
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(route => route, StringComparer.OrdinalIgnoreCase)
+            .Take(8)
+            .ToList();
+    }
+
+    private static bool HasEnoughProcessShape(
+        IReadOnlyList<(ActionModel Action, string Role)> methods,
+        int minimumMethods,
+        int minimumRoles)
+    {
+        return methods.Count >= minimumMethods &&
+            methods.Select(method => method.Role).Distinct(StringComparer.OrdinalIgnoreCase).Count() >= minimumRoles &&
+            methods.Any(method => IsProcessAction(method.Action));
+    }
+
+    private static bool IsProcessAction(ActionModel action)
+    {
+        return action.Classification is (ActionClassification.Workflow or ActionClassification.Command or ActionClassification.Export or ActionClassification.Validation) &&
+            !ActionRisk.IsSafeReadOnly(action);
+    }
+
+    private static string BuildSummary(string displayName, IReadOnlyList<(ActionModel Action, string Role)> methods)
+    {
+        var sequence = string.Join(" -> ", methods.Select(method => $"{method.Action.SourceService}.{method.Action.MethodName}"));
+        return $"{displayName} appears to be a multi-step process: {sequence}.";
+    }
+
+    private static double CalculateConfidence(
+        IReadOnlyList<(ActionModel Action, string Role)> methods,
+        IReadOnlyList<string> routeHints,
+        IReadOnlyList<string> domainTerms,
+        string origin)
+    {
+        var distinctRoles = methods
+            .Select(method => method.Role)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Count();
+        var averageActionScore = methods.Count == 0 ? 0.0 : methods.Average(method => method.Action.Score);
+        var roleScore = Math.Min(1.0, distinctRoles / 5.0);
+        var methodScore = Math.Min(1.0, methods.Count / 5.0);
+        var routeScore = routeHints.Count > 0 ? 0.1 : 0.0;
+        var domainScore = domainTerms.Count > 0 ? 0.1 : 0.0;
+        var originScore = origin.Equals("same-service lifecycle", StringComparison.OrdinalIgnoreCase) ? 0.05 : 0.0;
+
+        return Math.Round(Math.Min(1.0, (averageActionScore * 0.35) + (roleScore * 0.25) + (methodScore * 0.15) + routeScore + domainScore + originScore), 2);
+    }
+
+    private static IReadOnlyList<string> ExtractDominantDomainTerms(IEnumerable<ActionModel> actions, IEnumerable<string> extraText)
+    {
+        return actions
+            .SelectMany(action => ExtractDomainTerms(action.SourceService, action.MethodName, action.Name, action.Summary))
+            .Concat(extraText.SelectMany(text => ExtractDomainTerms(text)))
+            .Where(term => !IgnoredDomainTerms.Contains(term))
+            .GroupBy(term => term, StringComparer.OrdinalIgnoreCase)
+            .OrderByDescending(group => group.Count())
+            .ThenBy(group => group.Key, StringComparer.OrdinalIgnoreCase)
+            .Select(group => group.Key)
+            .Take(5)
+            .ToList();
+    }
+
+    private static IReadOnlyList<string> ExtractDomainTerms(params string[] values)
+    {
+        return values
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .SelectMany(SplitIdentifier)
+            .Where(word => word.Length >= 4)
+            .Where(word => !RoleOrder.ContainsKey(word))
+            .Where(word => !IgnoredDomainTerms.Contains(word))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private static string BuildDisplayName(
+        string sourceName,
+        IEnumerable<string> methodNames,
+        IReadOnlyList<string> domainTerms)
+    {
+        var sourceWords = SplitIdentifier(sourceName)
+            .Where(word => !IgnoredDomainTerms.Contains(word))
+            .ToList();
+        var methodWords = methodNames
+            .SelectMany(SplitIdentifier)
+            .Where(word => !IgnoredDomainTerms.Contains(word))
+            .Where(word => !RoleOrder.ContainsKey(word))
+            .GroupBy(word => word, StringComparer.OrdinalIgnoreCase)
+            .Where(group => group.Count() > 1)
+            .Select(group => group.Key)
+            .ToList();
+
+        var leadingWords = sourceWords.Count > 0 ? sourceWords : domainTerms;
+        var words = leadingWords
+            .Concat(methodWords)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Take(4)
+            .ToList();
+
+        if (words.Count == 0)
+        {
+            words.Add("Business");
+        }
+
+        words.Add("Pipeline");
+        return string.Join(' ', words);
+    }
+
+    private static string BuildRouteClusterName(string? componentName, string route, IReadOnlyList<string> domainTerms)
+    {
+        if (!string.IsNullOrWhiteSpace(componentName))
+        {
+            return componentName;
+        }
+
+        var routeWords = ExtractDomainTerms(route);
+        var words = domainTerms.Concat(routeWords).Distinct(StringComparer.OrdinalIgnoreCase).Take(3).ToList();
+        return words.Count == 0 ? "Route Workflow" : string.Join(' ', words);
+    }
+
+    private static bool IsGenericWorkflowEngineService(
+        ServiceModel service,
+        IEnumerable<ActionModel> actions)
+    {
+        return service.TypeName.Contains("Workflow", StringComparison.OrdinalIgnoreCase) &&
+            actions.Any(action => ContainsAny(action.MethodName, GenericWorkflowMethodTerms));
+    }
+
+    private static string? GetLifecycleRole(string methodName)
+    {
+        var normalized = methodName.EndsWith("Async", StringComparison.OrdinalIgnoreCase)
+            ? methodName[..^"Async".Length]
+            : methodName;
+
+        if (ContainsAny(normalized, "Prepare", "Initialize", "Initiate", "CreateDraft"))
+        {
+            return "prepare";
+        }
+
+        if (ContainsAny(normalized, "CheckStatus", "GetStatus", "Status", "Poll"))
+        {
+            return "status";
+        }
+
+        if (ContainsAny(normalized, "Validate", "Verify", "Check"))
+        {
+            return "validate";
+        }
+
+        if (ContainsAny(normalized, "Upload", "Import"))
+        {
+            return "upload";
+        }
+
+        if (ContainsAny(normalized, "Submit", "Send", "Publish"))
+        {
+            return "submit";
+        }
+
+        if (ContainsAny(normalized, "Promote", "Approve", "Complete", "Finalize"))
+        {
+            return "promote";
+        }
+
+        if (ContainsAny(normalized, "Notify", "Email"))
+        {
+            return "notify";
+        }
+
+        if (ContainsAny(normalized, "Generate", "Build", "Package"))
+        {
+            return "generate";
+        }
+
+        return null;
+    }
+
+    private static void AddAction(IDictionary<string, List<ActionModel>> actionMap, string key, ActionModel action)
+    {
+        if (!actionMap.TryGetValue(key, out var actions))
+        {
+            actions = [];
+            actionMap[key] = actions;
+        }
+
+        actions.Add(action);
+    }
+
+    private static string BuildClusterKey(WorkflowClusterModel cluster)
+        => string.Join(
+            "|",
+            cluster.Methods
+                .Select(method => $"{method.Service}.{method.Method}")
+                .OrderBy(value => value, StringComparer.OrdinalIgnoreCase));
+
+    private static bool ContainsAny(string value, params string[] fragments)
+        => fragments.Any(fragment => value.Contains(fragment, StringComparison.OrdinalIgnoreCase));
+
+    private static IReadOnlyList<string> SplitIdentifier(string value)
+    {
+        var normalized = value.EndsWith("Async", StringComparison.OrdinalIgnoreCase)
+            ? value[..^"Async".Length]
+            : value;
+
+        return IdentifierWordRegex()
+            .Matches(normalized)
+            .Select(match => match.Value)
+            .Where(word => !string.IsNullOrWhiteSpace(word))
+            .ToList();
+    }
+
+    private static string NormalizeId(string value)
+        => string.Join(
+            '-',
+            SplitIdentifier(value)
+                .Select(word => word.ToLowerInvariant()));
+
+    [GeneratedRegex("[A-Z]?[a-z]+|[A-Z]+(?=[A-Z]|$)|\\d+")]
+    private static partial Regex IdentifierWordRegex();
+
+    private sealed class MethodKeyComparer : IEqualityComparer<(string SourceService, string MethodName)>
+    {
+        public bool Equals((string SourceService, string MethodName) x, (string SourceService, string MethodName) y)
+            => string.Equals(x.SourceService, y.SourceService, StringComparison.OrdinalIgnoreCase) &&
+               string.Equals(x.MethodName, y.MethodName, StringComparison.OrdinalIgnoreCase);
+
+        public int GetHashCode((string SourceService, string MethodName) obj)
+            => HashCode.Combine(
+                StringComparer.OrdinalIgnoreCase.GetHashCode(obj.SourceService),
+                StringComparer.OrdinalIgnoreCase.GetHashCode(obj.MethodName));
+    }
+
+}

--- a/src/AgentBlazor.Cli.Analysis/WorkflowSuggestions/WorkflowSuggestionPromptBuilder.cs
+++ b/src/AgentBlazor.Cli.Analysis/WorkflowSuggestions/WorkflowSuggestionPromptBuilder.cs
@@ -24,13 +24,16 @@ public sealed class WorkflowSuggestionPromptBuilder
         sb.AppendLine("- Suggested C# code must use AgentBlazor CapabilityResult and only call listed methods.");
         sb.AppendLine("- Do not invent DTO or entity types in code. If a type is unclear, use comments rather than fake types.");
         sb.AppendLine("- If a listed method has approvalRecommended=true, the suggested [AgentAction] example must include RequiresApproval = true.");
+        sb.AppendLine("- Prioritize workflow clusters when present. They are static-analysis hints that multiple methods likely form one user process.");
+        sb.AppendLine("- When using a workflow cluster, reference several listed methods in the shown order instead of splitting each method into separate workflow suggestions.");
         sb.AppendLine("- A workflow is a user/business process, task, or decision flow. A one-method getter/list/view is usually a data surface, not a workflow.");
         sb.AppendLine("- Prefer methods classified as Workflow first. Prefer Command or Export only when the user-facing process is clear and approval guidance is included.");
         sb.AppendLine("- Use simple Query methods as supporting context for workflows, but do not suggest pure data-view workflows when process-oriented methods are available.");
         sb.AppendLine("- Name workflows for the user's business outcome, not the raw method verb or UI/rendering mechanism.");
         sb.AppendLine("- Avoid suggesting UI rendering, map layer application, chart drawing, styling, layout, or component state plumbing unless the method clearly represents a business workflow.");
         sb.AppendLine("- Avoid raw integration/client primitives such as starting chat sessions, sending email, file upload plumbing, or message transport unless they are part of a larger listed business process.");
-        sb.AppendLine("- Avoid auth, password reset, tenant mutation, message deletion, workflow execution, job execution, cache clearing, database mutation, and permission changes unless no safer workflow exists.");
+        sb.AppendLine("- Avoid auth, password reset, tenant mutation, message deletion, job execution, cache clearing, database mutation, and permission changes unless no safer workflow exists.");
+        sb.AppendLine("- Avoid generic workflow-engine methods such as ExecuteWorkflowAsync, RunWorkflow, LoadWorkflow, or RunWorkflowFromJsonAsync unless they are wrapped by a domain-specific listed service method.");
         sb.AppendLine("- If you must suggest a mutating or admin workflow, suggest at most one and explain that it needs human approval.");
         sb.AppendLine();
         sb.AppendLine("JSON shape:");
@@ -58,6 +61,7 @@ public sealed class WorkflowSuggestionPromptBuilder
         sb.AppendLine();
         AppendRoutes(sb, model);
         AppendConfirmedActions(sb, model);
+        AppendWorkflowClusters(sb, model);
         AppendServices(sb, model);
         return sb.ToString();
     }
@@ -104,9 +108,60 @@ public sealed class WorkflowSuggestionPromptBuilder
         sb.AppendLine();
     }
 
+    private static void AppendWorkflowClusters(StringBuilder sb, ProjectModel model)
+    {
+        sb.AppendLine("Workflow clusters:");
+        if (model.WorkflowClusters.Count == 0)
+        {
+            sb.AppendLine("- none");
+            sb.AppendLine();
+            return;
+        }
+
+        foreach (var cluster in model.WorkflowClusters
+            .OrderByDescending(cluster => cluster.Confidence)
+            .ThenBy(cluster => cluster.SourceService)
+            .Take(12))
+        {
+            sb.AppendLine($"- {cluster.Name}: origin={cluster.Origin}, service={cluster.SourceService}, risk={cluster.Risk}, approvalRecommended={cluster.RequiresApproval.ToString().ToLowerInvariant()}, confidence={cluster.Confidence:0.00}");
+            if (!string.IsNullOrWhiteSpace(cluster.Summary))
+            {
+                sb.AppendLine($"  summary={cluster.Summary}");
+            }
+
+            if (cluster.DomainTerms.Count > 0)
+            {
+                sb.AppendLine($"  domainTerms={string.Join(", ", cluster.DomainTerms)}");
+            }
+
+            if (cluster.RelatedServices.Count > 1)
+            {
+                sb.AppendLine($"  relatedServices={string.Join(", ", cluster.RelatedServices)}");
+            }
+
+            if (cluster.RouteHints.Count > 0)
+            {
+                sb.AppendLine($"  routeHints={string.Join(", ", cluster.RouteHints)}");
+            }
+
+            foreach (var evidence in cluster.Evidence.Take(4))
+            {
+                sb.AppendLine($"  evidence={evidence}");
+            }
+
+            foreach (var method in cluster.Methods)
+            {
+                sb.AppendLine($"  - {method.Service}.{method.Method} [role={method.Role}, classification={method.Classification}, risk={method.Risk}]");
+            }
+        }
+
+        sb.AppendLine();
+    }
+
     private static void AppendServices(StringBuilder sb, ProjectModel model)
     {
         sb.AppendLine("Discovered services and public methods:");
+        sb.AppendLine("Use this flat catalog as supporting context. Prefer the workflow clusters above when they exist.");
         var candidateActions = model.Actions
             .Where(action => action.ExposureMode is ActionExposureMode.Suggested or ActionExposureMode.Confirmed)
             .Where(AnalysisModelFilters.IsDeveloperFacingAction)

--- a/src/AgentBlazor.Cli/PACKAGE_README.md
+++ b/src/AgentBlazor.Cli/PACKAGE_README.md
@@ -11,7 +11,7 @@ dotnet tool install --global AgentBlazor.Cli
 If you prefer a pinned install:
 
 ```bash
-dotnet tool install --global AgentBlazor.Cli --version 0.2.18
+dotnet tool install --global AgentBlazor.Cli --version 0.2.19
 ```
 
 Example:
@@ -58,7 +58,9 @@ Version `0.2.17` improves workflow relevance by demoting pure read-only data/vie
 
 Version `0.2.18` improves top recommendation quality by demoting raw integration, admin/sensitive, data-access, and infrastructure suggestions so reports prioritize real business/process workflows instead of plumbing.
 
-Reports put top workflow recommendations and install blockers before the detailed inventory, filter helper/framework noise, classify remaining services by likely agent fit, show AgentBlazor action adoption, and call out `RequiresApproval = true` guidance for workflow suggestions that reference mutating methods.
+Version `0.2.19` adds workflow-cluster context before LLM suggestion generation. The analyzer now groups lifecycle, route-correlated, and domain-correlated methods into multi-step process candidates so reports can identify pipelines rather than treating every public method as a standalone workflow.
+
+Reports put top workflow recommendations and install blockers before the detailed inventory, show workflow clusters before LLM suggestions, filter helper/framework noise, classify remaining services by likely agent fit, show AgentBlazor action adoption, and call out `RequiresApproval = true` guidance for workflow suggestions that reference mutating methods.
 
 The CLI is an advanced path. The default install story is still `dotnet add package AgentBlazor` plus manual runtime wiring.
 
@@ -66,6 +68,7 @@ Docs:
 
 - Repository: https://github.com/ashpeterson/AgentBlazor
 - Advanced CLI guide: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/advanced/cli.md
+- 0.2.19 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.19.md
 - 0.2.18 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.18.md
 - 0.2.17 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.17.md
 - 0.2.16 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.16.md

--- a/src/AgentBlazor.Cli/Program.cs
+++ b/src/AgentBlazor.Cli/Program.cs
@@ -7,7 +7,7 @@ var version = typeof(ScaffoldCommand).Assembly
     .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
     ?.InformationalVersion
     ?? typeof(ScaffoldCommand).Assembly.GetName().Version?.ToString()
-    ?? "0.2.18";
+    ?? "0.2.19";
 version = version.Split('+', 2)[0];
 
 app.Configure(config =>

--- a/src/AgentBlazor.Cli/README.md
+++ b/src/AgentBlazor.Cli/README.md
@@ -36,7 +36,9 @@ Version `0.2.17` improves workflow relevance by demoting pure read-only data/vie
 
 Version `0.2.18` improves top recommendation quality by demoting raw integration, admin/sensitive, data-access, and infrastructure suggestions so reports prioritize real business/process workflows instead of plumbing.
 
-Current reports put top workflow recommendations and install blockers before the detailed inventory. The service inventory is classified by agent fit so data-access, admin/sensitive, integration, and workflow surfaces are easier to review without treating every public service as an equal first action candidate.
+Version `0.2.19` adds workflow-cluster context before LLM suggestion generation. The analyzer now groups lifecycle, route-correlated, and domain-correlated methods into multi-step process candidates so reports can identify pipelines rather than treating every public method as a standalone workflow.
+
+Current reports put top workflow recommendations and install blockers before the detailed inventory. Workflow clusters are shown before LLM suggestions, and the service inventory is classified by agent fit so data-access, admin/sensitive, integration, and workflow surfaces are easier to review without treating every public service as an equal first action candidate.
 
 See:
 

--- a/tests/AgentBlazor.Cli.Analysis.Tests/ExistingAppScaffoldPlannerTests.cs
+++ b/tests/AgentBlazor.Cli.Analysis.Tests/ExistingAppScaffoldPlannerTests.cs
@@ -250,7 +250,7 @@ public sealed class ExistingAppScaffoldPlannerTests : IDisposable
         Assert.Contains("""<PackageReference Include="MudBlazor" />""", projectText, StringComparison.Ordinal);
         Assert.DoesNotContain("PackageReference Include=\"AgentBlazor\" Version=", projectText, StringComparison.Ordinal);
         Assert.DoesNotContain("PackageReference Include=\"MudBlazor\" Version=", projectText, StringComparison.Ordinal);
-        Assert.Contains("""<PackageVersion Include="AgentBlazor" Version="0.2.18" />""", centralPackagesText, StringComparison.Ordinal);
+        Assert.Contains("""<PackageVersion Include="AgentBlazor" Version="0.2.19" />""", centralPackagesText, StringComparison.Ordinal);
         Assert.Contains("""<PackageVersion Include="MudBlazor" Version="9.0.0" />""", centralPackagesText, StringComparison.Ordinal);
     }
 

--- a/tests/AgentBlazor.Cli.Analysis.Tests/Generation/AnalysisReportGeneratorTests.cs
+++ b/tests/AgentBlazor.Cli.Analysis.Tests/Generation/AnalysisReportGeneratorTests.cs
@@ -66,6 +66,51 @@ public sealed class AnalysisReportGeneratorTests : IDisposable
     }
 
     [Fact]
+    public void GenerateMarkdown_IncludesWorkflowClusters_WhenDiscovered()
+    {
+        var model = CreateModel() with
+        {
+            WorkflowClusters =
+            [
+                new WorkflowClusterModel
+                {
+                    Name = "Revision Submission Package Pipeline",
+                    Origin = "same-service lifecycle",
+                    SourceService = "RevisionSubmissionService",
+                    Risk = "approval required",
+                    Confidence = 0.91,
+                    RouteHints = ["/developers/"],
+                    Evidence = ["same service contains 5 lifecycle methods", "method names form an ordered process sequence"],
+                    Methods =
+                    [
+                        new WorkflowClusterMethodModel
+                        {
+                            Service = "RevisionSubmissionService",
+                            Method = "GeneratePackageAsync",
+                            Role = "generate"
+                        },
+                        new WorkflowClusterMethodModel
+                        {
+                            Service = "RevisionSubmissionService",
+                            Method = "SubmitAsync",
+                            Role = "submit"
+                        }
+                    ]
+                }
+            ]
+        };
+
+        var content = _generator.GenerateMarkdown(model);
+
+        Assert.Contains("- Workflow clusters discovered: 1", content);
+        Assert.Contains("## Workflow Clusters", content);
+        Assert.Contains("Revision Submission Package Pipeline", content);
+        Assert.Contains("same-service lifecycle", content);
+        Assert.Contains("`RevisionSubmissionService.GeneratePackageAsync` (generate)", content);
+        Assert.Contains("same service contains 5 lifecycle methods", content);
+    }
+
+    [Fact]
     public void GenerateMarkdown_IncludesValidatedWorkflowSuggestions_WhenProvided()
     {
         var model = CreateModel() with
@@ -127,7 +172,36 @@ public sealed class AnalysisReportGeneratorTests : IDisposable
     [Fact]
     public void GenerateMarkdown_PutsPrioritizedGuidance_BeforeDetailedInventory()
     {
-        var model = CreateModel();
+        var model = CreateModel() with
+        {
+            Services =
+            [
+                new ServiceModel
+                {
+                    TypeName = "OrderService",
+                    FilePath = "Services/OrderService.cs",
+                    Lifetime = "Scoped",
+                    Methods =
+                    [
+                        new ServiceMethodModel { Name = "CreateOrderAsync", ReturnType = "Task", IsAsync = true, IsPublic = true }
+                    ]
+                }
+            ],
+            Actions =
+            [
+                new ActionModel
+                {
+                    Name = "Create Order",
+                    SourceService = "OrderService",
+                    MethodName = "CreateOrderAsync",
+                    FilePath = "Services/OrderService.cs",
+                    Classification = ActionClassification.Command,
+                    IsMutationLikely = true,
+                    Score = 0.9,
+                    ExposureMode = ActionExposureMode.Suggested
+                }
+            ]
+        };
         var suggestions = new WorkflowSuggestionSet
         {
             Model = "test-model",
@@ -135,13 +209,13 @@ public sealed class AnalysisReportGeneratorTests : IDisposable
             [
                 new WorkflowSuggestion
                 {
-                    Name = "Find orders",
-                    Description = "Find open orders.",
+                    Name = "Create order",
+                    Description = "Create an order.",
                     Methods =
                     [
-                        new WorkflowMethodReference { Service = "OrderService", Method = "FindOrdersAsync" }
+                        new WorkflowMethodReference { Service = "OrderService", Method = "CreateOrderAsync" }
                     ],
-                    Reasoning = "The orders page has a safe lookup method.",
+                    Reasoning = "The orders page has a command method for creating orders.",
                     Confidence = 0.9
                 }
             ]
@@ -153,7 +227,7 @@ public sealed class AnalysisReportGeneratorTests : IDisposable
             content.IndexOf("## Routes And Pages", StringComparison.Ordinal));
         Assert.True(content.IndexOf("## Workflow Suggestions", StringComparison.Ordinal) <
             content.IndexOf("## Service Inventory", StringComparison.Ordinal));
-        Assert.Contains("| Find orders | safe read-only | 0.90 | `OrderService.FindOrdersAsync` |", content);
+        Assert.Contains("| Create order | approval required | 0.90 | `OrderService.CreateOrderAsync` |", content);
     }
 
     [Fact]
@@ -161,6 +235,21 @@ public sealed class AnalysisReportGeneratorTests : IDisposable
     {
         var model = CreateModel() with
         {
+            Services =
+            [
+                new ServiceModel
+                {
+                    TypeName = "ExcelService",
+                    FilePath = "Services/ExcelService.cs",
+                    Methods = [new ServiceMethodModel { Name = "ExportAsync", ReturnType = "Task", IsAsync = true, IsPublic = true }]
+                },
+                new ServiceModel
+                {
+                    TypeName = "PDFService",
+                    FilePath = "Services/PDFService.cs",
+                    Methods = [new ServiceMethodModel { Name = "ExportAsync", ReturnType = "Task", IsAsync = true, IsPublic = true }]
+                }
+            ],
             Actions =
             [
                 .. CreateModel().Actions,
@@ -310,6 +399,16 @@ public sealed class AnalysisReportGeneratorTests : IDisposable
                     [
                         new ServiceMethodModel { Name = "ClearCache", ReturnType = "void", IsPublic = true }
                     ]
+                },
+                new ServiceModel
+                {
+                    TypeName = "WorkflowService",
+                    FilePath = "Services/Workflows/WorkflowService.cs",
+                    Lifetime = "Scoped",
+                    Methods =
+                    [
+                        new ServiceMethodModel { Name = "ExecuteWorkflowAsync", ReturnType = "Task<Workflow>", IsAsync = true, IsPublic = true }
+                    ]
                 }
             ],
             Actions =
@@ -373,6 +472,18 @@ public sealed class AnalysisReportGeneratorTests : IDisposable
                     IsMutationLikely = true,
                     RequiresApproval = true,
                     Score = 0.7
+                },
+                new ActionModel
+                {
+                    Name = "Execute Workflow",
+                    SourceService = "WorkflowService",
+                    MethodName = "ExecuteWorkflowAsync",
+                    FilePath = "Services/Workflows/WorkflowService.cs",
+                    ExposureMode = ActionExposureMode.Suggested,
+                    Classification = ActionClassification.Workflow,
+                    IsMutationLikely = true,
+                    RequiresApproval = true,
+                    Score = 0.85
                 }
             ]
         };
@@ -385,7 +496,8 @@ public sealed class AnalysisReportGeneratorTests : IDisposable
                 CreateSuggestion("Start AI Chat Session", "OriginAIChatClient", "StartAsync", 0.85),
                 CreateSuggestion("Upload File for Review", "FileUploaderService", "UploadFileAsync", 0.80),
                 CreateSuggestion("Add Favourite Country", "ESGUserService", "AddFavouriteCountryAsync", 0.75),
-                CreateSuggestion("Clear Cache", "MongoService", "ClearCache", 0.70)
+                CreateSuggestion("Clear Cache", "MongoService", "ClearCache", 0.70),
+                CreateSuggestion("Execute Workflow", "WorkflowService", "ExecuteWorkflowAsync", 0.85)
             ]
         };
 
@@ -397,8 +509,10 @@ public sealed class AnalysisReportGeneratorTests : IDisposable
         Assert.DoesNotContain("Upload File for Review", topRecommendations);
         Assert.DoesNotContain("Add Favourite Country", topRecommendations);
         Assert.DoesNotContain("Clear Cache", topRecommendations);
-        Assert.Contains("4 supporting data, integration, admin, or infrastructure suggestion(s) were not promoted", topRecommendations);
+        Assert.DoesNotContain("Execute Workflow", topRecommendations);
+        Assert.Contains("5 supporting data, integration, admin, or infrastructure suggestion(s) were not promoted", topRecommendations);
         Assert.Contains("### Clear Cache", content);
+        Assert.Contains("### Execute Workflow", content);
     }
 
     [Fact]
@@ -1439,6 +1553,21 @@ public sealed class AnalysisReportGeneratorTests : IDisposable
     {
         var model = CreateModel() with
         {
+            Services =
+            [
+                new ServiceModel
+                {
+                    TypeName = "StatusReportService",
+                    FilePath = "Services/StatusReportService.cs",
+                    Methods = [new ServiceMethodModel { Name = "GenerateStatusReportAsync", ReturnType = "Task", IsAsync = true, IsPublic = true }]
+                },
+                new ServiceModel
+                {
+                    TypeName = "UserService",
+                    FilePath = "Services/UserService.cs",
+                    Methods = [new ServiceMethodModel { Name = "ResetPasswordAsync", ReturnType = "Task", IsAsync = true, IsPublic = true }]
+                }
+            ],
             Actions =
             [
                 .. CreateModel().Actions,
@@ -1546,6 +1675,21 @@ public sealed class AnalysisReportGeneratorTests : IDisposable
     {
         var model = CreateModel() with
         {
+            Services =
+            [
+                new ServiceModel
+                {
+                    TypeName = "ExcelService",
+                    FilePath = "Services/ExcelService.cs",
+                    Methods = [new ServiceMethodModel { Name = "ExportAsync", ReturnType = "Task", IsAsync = true, IsPublic = true }]
+                },
+                new ServiceModel
+                {
+                    TypeName = "PDFService",
+                    FilePath = "Services/PDFService.cs",
+                    Methods = [new ServiceMethodModel { Name = "ExportAsync", ReturnType = "Task", IsAsync = true, IsPublic = true }]
+                }
+            ],
             Actions =
             [
                 new ActionModel
@@ -1578,10 +1722,25 @@ public sealed class AnalysisReportGeneratorTests : IDisposable
     }
 
     [Fact]
-    public void GenerateMarkdown_PrioritizesSafeStaticCandidates_BeforeHighRiskAdminActions()
+    public void GenerateMarkdown_DoesNotPromoteHighRiskAdminStaticCandidates()
     {
         var model = CreateModel() with
         {
+            Services =
+            [
+                new ServiceModel
+                {
+                    TypeName = "StatusReportService",
+                    FilePath = "Services/StatusReportService.cs",
+                    Methods = [new ServiceMethodModel { Name = "GenerateStatusReportAsync", ReturnType = "Task", IsAsync = true, IsPublic = true }]
+                },
+                new ServiceModel
+                {
+                    TypeName = "UserService",
+                    FilePath = "Services/UserService.cs",
+                    Methods = [new ServiceMethodModel { Name = "ResetPasswordAsync", ReturnType = "Task", IsAsync = true, IsPublic = true }]
+                }
+            ],
             Actions =
             [
                 new ActionModel
@@ -1598,11 +1757,11 @@ public sealed class AnalysisReportGeneratorTests : IDisposable
                 },
                 new ActionModel
                 {
-                    Name = "Get Status Snapshot",
-                    SourceService = "OriginAIClient",
-                    MethodName = "GetStatusSnapshotAsync",
-                    FilePath = "Services/OriginAIClient.cs",
-                    Classification = ActionClassification.Query,
+                    Name = "Generate Status Report",
+                    SourceService = "StatusReportService",
+                    MethodName = "GenerateStatusReportAsync",
+                    FilePath = "Services/StatusReportService.cs",
+                    Classification = ActionClassification.Export,
                     Score = 0.75,
                     ExposureMode = ActionExposureMode.Suggested
                 }
@@ -1612,10 +1771,9 @@ public sealed class AnalysisReportGeneratorTests : IDisposable
 
         var content = _generator.GenerateMarkdown(model);
 
-        Assert.True(content.IndexOf("### Get Status Snapshot", StringComparison.Ordinal) <
-            content.IndexOf("### Reset Password", StringComparison.Ordinal));
-        Assert.Contains("- Risk: safe read-only", content);
-        Assert.Contains("- Risk: high-risk/admin", content);
+        Assert.Contains("### Generate Status Report", content);
+        Assert.DoesNotContain("### Reset Password", content);
+        Assert.Contains("- Risk: review generated output", content);
     }
 
     [Fact]

--- a/tests/AgentBlazor.Cli.Analysis.Tests/WorkflowClusterAnalyzerTests.cs
+++ b/tests/AgentBlazor.Cli.Analysis.Tests/WorkflowClusterAnalyzerTests.cs
@@ -1,0 +1,198 @@
+using AgentBlazor.Cli.Analysis.Models;
+
+namespace AgentBlazor.Cli.Analysis.Tests;
+
+public sealed class WorkflowClusterAnalyzerTests
+{
+    [Fact]
+    public void Analyze_GroupsRevisionSubmissionLifecycleMethods()
+    {
+        var analyzer = new WorkflowClusterAnalyzer();
+        var model = new ProjectModel
+        {
+            Services =
+            [
+                new ServiceModel
+                {
+                    TypeName = "RevisionSubmissionService",
+                    FilePath = "Services/RevisionSubmissionService.cs",
+                    Methods =
+                    [
+                        CreateMethod("CheckStatusAsync"),
+                        CreateMethod("GeneratePackageAsync"),
+                        CreateMethod("PromoteAsync"),
+                        CreateMethod("SubmitAsync"),
+                        CreateMethod("UploadPackageAsync")
+                    ]
+                }
+            ],
+            Actions =
+            [
+                CreateAction("RevisionSubmissionService", "CheckStatusAsync", false, 0.7),
+                CreateAction("RevisionSubmissionService", "GeneratePackageAsync", true, 0.8),
+                CreateAction("RevisionSubmissionService", "PromoteAsync", true, 0.8),
+                CreateAction("RevisionSubmissionService", "SubmitAsync", true, 0.9, ["/developers/"]),
+                CreateAction("RevisionSubmissionService", "UploadPackageAsync", true, 0.8)
+            ]
+        };
+
+        var clusters = analyzer.Analyze(model);
+
+        var cluster = Assert.Single(clusters);
+        Assert.Equal("Revision Submission Package Pipeline", cluster.Name);
+        Assert.Equal("same-service lifecycle", cluster.Origin);
+        Assert.True(cluster.RequiresApproval);
+        Assert.Equal("approval required", cluster.Risk);
+        Assert.Contains("RevisionSubmissionService", cluster.RelatedServices);
+        Assert.Contains("Submission", cluster.DomainTerms);
+        Assert.Contains("method names form an ordered process sequence", cluster.Evidence);
+        Assert.Contains("/developers/", cluster.RouteHints);
+        Assert.Equal(
+            ["GeneratePackageAsync", "UploadPackageAsync", "SubmitAsync", "CheckStatusAsync", "PromoteAsync"],
+            cluster.Methods.Select(method => method.Method).ToArray());
+        Assert.Equal(
+            ["generate", "upload", "submit", "status", "promote"],
+            cluster.Methods.Select(method => method.Role).ToArray());
+    }
+
+    [Fact]
+    public void Analyze_GroupsCrossServiceRouteAndDomainWorkflow()
+    {
+        var analyzer = new WorkflowClusterAnalyzer();
+        var model = new ProjectModel
+        {
+            Pages =
+            [
+                new PageModel
+                {
+                    Route = "/packages/review",
+                    ComponentName = "PackageReview",
+                    SuggestedActions =
+                    [
+                        "package-generation-service-generate-package-async",
+                        "package-upload-service-upload-package-async",
+                        "package-submission-service-submit-package-async"
+                    ]
+                }
+            ],
+            Services =
+            [
+                CreateService("PackageGenerationService", "GeneratePackageAsync"),
+                CreateService("PackageUploadService", "UploadPackageAsync"),
+                CreateService("PackageSubmissionService", "SubmitPackageAsync")
+            ],
+            Actions =
+            [
+                CreateAction("PackageGenerationService", "GeneratePackageAsync", true, 0.82, ["/packages/review"]),
+                CreateAction("PackageUploadService", "UploadPackageAsync", true, 0.81, ["/packages/review"]),
+                CreateAction("PackageSubmissionService", "SubmitPackageAsync", true, 0.84, ["/packages/review"])
+            ]
+        };
+
+        var clusters = analyzer.Analyze(model);
+
+        var cluster = Assert.Single(clusters);
+        Assert.Equal("route-correlated workflow", cluster.Origin);
+        Assert.Equal("Package Review Pipeline", cluster.Name);
+        Assert.Contains("Package", cluster.DomainTerms);
+        Assert.Equal(
+            ["PackageGenerationService", "PackageSubmissionService", "PackageUploadService"],
+            cluster.RelatedServices.ToArray());
+        Assert.Contains("/packages/review", cluster.RouteHints);
+        Assert.Contains("methods are used or linked from route /packages/review", cluster.Evidence);
+        Assert.Equal(
+            ["GeneratePackageAsync", "UploadPackageAsync", "SubmitPackageAsync"],
+            cluster.Methods.Select(method => method.Method).ToArray());
+    }
+
+    [Fact]
+    public void Analyze_DoesNotClusterGenericWorkflowEngineMethods()
+    {
+        var analyzer = new WorkflowClusterAnalyzer();
+        var model = new ProjectModel
+        {
+            Services =
+            [
+                new ServiceModel
+                {
+                    TypeName = "WorkflowService",
+                    FilePath = "Services/Workflows/WorkflowService.cs",
+                    Methods =
+                    [
+                        CreateMethod("ExecuteWorkflowAsync"),
+                        CreateMethod("LoadWorkflow"),
+                        CreateMethod("RunWorkflow")
+                    ]
+                }
+            ],
+            Actions =
+            [
+                CreateAction("WorkflowService", "ExecuteWorkflowAsync", true, 0.9),
+                CreateAction("WorkflowService", "LoadWorkflow", false, 0.7),
+                CreateAction("WorkflowService", "RunWorkflow", true, 0.8)
+            ]
+        };
+
+        var clusters = analyzer.Analyze(model);
+
+        Assert.Empty(clusters);
+    }
+
+    private static ServiceMethodModel CreateMethod(string name) => new()
+    {
+        Name = name,
+        ReturnType = "Task",
+        IsPublic = true,
+        IsAsync = name.EndsWith("Async", StringComparison.Ordinal)
+    };
+
+    private static ServiceModel CreateService(string service, params string[] methods) => new()
+    {
+        TypeName = service,
+        FilePath = $"Services/{service}.cs",
+        Methods = methods.Select(CreateMethod).ToList()
+    };
+
+    private static ActionModel CreateAction(
+        string service,
+        string method,
+        bool mutation,
+        double score,
+        IReadOnlyList<string>? routes = null) => new()
+    {
+        Id = $"{ToKebabCase(service)}-{ToKebabCase(method)}",
+        Name = method,
+        SourceService = service,
+        MethodName = method,
+        FilePath = $"Services/{service}.cs",
+        ExposureMode = ActionExposureMode.Suggested,
+        Classification = mutation ? ActionClassification.Workflow : ActionClassification.Query,
+        IsMutationLikely = mutation,
+        RequiresApproval = mutation,
+        Score = score,
+        RelevantRoutes = routes ?? []
+    };
+
+    private static string ToKebabCase(string value)
+    {
+        var words = new List<string>();
+        var current = new System.Text.StringBuilder();
+        foreach (var character in value)
+        {
+            if (char.IsUpper(character) && current.Length > 0)
+            {
+                words.Add(current.ToString());
+                current.Clear();
+            }
+
+            current.Append(char.ToLowerInvariant(character));
+        }
+
+        if (current.Length > 0)
+        {
+            words.Add(current.ToString());
+        }
+
+        return string.Join('-', words);
+    }
+}

--- a/tests/AgentBlazor.Cli.Analysis.Tests/WorkflowSuggestions/WorkflowSuggestionPromptBuilderTests.cs
+++ b/tests/AgentBlazor.Cli.Analysis.Tests/WorkflowSuggestions/WorkflowSuggestionPromptBuilderTests.cs
@@ -39,6 +39,21 @@ public sealed class WorkflowSuggestionPromptBuilderTests
                 },
                 new ServiceModel
                 {
+                    TypeName = "OrderWorkflowService",
+                    FilePath = "Services/OrderWorkflowService.cs",
+                    Methods =
+                    [
+                        new ServiceMethodModel
+                        {
+                            Name = "SubmitOrderAsync",
+                            ReturnType = "Task",
+                            IsPublic = true,
+                            IsAsync = true
+                        }
+                    ]
+                },
+                new ServiceModel
+                {
                     TypeName = "ActivityIdHelper",
                     FilePath = "ActivityIdHelper.cs",
                     Methods =
@@ -196,6 +211,17 @@ public sealed class WorkflowSuggestionPromptBuilderTests
                 },
                 new ActionModel
                 {
+                    Name = "Submit Order",
+                    SourceService = "OrderWorkflowService",
+                    MethodName = "SubmitOrderAsync",
+                    FilePath = "Services/OrderWorkflowService.cs",
+                    ExposureMode = ActionExposureMode.Suggested,
+                    Classification = ActionClassification.Workflow,
+                    IsMutationLikely = true,
+                    Score = 0.9
+                },
+                new ActionModel
+                {
                     Name = "Get Latest Chat ID",
                     SourceService = "AIChatMessageAssetService",
                     MethodName = "GetLatestChatIdAsync",
@@ -327,4 +353,101 @@ public sealed class WorkflowSuggestionPromptBuilderTests
         Assert.Contains("EmailService", prompt);
         Assert.Contains("SendEmailAsync", prompt);
     }
+
+    [Fact]
+    public void Build_IncludesWorkflowClustersBeforeFlatServiceCatalog()
+    {
+        var builder = new WorkflowSuggestionPromptBuilder();
+        var model = new ProjectModel
+        {
+            AppName = "TestApp",
+            BlazorHostProject = "TestApp",
+            WorkflowClusters =
+            [
+                new WorkflowClusterModel
+                {
+                    Name = "Revision Submission Package Pipeline",
+                    SourceService = "RevisionSubmissionService",
+                    Risk = "approval required",
+                    Origin = "same-service lifecycle",
+                    RequiresApproval = true,
+                    Confidence = 0.88,
+                    Summary = "Revision Submission Package Pipeline appears to be a multi-step process: GeneratePackageAsync -> UploadPackageAsync -> SubmitAsync -> CheckStatusAsync -> PromoteAsync.",
+                    DomainTerms = ["Revision", "Submission", "Package"],
+                    RelatedServices = ["RevisionSubmissionService"],
+                    Evidence = ["same service contains 5 lifecycle methods", "method names form an ordered process sequence"],
+                    RouteHints = ["/developers/"],
+                    Methods =
+                    [
+                        CreateClusterMethod("GeneratePackageAsync", "generate"),
+                        CreateClusterMethod("UploadPackageAsync", "upload"),
+                        CreateClusterMethod("SubmitAsync", "submit"),
+                        CreateClusterMethod("CheckStatusAsync", "status"),
+                        CreateClusterMethod("PromoteAsync", "promote")
+                    ]
+                }
+            ],
+            Services =
+            [
+                new ServiceModel
+                {
+                    TypeName = "RevisionSubmissionService",
+                    FilePath = "Services/RevisionSubmissionService.cs",
+                    Methods =
+                    [
+                        new ServiceMethodModel { Name = "GeneratePackageAsync", IsPublic = true, IsAsync = true },
+                        new ServiceMethodModel { Name = "UploadPackageAsync", IsPublic = true, IsAsync = true },
+                        new ServiceMethodModel { Name = "SubmitAsync", IsPublic = true, IsAsync = true },
+                        new ServiceMethodModel { Name = "CheckStatusAsync", IsPublic = true, IsAsync = true },
+                        new ServiceMethodModel { Name = "PromoteAsync", IsPublic = true, IsAsync = true }
+                    ]
+                }
+            ],
+            Actions =
+            [
+                CreateAction("GeneratePackageAsync"),
+                CreateAction("UploadPackageAsync"),
+                CreateAction("SubmitAsync"),
+                CreateAction("CheckStatusAsync"),
+                CreateAction("PromoteAsync")
+            ]
+        };
+
+        var prompt = builder.Build(model);
+
+        Assert.Contains("Prioritize workflow clusters when present", prompt);
+        Assert.Contains("Workflow clusters:", prompt);
+        Assert.Contains("Revision Submission Package Pipeline", prompt);
+        Assert.Contains("origin=same-service lifecycle", prompt);
+        Assert.Contains("domainTerms=Revision, Submission, Package", prompt);
+        Assert.Contains("evidence=same service contains 5 lifecycle methods", prompt);
+        Assert.Contains("routeHints=/developers/", prompt);
+        Assert.Contains("RevisionSubmissionService.GeneratePackageAsync [role=generate", prompt);
+        Assert.Contains("RevisionSubmissionService.PromoteAsync [role=promote", prompt);
+        Assert.True(prompt.IndexOf("Workflow clusters:", StringComparison.Ordinal) <
+            prompt.IndexOf("Discovered services and public methods:", StringComparison.Ordinal));
+        Assert.Contains("Use this flat catalog as supporting context", prompt);
+    }
+
+    private static WorkflowClusterMethodModel CreateClusterMethod(string method, string role) => new()
+    {
+        Service = "RevisionSubmissionService",
+        Method = method,
+        Role = role,
+        Classification = ActionClassification.Workflow,
+        Risk = "approval required"
+    };
+
+    private static ActionModel CreateAction(string method) => new()
+    {
+        Name = method,
+        SourceService = "RevisionSubmissionService",
+        MethodName = method,
+        FilePath = "Services/RevisionSubmissionService.cs",
+        ExposureMode = ActionExposureMode.Suggested,
+        Classification = ActionClassification.Workflow,
+        IsMutationLikely = true,
+        RequiresApproval = true,
+        Score = 0.8
+    };
 }


### PR DESCRIPTION
## Summary
- add workflow-cluster model and static analyzer for lifecycle, route-correlated, and domain-correlated workflows
- feed workflow clusters into the LLM prompt before the flat service catalog
- add a Workflow Clusters section to analysis reports
- bump package version and docs to 0.2.19

## Verification
- dotnet build src/AgentBlazor.Cli/AgentBlazor.Cli.csproj -c Release -v minimal /p:Version=0.2.19
- dotnet build tests/AgentBlazor.Cli.Analysis.Tests/AgentBlazor.Cli.Analysis.Tests.csproj -v minimal
- dotnet vstest tests/AgentBlazor.Cli.Analysis.Tests/bin/Debug/net10.0/AgentBlazor.Cli.Analysis.Tests.dll
- dotnet pack src/AgentBlazor.Cli/AgentBlazor.Cli.csproj -c Release --no-build -o /tmp/agentblazor-0.2.19-pack -p:PackageVersion=0.2.19 -p:Version=0.2.19 -v minimal
- local tool install from /tmp/agentblazor-0.2.19-pack returned 0.2.19

Note: local full-solution restore on this container failed on Microsoft.NETCore.App.Host.ubuntu.24.04-x64 package resolution for demo/starter projects; CLI build/tests passed.