### PR TITLE
Release 0.2.20 cluster ranking fixes

### DIFF
--- a/docs/releases/0.2.20.md
+++ b/docs/releases/0.2.20.md
@@ -1,0 +1,11 @@
+# AgentBlazor.Cli 0.2.20
+
+`0.2.20` tightens the workflow-cluster analysis added in `0.2.19`.
+
+The analyzer now treats preferred non-admin process clusters as the primary workflow signal for LLM suggestion generation. Sensitive or supporting clusters, such as password reset and other high-risk/admin flows, are kept as audit context but are not sent as first-choice workflow material when a safer business process cluster exists.
+
+Validation now understands cluster-backed suggestions. A suggestion such as a revision submission process can reference generate, upload, submit, and status methods without being rejected just because the workflow title does not repeat every lifecycle verb.
+
+Reports now fall back to preferred static workflow clusters in `Top Recommendations` when the validated LLM suggestions are only data, integration, admin, or infrastructure surfaces. This avoids telling users that no process-oriented workflow candidates exist when the static pre-pass has already found a coherent process pipeline.
+
+This release also de-noises workflow clusters by avoiding duplicate pipeline names, removing near-duplicate domain clusters behind stronger same-service or route clusters, and no longer treating lookup methods such as `FindByEmailAsync` as email notification lifecycle steps.

--- a/src/AgentBlazor.Cli.Analysis/Generation/AnalysisReportGenerator.cs
+++ b/src/AgentBlazor.Cli.Analysis/Generation/AnalysisReportGenerator.cs
@@ -110,6 +110,20 @@ public sealed class AnalysisReportGenerator
 
             if (promotedSuggestions.Count == 0)
             {
+                var preferredClusters = GetPreferredWorkflowClusters(model, take: 5);
+                if (preferredClusters.Count > 0)
+                {
+                    sb.AppendLine("The validated LLM suggestions were data, integration, admin, or infrastructure surfaces. Use these static workflow clusters as the first workflow candidates instead.");
+                    var fallbackDemotedSuggestionCount = workflowSuggestions.Suggestions.Count;
+                    if (fallbackDemotedSuggestionCount > 0)
+                    {
+                        sb.AppendLine($"{fallbackDemotedSuggestionCount} supporting data, integration, admin, or infrastructure suggestion(s) were not promoted to top recommendations.");
+                    }
+
+                    WriteClusterRecommendationTable(sb, preferredClusters);
+                    return;
+                }
+
                 sb.AppendLine("No process-oriented workflow candidates were found. The validated LLM suggestions are data, integration, admin, or infrastructure surfaces; review them below, but treat them as supporting context rather than first workflow work.");
                 sb.AppendLine();
                 return;
@@ -142,6 +156,14 @@ public sealed class AnalysisReportGenerator
             return;
         }
 
+        var clusterCandidates = GetPreferredWorkflowClusters(model, take: 5);
+        if (clusterCandidates.Count > 0)
+        {
+            sb.AppendLine("LLM workflow suggestions were not requested. These are the highest-confidence static workflow clusters.");
+            WriteClusterRecommendationTable(sb, clusterCandidates);
+            return;
+        }
+
         var candidates = GetStaticWorkflowCandidates(model, take: 5);
         if (candidates.Count == 0)
         {
@@ -160,6 +182,22 @@ public sealed class AnalysisReportGenerator
                 ? action.Classification.ToString()
                 : action.Summary;
             sb.AppendLine($"| {EscapeTableCell(action.Name)} | {ActionRisk.Describe(ActionRisk.GetRiskBand(action))} | {action.Score.ToString("0.00", CultureInfo.InvariantCulture)} | `{EscapeTableCell(action.SourceService)}.{EscapeTableCell(action.MethodName)}` | {EscapeTableCell(TrimForTable(reasoning, 180))} |");
+        }
+
+        sb.AppendLine();
+    }
+
+    private static void WriteClusterRecommendationTable(StringBuilder sb, IReadOnlyList<WorkflowClusterModel> clusters)
+    {
+        sb.AppendLine();
+        sb.AppendLine("| Workflow | Risk | Confidence | Existing methods | Why it matters |");
+        sb.AppendLine("| --- | --- | --- | --- | --- |");
+        foreach (var cluster in clusters)
+        {
+            var methods = cluster.Methods.Count == 0
+                ? "-"
+                : string.Join("<br>", cluster.Methods.Select(method => $"`{EscapeTableCell(method.Service)}.{EscapeTableCell(method.Method)}`"));
+            sb.AppendLine($"| {EscapeTableCell(cluster.Name)} | {EscapeTableCell(cluster.Risk)} | {cluster.Confidence.ToString("0.00", CultureInfo.InvariantCulture)} | {methods} | {EscapeTableCell(TrimForTable(cluster.Summary, 180))} |");
         }
 
         sb.AppendLine();
@@ -625,6 +663,20 @@ public sealed class AnalysisReportGenerator
             .ThenBy(action => action.SourceService)
             .GroupBy(action => $"{action.SourceService}.{action.MethodName}", StringComparer.OrdinalIgnoreCase)
             .Select(group => group.First())
+            .Take(take)
+            .ToList();
+    }
+
+    private static IReadOnlyList<WorkflowClusterModel> GetPreferredWorkflowClusters(ProjectModel model, int take)
+    {
+        return model.WorkflowClusters
+            .Where(cluster => !cluster.Risk.Equals("high-risk/admin", StringComparison.OrdinalIgnoreCase))
+            .Where(cluster => cluster.Methods.Any(method =>
+                method.Classification is ActionClassification.Workflow or ActionClassification.Command or ActionClassification.Export))
+            .OrderBy(cluster => cluster.Risk.Equals("approval required", StringComparison.OrdinalIgnoreCase) ? 1 : 0)
+            .ThenByDescending(cluster => cluster.Confidence)
+            .ThenByDescending(cluster => cluster.Methods.Count)
+            .ThenBy(cluster => cluster.Name, StringComparer.OrdinalIgnoreCase)
             .Take(take)
             .ToList();
     }

--- a/src/AgentBlazor.Cli.Analysis/WorkflowClusterAnalyzer.cs
+++ b/src/AgentBlazor.Cli.Analysis/WorkflowClusterAnalyzer.cs
@@ -44,6 +44,7 @@ public sealed partial class WorkflowClusterAnalyzer
         "Status",
         "Workflow",
         "Workflows",
+        "Pipeline",
         "Check",
         "User",
         "Users",
@@ -68,7 +69,7 @@ public sealed partial class WorkflowClusterAnalyzer
         clusters.AddRange(BuildRouteCorrelatedClusters(model, candidates));
         clusters.AddRange(BuildDomainCorrelatedClusters(model, candidates));
 
-        return clusters
+        return RemoveOverlappingClusters(clusters)
             .GroupBy(cluster => BuildClusterKey(cluster), StringComparer.OrdinalIgnoreCase)
             .Select(group => group.OrderByDescending(cluster => cluster.Confidence).First())
             .OrderByDescending(cluster => cluster.Confidence)
@@ -234,7 +235,7 @@ public sealed partial class WorkflowClusterAnalyzer
 
             yield return BuildCluster(
                 origin: "domain-correlated workflow",
-                serviceName: $"{termGroup.Key} Pipeline",
+                serviceName: termGroup.Key,
                 servicePath: "",
                 methods: methods,
                 routeHints: BuildRouteHints(model, methods.Select(method => method.Action)),
@@ -448,7 +449,12 @@ public sealed partial class WorkflowClusterAnalyzer
             words.Add("Business");
         }
 
-        words.Add("Pipeline");
+        if (words.Count == 0 ||
+            !words[^1].Equals("Pipeline", StringComparison.OrdinalIgnoreCase))
+        {
+            words.Add("Pipeline");
+        }
+
         return string.Join(' ', words);
     }
 
@@ -508,7 +514,7 @@ public sealed partial class WorkflowClusterAnalyzer
             return "promote";
         }
 
-        if (ContainsAny(normalized, "Notify", "Email"))
+        if (StartsWithAny(normalized, "Notify", "Email", "SendEmail"))
         {
             return "notify";
         }
@@ -541,6 +547,63 @@ public sealed partial class WorkflowClusterAnalyzer
 
     private static bool ContainsAny(string value, params string[] fragments)
         => fragments.Any(fragment => value.Contains(fragment, StringComparison.OrdinalIgnoreCase));
+
+    private static bool StartsWithAny(string value, params string[] fragments)
+        => fragments.Any(fragment => value.StartsWith(fragment, StringComparison.OrdinalIgnoreCase));
+
+    private static IReadOnlyList<WorkflowClusterModel> RemoveOverlappingClusters(IReadOnlyList<WorkflowClusterModel> clusters)
+    {
+        var retained = new List<WorkflowClusterModel>();
+        foreach (var cluster in clusters
+            .OrderBy(GetOriginRank)
+            .ThenBy(cluster => (int)ParseRiskBand(cluster.Risk))
+            .ThenByDescending(cluster => cluster.Confidence)
+            .ThenByDescending(cluster => cluster.Methods.Count))
+        {
+            if (retained.Any(existing => HasHighMethodOverlap(existing, cluster)))
+            {
+                continue;
+            }
+
+            retained.Add(cluster);
+        }
+
+        return retained;
+    }
+
+    private static int GetOriginRank(WorkflowClusterModel cluster)
+        => cluster.Origin switch
+        {
+            "same-service lifecycle" => 0,
+            "route-correlated workflow" => 1,
+            "domain-correlated workflow" => 2,
+            _ => 3
+        };
+
+    private static ActionRiskBand ParseRiskBand(string risk)
+        => risk.Equals("high-risk/admin", StringComparison.OrdinalIgnoreCase)
+            ? ActionRiskBand.HighRisk
+            : risk.Equals("approval required", StringComparison.OrdinalIgnoreCase)
+                ? ActionRiskBand.ApprovalRequired
+                : ActionRiskBand.SafeReadOnly;
+
+    private static bool HasHighMethodOverlap(WorkflowClusterModel existing, WorkflowClusterModel candidate)
+    {
+        var existingMethods = existing.Methods
+            .Select(method => $"{method.Service}.{method.Method}")
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var candidateMethods = candidate.Methods
+            .Select(method => $"{method.Service}.{method.Method}")
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        if (existingMethods.Count == 0 || candidateMethods.Count == 0)
+        {
+            return false;
+        }
+
+        var intersection = candidateMethods.Count(existingMethods.Contains);
+        var overlap = intersection / (double)Math.Min(existingMethods.Count, candidateMethods.Count);
+        return overlap >= 0.75;
+    }
 
     private static IReadOnlyList<string> SplitIdentifier(string value)
     {

--- a/src/AgentBlazor.Cli.Analysis/WorkflowSuggestions/WorkflowSuggestionParser.cs
+++ b/src/AgentBlazor.Cli.Analysis/WorkflowSuggestions/WorkflowSuggestionParser.cs
@@ -74,7 +74,7 @@ public sealed class WorkflowSuggestionParser
                 continue;
             }
 
-            var semanticallyMisalignedMethods = FindSemanticallyMisalignedMethods(suggestion);
+            var semanticallyMisalignedMethods = FindSemanticallyMisalignedMethods(suggestion, model);
             if (semanticallyMisalignedMethods.Count > 0)
             {
                 rejected.Add(new RejectedWorkflowSuggestion
@@ -136,8 +136,15 @@ public sealed class WorkflowSuggestionParser
             suggestion.Methods.All(method => confirmedMethodNames.Contains(NormalizeName(method.Method)));
     }
 
-    private static IReadOnlyList<WorkflowMethodReference> FindSemanticallyMisalignedMethods(WorkflowSuggestion suggestion)
+    private static IReadOnlyList<WorkflowMethodReference> FindSemanticallyMisalignedMethods(
+        WorkflowSuggestion suggestion,
+        ProjectModel model)
     {
+        if (IsAlignedWithWorkflowCluster(suggestion, model))
+        {
+            return [];
+        }
+
         var workflowText = NormalizeText(string.Join(
             ' ',
             suggestion.Name,
@@ -154,6 +161,56 @@ public sealed class WorkflowSuggestionParser
                     methodTokens.Count(token => workflowText.Contains(token, StringComparison.Ordinal)) < requiredMatches;
             })
             .ToList();
+    }
+
+    private static bool IsAlignedWithWorkflowCluster(WorkflowSuggestion suggestion, ProjectModel model)
+    {
+        if (suggestion.Methods.Count < 2 || model.WorkflowClusters.Count == 0)
+        {
+            return false;
+        }
+
+        var suggestionMethods = suggestion.Methods
+            .Select(method => BuildMethodReferenceKey(method.Service, method.Method))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var workflowText = NormalizeText(string.Join(
+            ' ',
+            suggestion.Name,
+            suggestion.Description,
+            suggestion.CapabilityClass,
+            suggestion.Reasoning));
+
+        foreach (var cluster in model.WorkflowClusters)
+        {
+            var clusterMethods = cluster.Methods
+                .Select(method => BuildMethodReferenceKey(method.Service, method.Method))
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            if (!suggestionMethods.All(clusterMethods.Contains))
+            {
+                continue;
+            }
+
+            var coverage = suggestionMethods.Count / (double)Math.Max(1, clusterMethods.Count);
+            if (suggestionMethods.Count < 3 && coverage < 0.5)
+            {
+                continue;
+            }
+
+            var clusterTerms = SplitIdentifier(cluster.Name)
+                .Concat(cluster.DomainTerms.SelectMany(SplitIdentifier))
+                .Concat(SplitIdentifier(cluster.SourceService))
+                .Where(term => !IgnoredClusterWords.Contains(term))
+                .Where(term => term.Length >= 4)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+            if (clusterTerms.Count == 0 ||
+                clusterTerms.Any(term => workflowText.Contains(term, StringComparison.Ordinal)))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static IReadOnlyList<string> ExtractMeaningfulMethodTokens(string methodName)
@@ -250,6 +307,20 @@ public sealed class WorkflowSuggestionParser
             .Select(char.ToLowerInvariant)
             .ToArray());
     }
+
+    private static string BuildMethodReferenceKey(string service, string method)
+        => $"{NormalizeName(service)}.{NormalizeName(method)}";
+
+    private static readonly HashSet<string> IgnoredClusterWords = new(StringComparer.Ordinal)
+    {
+        "admin",
+        "async",
+        "business",
+        "pipeline",
+        "process",
+        "service",
+        "workflow"
+    };
 
     private static IReadOnlyList<WorkflowMethodReference> ReadMethods(JsonElement element)
     {

--- a/src/AgentBlazor.Cli.Analysis/WorkflowSuggestions/WorkflowSuggestionPromptBuilder.cs
+++ b/src/AgentBlazor.Cli.Analysis/WorkflowSuggestions/WorkflowSuggestionPromptBuilder.cs
@@ -26,6 +26,8 @@ public sealed class WorkflowSuggestionPromptBuilder
         sb.AppendLine("- If a listed method has approvalRecommended=true, the suggested [AgentAction] example must include RequiresApproval = true.");
         sb.AppendLine("- Prioritize workflow clusters when present. They are static-analysis hints that multiple methods likely form one user process.");
         sb.AppendLine("- When using a workflow cluster, reference several listed methods in the shown order instead of splitting each method into separate workflow suggestions.");
+        sb.AppendLine("- Prefer preferred workflow clusters over the flat service catalog and over sensitive/supporting clusters.");
+        sb.AppendLine("- Do not suggest high-risk/admin password, auth, tenant, permission, cache, database, message, or generic workflow-engine flows when a preferred business process cluster exists.");
         sb.AppendLine("- A workflow is a user/business process, task, or decision flow. A one-method getter/list/view is usually a data surface, not a workflow.");
         sb.AppendLine("- Prefer methods classified as Workflow first. Prefer Command or Export only when the user-facing process is clear and approval guidance is included.");
         sb.AppendLine("- Use simple Query methods as supporting context for workflows, but do not suggest pure data-view workflows when process-oriented methods are available.");
@@ -110,7 +112,25 @@ public sealed class WorkflowSuggestionPromptBuilder
 
     private static void AppendWorkflowClusters(StringBuilder sb, ProjectModel model)
     {
-        sb.AppendLine("Workflow clusters:");
+        var preferredClusters = model.WorkflowClusters
+            .Where(IsPreferredWorkflowCluster)
+            .OrderByDescending(cluster => cluster.Confidence)
+            .ThenBy(cluster => cluster.SourceService)
+            .Take(12)
+            .ToList();
+        var supportingClusters = model.WorkflowClusters
+            .Except(preferredClusters)
+            .OrderByDescending(cluster => cluster.Confidence)
+            .ThenBy(cluster => cluster.SourceService)
+            .Take(12)
+            .ToList();
+        var clustersToShow = preferredClusters.Count > 0
+            ? preferredClusters
+            : supportingClusters;
+
+        sb.AppendLine(preferredClusters.Count > 0
+            ? "Preferred workflow clusters:"
+            : "Workflow clusters:");
         if (model.WorkflowClusters.Count == 0)
         {
             sb.AppendLine("- none");
@@ -118,10 +138,7 @@ public sealed class WorkflowSuggestionPromptBuilder
             return;
         }
 
-        foreach (var cluster in model.WorkflowClusters
-            .OrderByDescending(cluster => cluster.Confidence)
-            .ThenBy(cluster => cluster.SourceService)
-            .Take(12))
+        foreach (var cluster in clustersToShow)
         {
             sb.AppendLine($"- {cluster.Name}: origin={cluster.Origin}, service={cluster.SourceService}, risk={cluster.Risk}, approvalRecommended={cluster.RequiresApproval.ToString().ToLowerInvariant()}, confidence={cluster.Confidence:0.00}");
             if (!string.IsNullOrWhiteSpace(cluster.Summary))
@@ -155,8 +172,22 @@ public sealed class WorkflowSuggestionPromptBuilder
             }
         }
 
+        if (preferredClusters.Count > 0 && supportingClusters.Count > 0)
+        {
+            sb.AppendLine("Sensitive/supporting workflow clusters:");
+            sb.AppendLine("- Do not suggest these before preferred clusters. They are included only as audit context.");
+            foreach (var cluster in supportingClusters.Take(6))
+            {
+                sb.AppendLine($"- {cluster.Name}: origin={cluster.Origin}, risk={cluster.Risk}, confidence={cluster.Confidence:0.00}");
+            }
+        }
+
         sb.AppendLine();
     }
+
+    private static bool IsPreferredWorkflowCluster(WorkflowClusterModel cluster)
+        => !cluster.Risk.Equals("high-risk/admin", StringComparison.OrdinalIgnoreCase) &&
+           cluster.Methods.Any(method => method.Classification is ActionClassification.Workflow or ActionClassification.Command or ActionClassification.Export);
 
     private static void AppendServices(StringBuilder sb, ProjectModel model)
     {

--- a/src/AgentBlazor.Cli/PACKAGE_README.md
+++ b/src/AgentBlazor.Cli/PACKAGE_README.md
@@ -11,7 +11,7 @@ dotnet tool install --global AgentBlazor.Cli
 If you prefer a pinned install:
 
 ```bash
-dotnet tool install --global AgentBlazor.Cli --version 0.2.19
+dotnet tool install --global AgentBlazor.Cli --version 0.2.20
 ```
 
 Example:
@@ -60,7 +60,9 @@ Version `0.2.18` improves top recommendation quality by demoting raw integration
 
 Version `0.2.19` adds workflow-cluster context before LLM suggestion generation. The analyzer now groups lifecycle, route-correlated, and domain-correlated methods into multi-step process candidates so reports can identify pipelines rather than treating every public method as a standalone workflow.
 
-Reports put top workflow recommendations and install blockers before the detailed inventory, show workflow clusters before LLM suggestions, filter helper/framework noise, classify remaining services by likely agent fit, show AgentBlazor action adoption, and call out `RequiresApproval = true` guidance for workflow suggestions that reference mutating methods.
+Version `0.2.20` tightens clustered workflow analysis by preferring non-admin process clusters in the LLM prompt, validating cluster-backed suggestions against the whole pipeline instead of every method verb, and falling back to preferred static clusters when LLM suggestions are only sensitive or supporting surfaces.
+
+Reports put top workflow recommendations and install blockers before the detailed inventory, show workflow clusters before LLM suggestions, separate preferred process clusters from sensitive/supporting clusters in the prompt, filter helper/framework noise, classify remaining services by likely agent fit, show AgentBlazor action adoption, and call out `RequiresApproval = true` guidance for workflow suggestions that reference mutating methods.
 
 The CLI is an advanced path. The default install story is still `dotnet add package AgentBlazor` plus manual runtime wiring.
 
@@ -68,6 +70,7 @@ Docs:
 
 - Repository: https://github.com/ashpeterson/AgentBlazor
 - Advanced CLI guide: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/advanced/cli.md
+- 0.2.20 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.20.md
 - 0.2.19 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.19.md
 - 0.2.18 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.18.md
 - 0.2.17 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.17.md

--- a/src/AgentBlazor.Cli/README.md
+++ b/src/AgentBlazor.Cli/README.md
@@ -38,7 +38,9 @@ Version `0.2.18` improves top recommendation quality by demoting raw integration
 
 Version `0.2.19` adds workflow-cluster context before LLM suggestion generation. The analyzer now groups lifecycle, route-correlated, and domain-correlated methods into multi-step process candidates so reports can identify pipelines rather than treating every public method as a standalone workflow.
 
-Current reports put top workflow recommendations and install blockers before the detailed inventory. Workflow clusters are shown before LLM suggestions, and the service inventory is classified by agent fit so data-access, admin/sensitive, integration, and workflow surfaces are easier to review without treating every public service as an equal first action candidate.
+Version `0.2.20` tightens clustered workflow analysis by preferring non-admin process clusters in the LLM prompt, validating cluster-backed suggestions against the whole pipeline instead of every method verb, and falling back to preferred static clusters when LLM suggestions are only sensitive or supporting surfaces.
+
+Current reports put top workflow recommendations and install blockers before the detailed inventory. Workflow clusters are shown before LLM suggestions, preferred process clusters are separated from sensitive/supporting clusters in the prompt, and the service inventory is classified by agent fit so data-access, admin/sensitive, integration, and workflow surfaces are easier to review without treating every public service as an equal first action candidate.
 
 See:
 

--- a/tests/AgentBlazor.Cli.Analysis.Tests/Generation/AnalysisReportGeneratorTests.cs
+++ b/tests/AgentBlazor.Cli.Analysis.Tests/Generation/AnalysisReportGeneratorTests.cs
@@ -344,6 +344,90 @@ public sealed class AnalysisReportGeneratorTests : IDisposable
     }
 
     [Fact]
+    public void GenerateMarkdown_UsesPreferredWorkflowClusters_WhenValidatedSuggestionsAreOnlySensitive()
+    {
+        var model = CreateModel() with
+        {
+            WorkflowClusters =
+            [
+                new WorkflowClusterModel
+                {
+                    Name = "Revision Submission Package Pipeline",
+                    SourceService = "RevisionSubmissionService",
+                    Risk = "approval required",
+                    Origin = "same-service lifecycle",
+                    Confidence = 0.88,
+                    Summary = "Revision submission appears to be a multi-step package process.",
+                    Methods =
+                    [
+                        CreateClusterMethod("RevisionSubmissionService", "GeneratePackageAsync", "generate", ActionClassification.Workflow),
+                        CreateClusterMethod("RevisionSubmissionService", "UploadPackageAsync", "upload", ActionClassification.Workflow),
+                        CreateClusterMethod("RevisionSubmissionService", "SubmitAsync", "submit", ActionClassification.Workflow),
+                        CreateClusterMethod("RevisionSubmissionService", "CheckStatusAsync", "status", ActionClassification.Workflow)
+                    ]
+                }
+            ],
+            Services =
+            [
+                new ServiceModel
+                {
+                    TypeName = "RevisionSubmissionService",
+                    FilePath = "Services/RevisionSubmissionService.cs",
+                    Methods =
+                    [
+                        new ServiceMethodModel { Name = "GeneratePackageAsync", IsPublic = true, IsAsync = true },
+                        new ServiceMethodModel { Name = "UploadPackageAsync", IsPublic = true, IsAsync = true },
+                        new ServiceMethodModel { Name = "SubmitAsync", IsPublic = true, IsAsync = true },
+                        new ServiceMethodModel { Name = "CheckStatusAsync", IsPublic = true, IsAsync = true }
+                    ]
+                },
+                new ServiceModel
+                {
+                    TypeName = "UserService",
+                    FilePath = "Services/Users/UserService.cs",
+                    Methods =
+                    [
+                        new ServiceMethodModel { Name = "ResetPasswordAsync", IsPublic = true, IsAsync = true }
+                    ]
+                }
+            ],
+            Actions =
+            [
+                new ActionModel
+                {
+                    Name = "Reset Password",
+                    SourceService = "UserService",
+                    MethodName = "ResetPasswordAsync",
+                    FilePath = "Services/Users/UserService.cs",
+                    Classification = ActionClassification.Workflow,
+                    IsMutationLikely = true,
+                    RequiresApproval = true,
+                    Score = 0.9,
+                    ExposureMode = ActionExposureMode.Suggested
+                }
+            ]
+        };
+        var suggestions = new WorkflowSuggestionSet
+        {
+            Model = "test-model",
+            Suggestions =
+            [
+                CreateSuggestion("Reset User Password", "UserService", "ResetPasswordAsync", 0.90)
+            ]
+        };
+
+        var content = _generator.GenerateMarkdown(model, workflowSuggestions: suggestions);
+        var topRecommendations = ExtractSection(content, "## Top Recommendations", "## Install Blockers");
+
+        Assert.Contains("Use these static workflow clusters as the first workflow candidates", topRecommendations);
+        Assert.Contains("Revision Submission Package Pipeline", topRecommendations);
+        Assert.Contains("RevisionSubmissionService.GeneratePackageAsync", topRecommendations);
+        Assert.DoesNotContain("No process-oriented workflow candidates were found", topRecommendations);
+        Assert.DoesNotContain("| Reset User Password |", topRecommendations);
+        Assert.Contains("### Reset User Password", content);
+    }
+
+    [Fact]
     public void GenerateMarkdown_DemotesIntegrationAdminAndDataAccessSuggestions_FromTopRecommendations()
     {
         var model = CreateModel() with
@@ -1912,6 +1996,19 @@ public sealed class AnalysisReportGeneratorTests : IDisposable
             ]
         };
     }
+
+    private static WorkflowClusterMethodModel CreateClusterMethod(
+        string service,
+        string method,
+        string role,
+        ActionClassification classification) => new()
+    {
+        Service = service,
+        Method = method,
+        Role = role,
+        Classification = classification,
+        Risk = "approval required"
+    };
 
     private static ProjectModel CreateModel() => new()
     {

--- a/tests/AgentBlazor.Cli.Analysis.Tests/WorkflowClusterAnalyzerTests.cs
+++ b/tests/AgentBlazor.Cli.Analysis.Tests/WorkflowClusterAnalyzerTests.cs
@@ -138,6 +138,44 @@ public sealed class WorkflowClusterAnalyzerTests
         Assert.Empty(clusters);
     }
 
+    [Fact]
+    public void Analyze_DoesNotTreatFindByEmailAsNotificationStep()
+    {
+        var analyzer = new WorkflowClusterAnalyzer();
+        var model = new ProjectModel
+        {
+            Services =
+            [
+                new ServiceModel
+                {
+                    TypeName = "UserService",
+                    FilePath = "Services/Users/UserService.cs",
+                    Methods =
+                    [
+                        CreateMethod("FindByEmailAsync"),
+                        CreateMethod("GenerateResetTokenAsync"),
+                        CreateMethod("SendPasswordResetEmailAsync"),
+                        CreateMethod("ValidateResetTokenAsync")
+                    ]
+                }
+            ],
+            Actions =
+            [
+                CreateAction("UserService", "FindByEmailAsync", false, 0.7),
+                CreateAction("UserService", "GenerateResetTokenAsync", true, 0.8),
+                CreateAction("UserService", "SendPasswordResetEmailAsync", true, 0.8),
+                CreateAction("UserService", "ValidateResetTokenAsync", false, 0.8)
+            ]
+        };
+
+        var cluster = Assert.Single(analyzer.Analyze(model));
+
+        Assert.DoesNotContain(cluster.Methods, method => method.Method == "FindByEmailAsync");
+        Assert.Equal(
+            ["GenerateResetTokenAsync", "ValidateResetTokenAsync", "SendPasswordResetEmailAsync"],
+            cluster.Methods.Select(method => method.Method).ToArray());
+    }
+
     private static ServiceMethodModel CreateMethod(string name) => new()
     {
         Name = name,

--- a/tests/AgentBlazor.Cli.Analysis.Tests/WorkflowSuggestions/WorkflowSuggestionParserTests.cs
+++ b/tests/AgentBlazor.Cli.Analysis.Tests/WorkflowSuggestions/WorkflowSuggestionParserTests.cs
@@ -289,6 +289,81 @@ public sealed class WorkflowSuggestionParserTests
         Assert.Empty(result.Rejected);
     }
 
+    [Fact]
+    public void ParseAndValidate_AcceptsClusterBackedSuggestion_WhenLifecycleVerbsAreNotInWorkflowText()
+    {
+        var parser = new WorkflowSuggestionParser();
+        var model = new ProjectModel
+        {
+            AppName = "RevisionApp",
+            BlazorHostProject = "RevisionApp",
+            WorkflowClusters =
+            [
+                new WorkflowClusterModel
+                {
+                    Name = "Revision Submission Package Pipeline",
+                    SourceService = "RevisionSubmissionService",
+                    Risk = "approval required",
+                    Origin = "same-service lifecycle",
+                    Confidence = 0.88,
+                    DomainTerms = ["Revision", "Submission", "Package"],
+                    Methods =
+                    [
+                        CreateClusterMethod("GeneratePackageAsync", "generate"),
+                        CreateClusterMethod("UploadPackageAsync", "upload"),
+                        CreateClusterMethod("SubmitAsync", "submit"),
+                        CreateClusterMethod("CheckStatusAsync", "status")
+                    ]
+                }
+            ],
+            Services =
+            [
+                new ServiceModel
+                {
+                    TypeName = "RevisionSubmissionService",
+                    FilePath = "Services/RevisionSubmissionService.cs",
+                    Methods =
+                    [
+                        CreateMethod("GeneratePackageAsync"),
+                        CreateMethod("UploadPackageAsync"),
+                        CreateMethod("SubmitAsync"),
+                        CreateMethod("CheckStatusAsync")
+                    ]
+                }
+            ],
+            Actions =
+            [
+                CreateAction("GeneratePackageAsync"),
+                CreateAction("UploadPackageAsync"),
+                CreateAction("SubmitAsync"),
+                CreateAction("CheckStatusAsync")
+            ]
+        };
+        var json = """
+        {
+          "workflows": [
+            {
+              "name": "Revision Submission Process",
+              "description": "Coordinates the revision package submission lifecycle for approval.",
+              "methods": [
+                { "service": "RevisionSubmissionService", "method": "GeneratePackageAsync" },
+                { "service": "RevisionSubmissionService", "method": "UploadPackageAsync" },
+                { "service": "RevisionSubmissionService", "method": "SubmitAsync" },
+                { "service": "RevisionSubmissionService", "method": "CheckStatusAsync" }
+              ],
+              "confidence": 0.86
+            }
+          ]
+        }
+        """;
+
+        var result = parser.ParseAndValidate(json, model, "test-model");
+
+        var suggestion = Assert.Single(result.Suggestions);
+        Assert.Equal("Revision Submission Process", suggestion.Name);
+        Assert.Empty(result.Rejected);
+    }
+
     private static ProjectModel CreateModel() => new()
     {
         AppName = "OrderApp",
@@ -341,5 +416,35 @@ public sealed class WorkflowSuggestionParserTests
                 Score = 0.8
             }
         ]
+    };
+
+    private static ServiceMethodModel CreateMethod(string name) => new()
+    {
+        Name = name,
+        ReturnType = "Task",
+        IsPublic = true,
+        IsAsync = name.EndsWith("Async", StringComparison.Ordinal)
+    };
+
+    private static WorkflowClusterMethodModel CreateClusterMethod(string method, string role) => new()
+    {
+        Service = "RevisionSubmissionService",
+        Method = method,
+        Role = role,
+        Classification = ActionClassification.Workflow,
+        Risk = "approval required"
+    };
+
+    private static ActionModel CreateAction(string method) => new()
+    {
+        Name = method,
+        SourceService = "RevisionSubmissionService",
+        MethodName = method,
+        FilePath = "Services/RevisionSubmissionService.cs",
+        ExposureMode = ActionExposureMode.Suggested,
+        Classification = ActionClassification.Workflow,
+        IsMutationLikely = true,
+        RequiresApproval = true,
+        Score = 0.8
     };
 }

--- a/tests/AgentBlazor.Cli.Analysis.Tests/WorkflowSuggestions/WorkflowSuggestionPromptBuilderTests.cs
+++ b/tests/AgentBlazor.Cli.Analysis.Tests/WorkflowSuggestions/WorkflowSuggestionPromptBuilderTests.cs
@@ -385,6 +385,24 @@ public sealed class WorkflowSuggestionPromptBuilderTests
                         CreateClusterMethod("CheckStatusAsync", "status"),
                         CreateClusterMethod("PromoteAsync", "promote")
                     ]
+                },
+                new WorkflowClusterModel
+                {
+                    Name = "Password Reset Token Pipeline",
+                    SourceService = "UserService",
+                    Risk = "high-risk/admin",
+                    Origin = "same-service lifecycle",
+                    RequiresApproval = true,
+                    Confidence = 0.91,
+                    Summary = "Password Reset Token Pipeline appears to be a sensitive account recovery process.",
+                    DomainTerms = ["Password", "Reset", "Token"],
+                    RelatedServices = ["UserService"],
+                    Methods =
+                    [
+                        CreateClusterMethod("UserService", "GenerateResetTokenAsync", "generate"),
+                        CreateClusterMethod("UserService", "ValidateResetTokenAsync", "validate"),
+                        CreateClusterMethod("UserService", "SendPasswordResetEmailAsync", "submit")
+                    ]
                 }
             ],
             Services =
@@ -416,7 +434,7 @@ public sealed class WorkflowSuggestionPromptBuilderTests
         var prompt = builder.Build(model);
 
         Assert.Contains("Prioritize workflow clusters when present", prompt);
-        Assert.Contains("Workflow clusters:", prompt);
+        Assert.Contains("Preferred workflow clusters:", prompt);
         Assert.Contains("Revision Submission Package Pipeline", prompt);
         Assert.Contains("origin=same-service lifecycle", prompt);
         Assert.Contains("domainTerms=Revision, Submission, Package", prompt);
@@ -424,14 +442,21 @@ public sealed class WorkflowSuggestionPromptBuilderTests
         Assert.Contains("routeHints=/developers/", prompt);
         Assert.Contains("RevisionSubmissionService.GeneratePackageAsync [role=generate", prompt);
         Assert.Contains("RevisionSubmissionService.PromoteAsync [role=promote", prompt);
-        Assert.True(prompt.IndexOf("Workflow clusters:", StringComparison.Ordinal) <
+        Assert.Contains("Sensitive/supporting workflow clusters:", prompt);
+        Assert.Contains("Do not suggest these before preferred clusters", prompt);
+        Assert.Contains("Password Reset Token Pipeline: origin=same-service lifecycle, risk=high-risk/admin", prompt);
+        Assert.DoesNotContain("UserService.GenerateResetTokenAsync [role=generate", prompt);
+        Assert.True(prompt.IndexOf("Preferred workflow clusters:", StringComparison.Ordinal) <
             prompt.IndexOf("Discovered services and public methods:", StringComparison.Ordinal));
         Assert.Contains("Use this flat catalog as supporting context", prompt);
     }
 
-    private static WorkflowClusterMethodModel CreateClusterMethod(string method, string role) => new()
+    private static WorkflowClusterMethodModel CreateClusterMethod(string method, string role)
+        => CreateClusterMethod("RevisionSubmissionService", method, role);
+
+    private static WorkflowClusterMethodModel CreateClusterMethod(string service, string method, string role) => new()
     {
-        Service = "RevisionSubmissionService",
+        Service = service,
         Method = method,
         Role = role,
         Classification = ActionClassification.Workflow,


### PR DESCRIPTION
## Summary
- prefer non-admin workflow clusters in the LLM prompt and keep sensitive clusters as audit context
- validate cluster-backed suggestions against the whole discovered pipeline instead of requiring every method verb in the workflow text
- fall back to preferred static workflow clusters in Top Recommendations when LLM suggestions are only sensitive/supporting surfaces
- de-noise clusters by avoiding duplicate pipeline names, overlapping duplicate clusters, and lookup methods misclassified as notification steps
- update CLI docs and add 0.2.20 release notes

## Verification
- dotnet build tests/AgentBlazor.Cli.Analysis.Tests/AgentBlazor.Cli.Analysis.Tests.csproj -v minimal
- dotnet vstest tests/AgentBlazor.Cli.Analysis.Tests/bin/Debug/net10.0/AgentBlazor.Cli.Analysis.Tests.dll
- dotnet build src/AgentBlazor.Cli/AgentBlazor.Cli.csproj -c Release -v minimal /p:Version=0.2.20