### PR TITLE
Release 0.2.21 version correction

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
 
   <!-- Common package metadata for all AgentBlazor packages -->
   <PropertyGroup>
-    <Version>0.2.19</Version>
+    <Version>0.2.21</Version>
     <Authors>Ash Peterson</Authors>
     <Company>AgentBlazor</Company>
     <Copyright>Copyright (c) 2026 Ash Peterson</Copyright>
@@ -16,7 +16,7 @@
     <RepositoryType>git</RepositoryType>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <PackageIcon>icon.png</PackageIcon>
-    <PackageReleaseNotes>v0.2.19: CLI analysis workflow clustering. Adds a static pre-pass that groups lifecycle, route-correlated, and domain-correlated methods into multi-step workflow clusters before prompting the model, so reports can surface real pipelines instead of renaming isolated service methods.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.2.21: Corrective CLI analysis release. Carries the 0.2.20 clustered workflow ranking fixes and ensures the packaged CLI executable reports the same version as the NuGet package.</PackageReleaseNotes>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <Deterministic>true</Deterministic>

--- a/docs/releases/0.2.21.md
+++ b/docs/releases/0.2.21.md
@@ -1,0 +1,12 @@
+# AgentBlazor.Cli 0.2.21
+
+`0.2.21` is a corrective release for `0.2.20`.
+
+It carries the same clustered workflow ranking fixes:
+
+- prefer non-admin process clusters in the LLM prompt
+- validate cluster-backed suggestions against the discovered pipeline instead of requiring every lifecycle verb in the workflow prose
+- fall back to preferred static workflow clusters in `Top Recommendations` when validated LLM suggestions are only sensitive or supporting surfaces
+- de-noise cluster names, duplicate domain clusters, and lookup methods misclassified as notification steps
+
+This release also updates the source package version metadata so the installed CLI executable reports `0.2.21` from `agentblazor --version`. The local package smoke test now packs with both `Version` and `PackageVersion` and fails if the installed tool reports a different version than the package being tested.

--- a/scripts/smoke-test-local-package.ps1
+++ b/scripts/smoke-test-local-package.ps1
@@ -245,6 +245,7 @@ Invoke-Step "Preparing local package feed" {
                 "-c", "Release",
                 "-o", $localFeed,
                 "/p:UseSharedCompilation=false",
+                "/p:Version=$PackageVersion",
                 "/p:PackageVersion=$PackageVersion",
                 "/p:RestoreLockedMode=false",
                 "/p:RestoreForceEvaluate=true"
@@ -589,6 +590,16 @@ Invoke-Step "Installing the local CLI package" {
         "--tool-path", $toolPath,
         "--configfile", $nugetConfigPath
     ) -WorkingDirectory $scratchRoot
+
+    $cliExe = Resolve-AgentBlazorToolPath
+    $cliVersion = (& $cliExe --version).Trim()
+    if ($LASTEXITCODE -ne 0) {
+        throw "agentblazor --version failed."
+    }
+
+    if ($cliVersion -ne $PackageVersion) {
+        throw "Installed AgentBlazor.Cli reported version '$cliVersion', expected '$PackageVersion'."
+    }
 }
 
 Invoke-Step "Generating AGENT.md with the CLI" {

--- a/src/AgentBlazor.Cli.Analysis/ExistingAppScaffoldApplier.cs
+++ b/src/AgentBlazor.Cli.Analysis/ExistingAppScaffoldApplier.cs
@@ -301,7 +301,7 @@ public sealed class ExistingAppScaffoldApplier
             .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
             ?.InformationalVersion
             ?? typeof(ExistingAppScaffoldApplier).Assembly.GetName().Version?.ToString()
-            ?? "0.2.19";
+            ?? "0.2.21";
 
         return version.Split('+', 2)[0];
     }

--- a/src/AgentBlazor.Cli/PACKAGE_README.md
+++ b/src/AgentBlazor.Cli/PACKAGE_README.md
@@ -11,7 +11,7 @@ dotnet tool install --global AgentBlazor.Cli
 If you prefer a pinned install:
 
 ```bash
-dotnet tool install --global AgentBlazor.Cli --version 0.2.20
+dotnet tool install --global AgentBlazor.Cli --version 0.2.21
 ```
 
 Example:
@@ -62,6 +62,8 @@ Version `0.2.19` adds workflow-cluster context before LLM suggestion generation.
 
 Version `0.2.20` tightens clustered workflow analysis by preferring non-admin process clusters in the LLM prompt, validating cluster-backed suggestions against the whole pipeline instead of every method verb, and falling back to preferred static clusters when LLM suggestions are only sensitive or supporting surfaces.
 
+Version `0.2.21` is a corrective package release for `0.2.20`; it carries the same clustered workflow ranking fixes and ensures the packaged CLI executable reports the same version as the NuGet package.
+
 Reports put top workflow recommendations and install blockers before the detailed inventory, show workflow clusters before LLM suggestions, separate preferred process clusters from sensitive/supporting clusters in the prompt, filter helper/framework noise, classify remaining services by likely agent fit, show AgentBlazor action adoption, and call out `RequiresApproval = true` guidance for workflow suggestions that reference mutating methods.
 
 The CLI is an advanced path. The default install story is still `dotnet add package AgentBlazor` plus manual runtime wiring.
@@ -70,6 +72,7 @@ Docs:
 
 - Repository: https://github.com/ashpeterson/AgentBlazor
 - Advanced CLI guide: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/advanced/cli.md
+- 0.2.21 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.21.md
 - 0.2.20 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.20.md
 - 0.2.19 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.19.md
 - 0.2.18 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.18.md

--- a/src/AgentBlazor.Cli/Program.cs
+++ b/src/AgentBlazor.Cli/Program.cs
@@ -7,7 +7,7 @@ var version = typeof(ScaffoldCommand).Assembly
     .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
     ?.InformationalVersion
     ?? typeof(ScaffoldCommand).Assembly.GetName().Version?.ToString()
-    ?? "0.2.19";
+    ?? "0.2.21";
 version = version.Split('+', 2)[0];
 
 app.Configure(config =>

--- a/src/AgentBlazor.Cli/README.md
+++ b/src/AgentBlazor.Cli/README.md
@@ -40,6 +40,8 @@ Version `0.2.19` adds workflow-cluster context before LLM suggestion generation.
 
 Version `0.2.20` tightens clustered workflow analysis by preferring non-admin process clusters in the LLM prompt, validating cluster-backed suggestions against the whole pipeline instead of every method verb, and falling back to preferred static clusters when LLM suggestions are only sensitive or supporting surfaces.
 
+Version `0.2.21` is a corrective package release for `0.2.20`; it carries the same clustered workflow ranking fixes and ensures the packaged CLI executable reports the same version as the NuGet package.
+
 Current reports put top workflow recommendations and install blockers before the detailed inventory. Workflow clusters are shown before LLM suggestions, preferred process clusters are separated from sensitive/supporting clusters in the prompt, and the service inventory is classified by agent fit so data-access, admin/sensitive, integration, and workflow surfaces are easier to review without treating every public service as an equal first action candidate.
 
 See:

--- a/tests/AgentBlazor.Cli.Analysis.Tests/ExistingAppScaffoldPlannerTests.cs
+++ b/tests/AgentBlazor.Cli.Analysis.Tests/ExistingAppScaffoldPlannerTests.cs
@@ -250,7 +250,7 @@ public sealed class ExistingAppScaffoldPlannerTests : IDisposable
         Assert.Contains("""<PackageReference Include="MudBlazor" />""", projectText, StringComparison.Ordinal);
         Assert.DoesNotContain("PackageReference Include=\"AgentBlazor\" Version=", projectText, StringComparison.Ordinal);
         Assert.DoesNotContain("PackageReference Include=\"MudBlazor\" Version=", projectText, StringComparison.Ordinal);
-        Assert.Contains("""<PackageVersion Include="AgentBlazor" Version="0.2.19" />""", centralPackagesText, StringComparison.Ordinal);
+        Assert.Contains("""<PackageVersion Include="AgentBlazor" Version="0.2.21" />""", centralPackagesText, StringComparison.Ordinal);
         Assert.Contains("""<PackageVersion Include="MudBlazor" Version="9.0.0" />""", centralPackagesText, StringComparison.Ordinal);
     }
 


### PR DESCRIPTION
## Summary
- bump source package metadata and CLI fallback versions to 0.2.21
- document 0.2.21 as the corrective release for 0.2.20
- pack local smoke packages with both Version and PackageVersion
- fail local package smoke if installed agentblazor --version does not match the package version

## Verification
- dotnet build tests/AgentBlazor.Cli.Analysis.Tests/AgentBlazor.Cli.Analysis.Tests.csproj -v minimal
- dotnet vstest tests/AgentBlazor.Cli.Analysis.Tests/bin/Debug/net10.0/AgentBlazor.Cli.Analysis.Tests.dll
- dotnet build src/AgentBlazor.Cli/AgentBlazor.Cli.csproj -c Release -v minimal /p:Version=0.2.21 && src/AgentBlazor.Cli/bin/Release/net10.0/agentblazor --version
- dotnet pack src/AgentBlazor.Cli/AgentBlazor.Cli.csproj -nologo -c Release -o /tmp/agentblazor-local-pack-0.2.21/feed /p:UseSharedCompilation=false /p:Version=0.2.21 /p:PackageVersion=0.2.21 /p:RestoreLockedMode=false /p:RestoreForceEvaluate=true
- local tool install from /tmp/agentblazor-local-pack-0.2.21/feed reports 0.2.21 and deps identity contains agentblazor/0.2.21

Note: pwsh is not installed in this container, so the PowerShell smoke script itself is covered by CI.