### PR TITLE
Release CLI V2 workflow onboarding

### DIFF
--- a/.github/workflows/publish-nuget-org.yml
+++ b/.github/workflows/publish-nuget-org.yml
@@ -95,6 +95,11 @@ jobs:
         run: |
           ./scripts/smoke-test-local-package.ps1 -Pack -PackageVersion "${{ inputs.package_version }}"
 
+      - name: Smoke test CLI V2 workflow onboarding package
+        run: scripts/smoke-test-cli-v2-workflows.sh
+        env:
+          AGENTBLAZOR_CLI_PACKAGE_VERSION: ${{ inputs.package_version }}
+
       - name: Publish runtime package to nuget.org
         run: >
           dotnet nuget push

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
 
   <!-- Common package metadata for all AgentBlazor packages -->
   <PropertyGroup>
-    <Version>0.2.21</Version>
+    <Version>0.2.22</Version>
     <Authors>Ash Peterson</Authors>
     <Company>AgentBlazor</Company>
     <Copyright>Copyright (c) 2026 Ash Peterson</Copyright>
@@ -16,7 +16,7 @@
     <RepositoryType>git</RepositoryType>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <PackageIcon>icon.png</PackageIcon>
-    <PackageReleaseNotes>v0.2.21: Corrective CLI analysis release. Carries the 0.2.20 clustered workflow ranking fixes and ensures the packaged CLI executable reports the same version as the NuGet package.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.2.22: CLI V2 workflow onboarding release. Adds scaffold workflows review artifacts, SOUL/skill generation, reviewer-gated approval, agent-loop patch application, audit output, and packaged V2 workflow smoke coverage.</PackageReleaseNotes>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <Deterministic>true</Deterministic>

--- a/docs/internal/cli-v2-nuget-release-testing-readiness-2026-06-18.md
+++ b/docs/internal/cli-v2-nuget-release-testing-readiness-2026-06-18.md
@@ -1,0 +1,104 @@
+# AgentBlazor CLI V2 NuGet Release Testing Readiness
+
+Date: 2026-06-18
+
+## Scope
+
+This readiness note covers the CLI V2 workflow onboarding path for NuGet release testing. It does not claim the whole AgentBlazor package set is production-ready; it records whether the packaged `AgentBlazor.Cli` can be handed to release testers for the V2 `scaffold workflows` flow.
+
+## Release-Testing Decision
+
+Status: ready for local NuGet release testing of CLI V2 workflow onboarding.
+
+The current worktree has enough evidence to begin NuGet release testing for:
+
+- `agentblazor scaffold workflows [path]`
+- developer app description and desired agent workflow capture
+- deep static workflow analysis with corpus/retrieval evidence
+- review artifacts: `.agentblazor/workflow-onboarding.json`, `.agentblazor/workflow-onboarding.md`, `.agentblazor/workflow-onboarding.html`
+- approved SOUL/skill generation
+- reviewer-gated non-interactive approval
+- AgentBlazor-owned agent-loop patch application and audit output
+- packaged CLI install and workflow smoke from a local NuGet feed
+
+## Evidence Matrix
+
+| Requirement | Evidence | Status |
+| --- | --- | --- |
+| V2 scope is documented separately from CLI v1 | `docs/internal/cli-v2-workflow-onboarding-scope-2026-06-12.md` | Pass |
+| `analyze` remains read-only | V2 scope preserves read-only `analyze`; V2 implementation is routed through `ScaffoldCommand` workflow mode | Pass |
+| `scaffold workflows` exists as the workflow onboarding surface | `src/AgentBlazor.Cli/Commands/ScaffoldCommand.cs`; `src/AgentBlazor.Cli/Program.cs` examples | Pass |
+| App description and desired agent workflows can guide analysis | `--description`, `--agent-goals`, `.agentblazorc` persistence; covered by `ScaffoldWorkflowsCommandTests` | Pass |
+| Deep analysis corpus and lexical retrieval exist | `AnalysisCorpusBuilder`, `SemanticRetrieval`, `ProjectModel.Corpus`; covered by `WorkflowOnboardingTests.CorpusBuilder_CreatesRetrievableWorkflowEvidence` | Pass |
+| Review artifacts are deterministic and include candidate evidence | `WorkflowOnboardingArtifactWriter`; covered by `WorkflowOnboardingTests` and scaffold workflow integration tests | Pass |
+| Approved workflows generate SOUL and skill artifacts | `WorkflowOnboardingArtifactWriter`; covered by `ScaffoldWorkflowsApproveNonInteractive_WithWorkflowSelection_WritesSoulAndSkillArtifacts` | Pass |
+| Review-only decisions do not generate SOUL/skills | Covered by `ScaffoldWorkflowsApproveNonInteractive_WithReviewActions_UpdatesReviewOnly` | Pass |
+| Non-interactive approval refuses ambiguous workflow selection | Covered by `ScaffoldWorkflowsApproveNonInteractive_WithoutWorkflowSelection_RefusesApply` | Pass |
+| Non-interactive workflow application requires reviewer identity | Covered by `ScaffoldWorkflowsApproveNonInteractive_WithWorkflowSelectionWithoutReviewer_RefusesApply` | Pass |
+| Approved artifacts are applied through AgentBlazor-owned agent-loop patch proposal path | `AgentLoop`, `ScaffoldCommand` workflow apply path; covered by `AgentLoopTests` and scaffold workflow integration tests | Pass |
+| Audit record includes reviewer, workflow decision metadata, proposed/applied files, and tool trace | `AgentLoop.WriteAuditAsync`, scaffold workflow integration tests, packaged smoke script | Pass |
+| Skill progressive disclosure and curator behavior exist | `SkillSystem`; covered by `WorkflowOnboardingTests.SkillViewStore_LoadsIndexSkillAndReferenceWithinSkillRoot` and `SkillCurator_MarksStalePreservesPinnedAndArchivesEligibleSkills` | Pass |
+| Packaged CLI can be installed from local NuGet output and run V2 workflow onboarding | `scripts/smoke-test-cli-v2-workflows.sh` | Pass |
+| Package README documents V2 workflow onboarding | `src/AgentBlazor.Cli/PACKAGE_README.md` | Pass |
+| NuGet prerelease checklist includes V2 workflow onboarding gate | `docs/internal/nuget-prerelease-checklist.md` | Pass |
+
+## Verification Commands
+
+Latest local verification for this readiness state:
+
+```bash
+scripts/smoke-test-cli-v2-workflows.sh
+dotnet test tests/AgentBlazor.Cli.IntegrationTests/AgentBlazor.Cli.IntegrationTests.csproj --no-restore --filter FullyQualifiedName~ScaffoldWorkflowsCommandTests --logger "console;verbosity=minimal"
+dotnet build src/AgentBlazor.Cli/AgentBlazor.Cli.csproj --no-restore
+git diff --check
+```
+
+Observed results:
+
+- `scripts/smoke-test-cli-v2-workflows.sh`: passed for packaged `AgentBlazor.Cli 0.2.22`
+- `ScaffoldWorkflowsCommandTests`: 5 passed
+- CLI project build: passed with 0 warnings and 0 errors
+- `git diff --check`: passed
+
+## Packaged Smoke Coverage
+
+`scripts/smoke-test-cli-v2-workflows.sh` proves the current local package path can:
+
+- pack `AgentBlazor.Cli`
+- install the packaged tool using an isolated NuGet config
+- verify the installed tool reports the package version
+- run `agentblazor scaffold workflows --diff` against `tests/cli-targets/realistic-blazor-app`
+- confirm preview mode does not write `SOUL.md`
+- approve `same-service-lifecycle-inventory-pipeline` with `--reviewed-by`
+- verify review JSON, Markdown, HTML, SOUL, skill index, metadata, SKILL, evidence reference, and audit JSON
+- verify audit JSON contains reviewer, workflow ID, `propose_patch`, and `apply_approved_patch`
+- verify audit JSON does not include the absolute scratch app path
+- verify non-interactive approval without `--reviewed-by` fails
+
+## Known Boundaries
+
+- Model-backed autonomous workflow scaffolding is not included in this release-testing slice. The implemented loop is the controlled patch/audit substrate; model-backed planning remains a later phase.
+- Embedding-backed retrieval is not included. The first release-testing slice uses in-memory lexical retrieval behind the retrieval abstraction.
+- Published-feed validation has not been run for V2 workflow onboarding yet. The next external gate is to publish a prerelease feed package and repeat `scaffold workflows --diff` plus one reviewer-approved workflow from the published tool.
+- Full solution restore/build remains broader than this CLI V2 gate because unrelated demo/package source mapping can affect full-solution commands. The V2 readiness gate is the packaged CLI workflow smoke plus targeted CLI tests.
+
+## Next Release Testing Step
+
+Publish the candidate package to the intended prerelease feed, then repeat:
+
+```bash
+agentblazor --version
+agentblazor scaffold workflows path/to/App.csproj --description "..." --agent-goals "..." --diff --non-interactive
+agentblazor scaffold workflows path/to/App.csproj --workflow <workflow-id-or-slug> --reviewed-by "<reviewer>" --approve --non-interactive
+```
+
+Verify the generated app contains:
+
+- `.agentblazor/workflow-onboarding.json`
+- `.agentblazor/workflow-onboarding.md`
+- `.agentblazor/workflow-onboarding.html`
+- `.agentblazor/SOUL.md`
+- `.agentblazor/skills/index.json`
+- at least one `.agentblazor/skills/<skill>/SKILL.md`
+- `.agentblazor/skills/.metadata.json`
+- `.agentblazor/audit/workflow-onboarding-*.json`

--- a/docs/internal/cli-v2-workflow-onboarding-scope-2026-06-12.md
+++ b/docs/internal/cli-v2-workflow-onboarding-scope-2026-06-12.md
@@ -1,0 +1,41 @@
+# AgentBlazor CLI V2 Workflow Onboarding Scope
+
+Last updated: 2026-06-12
+
+## Goal
+
+`agentblazor scaffold workflows` adds an approved workflow-onboarding path on top of the existing analyze and scaffold stack. It keeps manual `[AgentCapability]` and `[AgentAction]` authoring valid, but gives the CLI enough app context to propose multi-step workflows, generate `.agentblazor` SOUL and skill files, and separate baseline install wiring from workflow artifacts.
+
+## Initial Implementation
+
+- Extend `ProjectModel` with an `AnalysisCorpus` built from routes, pages, services, methods, DI registrations, existing capability actions, workflow clusters, domain terms, route correlations, and file references.
+- Add an in-memory semantic retrieval abstraction with a lexical implementation for the first release slice.
+- Keep `agentblazor analyze` read-only. It may use the deeper model and corpus, but it must only write the analysis report requested by the user.
+- Add `agentblazor scaffold workflows [path] --host <project> --provider <provider> --scan-scope <references|solution> --diff --approve --non-interactive`.
+- Support `--reviewed-by <name>` so workflow approval, rejection, and pin decisions can carry a reviewer identity into generated review artifacts.
+- In non-interactive mode, write a report unless workflow ids are supplied with `--approve`.
+- Generate deterministic `.agentblazor/workflow-onboarding.json`, `.agentblazor/workflow-onboarding.md`, and `.agentblazor/workflow-onboarding.html` review artifacts for candidate approval, team review, and audit trails.
+- Generate deterministic `.agentblazor/SOUL.md`, `.agentblazor/skills/index.json`, `.agentblazor/skills/<skill-slug>/SKILL.md`, optional references, and `.agentblazor/skills/.metadata.json` for approved workflows.
+- Apply approved workflow artifacts through the AgentBlazor-owned agent-loop patch proposal path and write `.agentblazor/audit/workflow-onboarding-<timestamp>.json` with reviewer, workflow decision metadata, proposed/applied files, and tool transcript.
+- Treat baseline AgentBlazor wiring and workflow artifacts as separate approval groups.
+- Implement skill progressive disclosure APIs in the analysis layer: index, full `SKILL.md`, and reference file views.
+- Track skill reads/executions and curator metadata immediately. Preserve pinned skills, mark stale after 30 inactive days, and archive unpinned stale skills after an additional 60 inactive days.
+- Add the first AgentBlazor-owned C# agent-loop primitives: root-scoped file reads, patch proposals, diff rendering, preview conversion, approved patch apply, validation command execution, and an auditable tool transcript.
+
+## Later Phases
+
+- Add embedding-backed retrieval behind the same retrieval abstraction.
+- Connect the AgentBlazor-owned C# agent loop to model-backed planning and workflow scaffolding. The loop must propose patches into the existing preview/apply pipeline and must not let a model write files directly.
+- Add cheap-model skill refinement only after usage tracking and archive behavior are covered by tests.
+
+## Safety Rules
+
+- Reject workflow suggestions that reference methods not present in static evidence.
+- Reject direct writes outside the detected solution root unless that path is explicitly approved.
+- Require separate approvals for analysis artifacts, SOUL.md, skill files, capability/workflow classes, Program.cs/service wiring, UI/chat wiring, and validation commands.
+- Encode restrictions at three levels: SOUL.md project restrictions, CLI session mode/file-scope restrictions, and SKILL.md frontmatter restrictions.
+
+## Verification
+
+- Unit tests cover workflow cluster evidence, retrieval, unsupported suggestion rejection, SOUL/SKILL determinism, skill view restrictions, and stale/archive behavior.
+- CLI verification covers read-only analyze, workflow scaffold diff preview, approved artifact generation, non-interactive refusal for ambiguous workflow application, and unchanged baseline scaffold behavior.

--- a/docs/internal/nuget-prerelease-checklist.md
+++ b/docs/internal/nuget-prerelease-checklist.md
@@ -1,8 +1,10 @@
 # NuGet Prerelease Checklist
 
-Last updated: 2026-04-20
+Last updated: 2026-06-18
 
 Use this before publishing `AgentBlazor`, `AgentBlazor.Client`, and `AgentBlazor.Cli` prerelease packages for real-project validation.
+
+CLI V2 workflow onboarding release-testing readiness is tracked in `docs/internal/cli-v2-nuget-release-testing-readiness-2026-06-18.md`.
 
 ## Goal
 
@@ -31,11 +33,15 @@ Ship a package that:
    - `powershell -ExecutionPolicy Bypass -File .\scripts\smoke-test-local-package.ps1 -Pack -PackageVersion 0.1.0-preview.N`
    - add `-OpenAIApiKey $env:OPENAI_API_KEY` to include a live AG-UI workflow run
    - add `-KeepScratch` if you want to inspect the generated consumer app after the build
-6. After the package is published, repeat the clean-app install using the published feed:
+6. Run the CLI V2 workflow onboarding package smoke:
+   - `scripts/smoke-test-cli-v2-workflows.sh`
+   - this packs `AgentBlazor.Cli`, installs the packaged tool through an isolated NuGet config, runs `agentblazor scaffold workflows --diff`, approves the inventory workflow with `--reviewed-by`, verifies SOUL/skill/review/audit artifacts, and confirms non-interactive approval refuses to run without reviewer identity
+7. After the package is published, repeat the clean-app install using the published feed:
    - install `AgentBlazor` from the feed
    - install `AgentBlazor.Client` from the feed for hosted WebAssembly client validation
    - install `AgentBlazor.Cli` from the same feed
    - run `agentblazor --version`, `agentblazor scaffold --diff`, `agentblazor scaffold --approve`, `dotnet restore`, `dotnet build`, `agentblazor doctor`, and `agentblazor validate`
+   - run `agentblazor scaffold workflows --diff`, then approve one workflow with `--reviewed-by`, and verify `.agentblazor/SOUL.md`, `.agentblazor/skills/index.json`, at least one `SKILL.md`, and `.agentblazor/audit/workflow-onboarding-*.json`
 
 ## What The Smoke Test Proves
 
@@ -49,6 +55,16 @@ The smoke test script:
 - starts the app and verifies the home route loads
 - optionally runs a live AG-UI semantic workflow turn when an OpenAI key is supplied
 
+The CLI V2 workflow smoke script:
+
+- creates an isolated local feed for the packed `AgentBlazor.Cli`
+- installs the packaged CLI as a local tool
+- runs workflow onboarding preview against `tests/cli-targets/realistic-blazor-app`
+- applies an approved workflow through the agent-loop patch proposal path
+- verifies `.agentblazor/workflow-onboarding.json`, `.agentblazor/workflow-onboarding.md`, `.agentblazor/workflow-onboarding.html`, `.agentblazor/SOUL.md`, skill index, skill metadata, `SKILL.md`, evidence reference, and audit JSON
+- verifies the audit record contains reviewer, workflow ID, and agent-loop tools without absolute scratch paths
+- verifies non-interactive approval fails without `--reviewed-by`
+
 This catches packaging regressions such as:
 
 - unresolved internal package dependencies
@@ -57,6 +73,7 @@ This catches packaging regressions such as:
 - missing host-shell assets or endpoint wiring in the documented setup
 - CLI packaging regressions that would break `agentblazor init`
 - CLI/runtime package-version drift that would scaffold a different `AgentBlazor` version than the installed CLI package
+- V2 workflow onboarding packaging regressions that would break packaged `scaffold workflows`, SOUL/skill generation, reviewer-gated approval, or audit output
 
 ## Current Release Position
 

--- a/docs/releases/0.2.22.md
+++ b/docs/releases/0.2.22.md
@@ -1,0 +1,46 @@
+# AgentBlazor.Cli 0.2.22
+
+`0.2.22` adds the first CLI V2 workflow onboarding release path.
+
+## Highlights
+
+- Added `agentblazor scaffold workflows` as the workflow onboarding surface.
+- Captures app description and developer-stated agent workflow goals through CLI options and `.agentblazorc`.
+- Builds a deeper analysis corpus from routes, services, methods, DI registrations, workflow clusters, existing AgentBlazor capability attributes, domain terms, route correlations, and file references.
+- Adds lexical retrieval over the analysis corpus as the first semantic retrieval implementation.
+- Generates workflow review artifacts:
+  - `.agentblazor/workflow-onboarding.json`
+  - `.agentblazor/workflow-onboarding.md`
+  - `.agentblazor/workflow-onboarding.html`
+- Generates approved workflow artifacts:
+  - `.agentblazor/SOUL.md`
+  - `.agentblazor/skills/index.json`
+  - `.agentblazor/skills/.metadata.json`
+  - `.agentblazor/skills/<skill-slug>/SKILL.md`
+  - optional `.agentblazor/skills/<skill-slug>/references/evidence.md`
+- Preserves existing manual `[AgentCapability]` and `[AgentAction]` workflows by turning them into skills without duplicating capability classes.
+- Adds reviewer-gated non-interactive approval through `--reviewed-by`.
+- Applies approved workflow artifacts through an AgentBlazor-owned agent-loop patch proposal path instead of direct model writes.
+- Writes audit records under `.agentblazor/audit/workflow-onboarding-<timestamp>.json` with reviewer, workflow decision metadata, proposed/applied files, and tool transcript.
+- Adds skill progressive disclosure and curator metadata primitives.
+- Adds packaged CLI workflow smoke coverage through `scripts/smoke-test-cli-v2-workflows.sh`.
+
+## Safety Notes
+
+- `agentblazor analyze` remains read-only.
+- `scaffold workflows --diff` previews review artifacts without mutation.
+- Non-interactive workflow artifact application refuses to run without explicit workflow selection or already approved workflows.
+- Non-interactive approved application requires `--reviewed-by`.
+- The agent-loop substrate is controlled by AgentBlazor and proposes patches into the preview/apply path; model-backed autonomous planning remains a later phase.
+
+## Verification
+
+Release-readiness evidence is tracked in:
+
+- `docs/internal/cli-v2-nuget-release-testing-readiness-2026-06-18.md`
+
+Key local gates:
+
+- `scripts/smoke-test-cli-v2-workflows.sh`
+- `dotnet test tests/AgentBlazor.Cli.Analysis.Tests/AgentBlazor.Cli.Analysis.Tests.csproj --no-restore --filter "FullyQualifiedName~AgentLoopTests|FullyQualifiedName~WorkflowOnboardingTests"`
+- `dotnet test tests/AgentBlazor.Cli.IntegrationTests/AgentBlazor.Cli.IntegrationTests.csproj --no-restore --filter FullyQualifiedName~ScaffoldWorkflowsCommandTests`

--- a/scripts/smoke-test-cli-v2-workflows.sh
+++ b/scripts/smoke-test-cli-v2-workflows.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+scratch_root="${AGENTBLAZOR_V2_SMOKE_ROOT:-/tmp/agentblazor-cli-v2-workflow-smoke}"
+pack_dir="$scratch_root/packages"
+tool_dir="$scratch_root/tool"
+nuget_dir="$scratch_root/nuget"
+preview_app="$scratch_root/preview-app"
+approve_app="$scratch_root/approve-app"
+nuget_config="$nuget_dir/NuGet.Config"
+
+log() {
+  printf '==> %s\n' "$1"
+}
+
+fail() {
+  printf 'ERROR: %s\n' "$1" >&2
+  exit 1
+}
+
+assert_file() {
+  local path="$1"
+  [[ -f "$path" ]] || fail "Expected file '$path' to exist."
+}
+
+assert_contains() {
+  local path="$1"
+  local pattern="$2"
+  rg -q --fixed-strings "$pattern" "$path" || fail "Expected '$path' to contain '$pattern'."
+}
+
+assert_not_contains() {
+  local path="$1"
+  local pattern="$2"
+  if rg -q --fixed-strings "$pattern" "$path"; then
+    fail "Expected '$path' not to contain '$pattern'."
+  fi
+}
+
+resolve_tool() {
+  if [[ -x "$tool_dir/agentblazor" ]]; then
+    printf '%s\n' "$tool_dir/agentblazor"
+    return
+  fi
+
+  if [[ -x "$tool_dir/agentblazor.exe" ]]; then
+    printf '%s\n' "$tool_dir/agentblazor.exe"
+    return
+  fi
+
+  fail "AgentBlazor CLI executable was not installed under '$tool_dir'."
+}
+
+log "Resetting scratch workspace"
+rm -rf "$scratch_root"
+mkdir -p "$pack_dir" "$tool_dir" "$nuget_dir"
+
+log "Packing AgentBlazor.Cli"
+pack_args=(
+  "pack"
+  "$repo_root/src/AgentBlazor.Cli/AgentBlazor.Cli.csproj"
+  "--no-restore"
+  "-o"
+  "$pack_dir"
+)
+if [[ -n "${AGENTBLAZOR_CLI_PACKAGE_VERSION:-}" ]]; then
+  pack_args+=(
+    "/p:Version=$AGENTBLAZOR_CLI_PACKAGE_VERSION"
+    "/p:PackageVersion=$AGENTBLAZOR_CLI_PACKAGE_VERSION"
+  )
+fi
+dotnet "${pack_args[@]}"
+
+package_path="$(find "$pack_dir" -maxdepth 1 -name 'AgentBlazor.Cli.*.nupkg' ! -name '*.symbols.nupkg' | sort | tail -n 1)"
+[[ -n "$package_path" ]] || fail "AgentBlazor.Cli package was not produced."
+package_name="$(basename "$package_path")"
+package_version="${package_name#AgentBlazor.Cli.}"
+package_version="${package_version%.nupkg}"
+expected_tool_version="${AGENTBLAZOR_EXPECTED_TOOL_VERSION:-$package_version}"
+
+log "Writing isolated NuGet configuration"
+cp "$pack_dir"/*.nupkg "$nuget_dir"/
+cat > "$nuget_config" <<EOF
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="local-agentblazor-cli" value="$nuget_dir" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+  <packageSourceMapping>
+    <packageSource key="local-agentblazor-cli">
+      <package pattern="AgentBlazor.Cli" />
+      <package pattern="agentblazor.cli" />
+    </packageSource>
+    <packageSource key="nuget.org">
+      <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>
+</configuration>
+EOF
+
+log "Installing packaged AgentBlazor.Cli tool"
+dotnet tool install AgentBlazor.Cli \
+  --version "$package_version" \
+  --tool-path "$tool_dir" \
+  --configfile "$nuget_config"
+
+cli_exe="$(resolve_tool)"
+tool_version="$("$cli_exe" --version | tr -d '\r\n')"
+[[ "$tool_version" == "$expected_tool_version" ]] ||
+  fail "Installed tool reported version '$tool_version', expected '$expected_tool_version'."
+
+log "Running packaged workflow preview"
+cp -R "$repo_root/tests/cli-targets/realistic-blazor-app" "$preview_app"
+"$cli_exe" scaffold workflows "$preview_app/RealisticBlazorApp.csproj" \
+  --description "Inventory operations app" \
+  --agent-goals "prepare restock plans" \
+  --diff \
+  --non-interactive
+
+[[ ! -e "$preview_app/.agentblazor/SOUL.md" ]] ||
+  fail "Preview-only workflow scaffold should not write SOUL.md."
+
+log "Running packaged workflow approval with audit"
+cp -R "$repo_root/tests/cli-targets/realistic-blazor-app" "$approve_app"
+"$cli_exe" scaffold workflows "$approve_app/RealisticBlazorApp.csproj" \
+  --workflow same-service-lifecycle-inventory-pipeline \
+  --description "Inventory operations app" \
+  --agent-goals "prepare restock plans" \
+  --reviewed-by "Package Smoke" \
+  --approve \
+  --non-interactive
+
+agent_dir="$approve_app/.agentblazor"
+assert_file "$agent_dir/workflow-onboarding.json"
+assert_file "$agent_dir/workflow-onboarding.md"
+assert_file "$agent_dir/workflow-onboarding.html"
+assert_file "$agent_dir/SOUL.md"
+assert_file "$agent_dir/skills/index.json"
+assert_file "$agent_dir/skills/.metadata.json"
+assert_file "$agent_dir/skills/inventory-pipeline/SKILL.md"
+assert_file "$agent_dir/skills/inventory-pipeline/references/evidence.md"
+
+audit_path="$(find "$agent_dir/audit" -maxdepth 1 -name 'workflow-onboarding-*.json' | sort | tail -n 1)"
+[[ -n "$audit_path" ]] || fail "Workflow onboarding audit record was not generated."
+
+assert_contains "$agent_dir/workflow-onboarding.json" '"reviewedBy": "Package Smoke"'
+assert_contains "$agent_dir/workflow-onboarding.json" '"status": "approved"'
+assert_contains "$agent_dir/workflow-onboarding.html" 'Reviewed by: Package Smoke'
+assert_contains "$agent_dir/SOUL.md" 'Inventory Pipeline'
+assert_contains "$agent_dir/skills/inventory-pipeline/SKILL.md" 'requiredApprovals'
+assert_contains "$audit_path" '"reviewedBy": "Package Smoke"'
+assert_contains "$audit_path" 'same-service-lifecycle-inventory-pipeline'
+assert_contains "$audit_path" 'propose_patch'
+assert_contains "$audit_path" 'apply_approved_patch'
+assert_not_contains "$audit_path" "$approve_app"
+
+log "Verifying non-interactive approval requires reviewer identity"
+reviewer_gate_app="$scratch_root/reviewer-gate-app"
+cp -R "$repo_root/tests/cli-targets/realistic-blazor-app" "$reviewer_gate_app"
+set +e
+reviewer_gate_output="$("$cli_exe" scaffold workflows "$reviewer_gate_app/RealisticBlazorApp.csproj" \
+  --workflow same-service-lifecycle-inventory-pipeline \
+  --approve \
+  --non-interactive 2>&1)"
+reviewer_gate_exit=$?
+set -e
+[[ "$reviewer_gate_exit" -ne 0 ]] || fail "Workflow approval without --reviewed-by should fail."
+printf '%s\n' "$reviewer_gate_output" | rg -q --fixed-strings 'requires --reviewed-by' ||
+  fail "Reviewer gate output did not mention --reviewed-by."
+
+log "CLI V2 workflow package smoke passed for AgentBlazor.Cli $package_version"

--- a/src/AgentBlazor.Cli.Analysis/AgentLoop.cs
+++ b/src/AgentBlazor.Cli.Analysis/AgentLoop.cs
@@ -1,0 +1,371 @@
+using System.Diagnostics;
+using System.Text;
+using System.Text.Json;
+using AgentBlazor.Cli.Analysis.Models;
+
+namespace AgentBlazor.Cli.Analysis;
+
+public sealed class AgentLoop
+{
+    private readonly Dictionary<string, AgentPatchProposal> _proposals = new(StringComparer.OrdinalIgnoreCase);
+    private readonly List<AgentToolTrace> _transcript = [];
+
+    public AgentLoop(string solutionRoot)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(solutionRoot);
+        SolutionRoot = Path.GetFullPath(solutionRoot);
+    }
+
+    public string SolutionRoot { get; }
+
+    public IReadOnlyList<AgentToolTrace> Transcript => _transcript;
+
+    public async Task<AgentFileRead> ReadFileAsync(string path, CancellationToken ct = default)
+    {
+        var fullPath = ResolveInsideRoot(path);
+        var content = await File.ReadAllTextAsync(fullPath, ct).ConfigureAwait(false);
+        AddTrace("read_file", fullPath, "read file inside solution root");
+        return new AgentFileRead
+        {
+            Path = fullPath,
+            RelativePath = ToRelativePath(fullPath),
+            Content = content
+        };
+    }
+
+    public AgentPatchProposal ProposePatch(string summary, IReadOnlyList<AgentProposedFileChange> changes)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(summary);
+        if (changes.Count == 0)
+        {
+            throw new InvalidOperationException("Patch proposal must include at least one file change.");
+        }
+
+        var normalized = changes
+            .Select(change => NormalizeChange(change))
+            .ToList();
+        var proposal = new AgentPatchProposal
+        {
+            Id = "patch-" + Guid.NewGuid().ToString("N"),
+            Summary = summary.Trim(),
+            Changes = normalized
+        };
+        _proposals[proposal.Id] = proposal;
+        AddTrace("propose_patch", string.Join(", ", normalized.Select(change => change.RelativePath)), summary);
+        return proposal;
+    }
+
+    public string RenderDiff(AgentPatchProposal proposal)
+    {
+        ArgumentNullException.ThrowIfNull(proposal);
+
+        var sb = new StringBuilder();
+        foreach (var change in proposal.Changes)
+        {
+            sb.AppendLine($"--- {change.RelativePath}");
+            sb.AppendLine($"+++ {change.RelativePath}");
+            sb.AppendLine("@@");
+            foreach (var line in SplitLines(change.OriginalContent))
+            {
+                sb.AppendLine("-" + line);
+            }
+            foreach (var line in SplitLines(change.UpdatedContent))
+            {
+                sb.AppendLine("+" + line);
+            }
+        }
+
+        AddTrace("render_diff", proposal.Id, proposal.Summary);
+        return sb.ToString();
+    }
+
+    public ScaffoldPreviewResult ToPreview(AgentPatchProposal proposal)
+    {
+        ArgumentNullException.ThrowIfNull(proposal);
+
+        AddTrace("render_preview", proposal.Id, proposal.Summary);
+        return new ScaffoldPreviewResult
+        {
+            Changes = proposal.Changes
+                .Select(change => new ScaffoldPreviewFile
+                {
+                    Path = change.Path,
+                    ChangeKind = change.ChangeKind == AgentPatchChangeKind.Create
+                        ? ScaffoldPreviewChangeKind.Create
+                        : ScaffoldPreviewChangeKind.Update,
+                    Summary = proposal.Summary,
+                    OriginalContent = change.OriginalContent,
+                    UpdatedContent = change.UpdatedContent
+                })
+                .ToList()
+        };
+    }
+
+    public async Task<AgentPatchApplyResult> ApplyApprovedPatchAsync(
+        string proposalId,
+        string approvedBy,
+        CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(proposalId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(approvedBy);
+
+        if (!_proposals.TryGetValue(proposalId, out var proposal))
+        {
+            throw new InvalidOperationException($"Unknown patch proposal '{proposalId}'.");
+        }
+
+        foreach (var change in proposal.Changes)
+        {
+            ResolveInsideRoot(change.Path);
+            Directory.CreateDirectory(Path.GetDirectoryName(change.Path)!);
+            await File.WriteAllTextAsync(change.Path, change.UpdatedContent, ct).ConfigureAwait(false);
+        }
+
+        AddTrace("apply_approved_patch", proposal.Id, $"approved by {approvedBy.Trim()}");
+        return new AgentPatchApplyResult
+        {
+            ProposalId = proposal.Id,
+            ApprovedBy = approvedBy.Trim(),
+            AppliedPaths = proposal.Changes.Select(change => change.Path).ToList()
+        };
+    }
+
+    public async Task<AgentCommandResult> RunValidationCommandAsync(
+        string fileName,
+        IReadOnlyList<string> arguments,
+        string approvedBy,
+        CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(fileName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(approvedBy);
+
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = fileName,
+            WorkingDirectory = SolutionRoot,
+            RedirectStandardError = true,
+            RedirectStandardOutput = true
+        };
+        foreach (var argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        using var process = Process.Start(startInfo) ?? throw new InvalidOperationException($"Failed to start '{fileName}'.");
+        var outputTask = process.StandardOutput.ReadToEndAsync(ct);
+        var errorTask = process.StandardError.ReadToEndAsync(ct);
+        await process.WaitForExitAsync(ct).ConfigureAwait(false);
+        var output = await outputTask.ConfigureAwait(false);
+        var error = await errorTask.ConfigureAwait(false);
+
+        AddTrace("run_validation_command", fileName + " " + string.Join(' ', arguments), $"approved by {approvedBy.Trim()}");
+        return new AgentCommandResult
+        {
+            FileName = fileName,
+            Arguments = arguments,
+            ExitCode = process.ExitCode,
+            StandardOutput = output,
+            StandardError = error
+        };
+    }
+
+    public async Task<AgentAuditRecord> WriteAuditAsync(
+        string kind,
+        string reviewedBy,
+        AgentPatchProposal proposal,
+        AgentPatchApplyResult applyResult,
+        DateTimeOffset timestampUtc,
+        IReadOnlyDictionary<string, IReadOnlyList<string>>? metadata = null,
+        CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(kind);
+        ArgumentException.ThrowIfNullOrWhiteSpace(reviewedBy);
+        ArgumentNullException.ThrowIfNull(proposal);
+        ArgumentNullException.ThrowIfNull(applyResult);
+
+        var auditDirectory = ResolveInsideRoot(Path.Combine(".agentblazor", "audit"));
+        Directory.CreateDirectory(auditDirectory);
+        var auditPath = Path.Combine(
+            auditDirectory,
+            $"{WorkflowOnboardingPlanner.ToSlug(kind)}-{timestampUtc:yyyyMMddHHmmss}.json");
+        var record = new AgentAuditRecord
+        {
+            Kind = kind,
+            ReviewedBy = reviewedBy.Trim(),
+            TimestampUtc = timestampUtc,
+            ProposalId = proposal.Id,
+            Summary = proposal.Summary,
+            ProposedFiles = proposal.Changes.Select(change => change.RelativePath).ToList(),
+            AppliedFiles = applyResult.AppliedPaths.Select(ToRelativePath).ToList(),
+            Metadata = metadata ?? new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase),
+            Transcript = Transcript.ToList(),
+            Path = ToRelativePath(auditPath)
+        };
+        var content = JsonSerializer.Serialize(record, AgentAuditRecord.JsonOptions) + Environment.NewLine;
+        await File.WriteAllTextAsync(auditPath, content, ct).ConfigureAwait(false);
+        AddTrace("write_audit", ToRelativePath(auditPath), kind);
+        return record;
+    }
+
+    private AgentProposedFileChange NormalizeChange(AgentProposedFileChange change)
+    {
+        var fullPath = ResolveInsideRoot(change.Path);
+        var exists = File.Exists(fullPath);
+        var original = exists ? File.ReadAllText(fullPath) : string.Empty;
+        if (exists && !string.Equals(original, change.OriginalContent, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException($"Patch proposal for '{ToRelativePath(fullPath)}' is stale.");
+        }
+
+        if (!exists && change.ChangeKind != AgentPatchChangeKind.Create)
+        {
+            throw new InvalidOperationException($"Patch proposal for '{ToRelativePath(fullPath)}' targets a missing file.");
+        }
+
+        return change with
+        {
+            Path = fullPath,
+            RelativePath = ToRelativePath(fullPath),
+            OriginalContent = original,
+            ChangeKind = exists ? AgentPatchChangeKind.Update : AgentPatchChangeKind.Create
+        };
+    }
+
+    private string ResolveInsideRoot(string path)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        var fullPath = Path.IsPathRooted(path)
+            ? Path.GetFullPath(path)
+            : Path.GetFullPath(Path.Combine(SolutionRoot, path));
+        if (!IsInsideRoot(SolutionRoot, fullPath))
+        {
+            throw new InvalidOperationException($"Agent tool path is outside the solution root: {path}");
+        }
+
+        return fullPath;
+    }
+
+    private string ToRelativePath(string fullPath)
+        => Path.GetRelativePath(SolutionRoot, fullPath)
+            .Replace(Path.DirectorySeparatorChar, '/');
+
+    private void AddTrace(string tool, string target, string summary)
+        => _transcript.Add(new AgentToolTrace
+        {
+            Tool = tool,
+            Target = target,
+            Summary = summary,
+            TimestampUtc = DateTimeOffset.UtcNow
+        });
+
+    private static bool IsInsideRoot(string root, string path)
+    {
+        var fullRoot = Path.GetFullPath(root).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) + Path.DirectorySeparatorChar;
+        var fullPath = Path.GetFullPath(path);
+        return fullPath.StartsWith(fullRoot, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static IReadOnlyList<string> SplitLines(string value)
+        => value.Replace("\r\n", "\n", StringComparison.Ordinal)
+            .Split('\n');
+}
+
+public sealed record AgentFileRead
+{
+    public string Path { get; init; } = "";
+
+    public string RelativePath { get; init; } = "";
+
+    public string Content { get; init; } = "";
+}
+
+public sealed record AgentPatchProposal
+{
+    public string Id { get; init; } = "";
+
+    public string Summary { get; init; } = "";
+
+    public IReadOnlyList<AgentProposedFileChange> Changes { get; init; } = [];
+}
+
+public sealed record AgentProposedFileChange
+{
+    public string Path { get; init; } = "";
+
+    public string RelativePath { get; init; } = "";
+
+    public AgentPatchChangeKind ChangeKind { get; init; }
+
+    public string OriginalContent { get; init; } = "";
+
+    public string UpdatedContent { get; init; } = "";
+}
+
+public enum AgentPatchChangeKind
+{
+    Create,
+    Update
+}
+
+public sealed record AgentPatchApplyResult
+{
+    public string ProposalId { get; init; } = "";
+
+    public string ApprovedBy { get; init; } = "";
+
+    public IReadOnlyList<string> AppliedPaths { get; init; } = [];
+}
+
+public sealed record AgentCommandResult
+{
+    public string FileName { get; init; } = "";
+
+    public IReadOnlyList<string> Arguments { get; init; } = [];
+
+    public int ExitCode { get; init; }
+
+    public string StandardOutput { get; init; } = "";
+
+    public string StandardError { get; init; } = "";
+}
+
+public sealed record AgentToolTrace
+{
+    public string Tool { get; init; } = "";
+
+    public string Target { get; init; } = "";
+
+    public string Summary { get; init; } = "";
+
+    public DateTimeOffset TimestampUtc { get; init; }
+}
+
+public sealed record AgentAuditRecord
+{
+    internal static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    public string Kind { get; init; } = "";
+
+    public string ReviewedBy { get; init; } = "";
+
+    public DateTimeOffset TimestampUtc { get; init; }
+
+    public string ProposalId { get; init; } = "";
+
+    public string Summary { get; init; } = "";
+
+    public IReadOnlyList<string> ProposedFiles { get; init; } = [];
+
+    public IReadOnlyList<string> AppliedFiles { get; init; } = [];
+
+    public IReadOnlyDictionary<string, IReadOnlyList<string>> Metadata { get; init; } =
+        new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase);
+
+    public IReadOnlyList<AgentToolTrace> Transcript { get; init; } = [];
+
+    public string Path { get; init; } = "";
+}

--- a/src/AgentBlazor.Cli.Analysis/AnalysisCorpusBuilder.cs
+++ b/src/AgentBlazor.Cli.Analysis/AnalysisCorpusBuilder.cs
@@ -1,0 +1,373 @@
+using System.Text;
+using AgentBlazor.Cli.Analysis.Models;
+
+namespace AgentBlazor.Cli.Analysis;
+
+public sealed class AnalysisCorpusBuilder
+{
+    private static readonly HashSet<string> IgnoredTerms = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "agent",
+        "async",
+        "blazor",
+        "class",
+        "component",
+        "data",
+        "model",
+        "page",
+        "request",
+        "response",
+        "result",
+        "service",
+        "services",
+        "task",
+        "user",
+        "workflow"
+    };
+
+    public AnalysisCorpus Build(ProjectModel model)
+    {
+        ArgumentNullException.ThrowIfNull(model);
+
+        var chunks = new List<AnalysisCorpusChunk>();
+        var fileReferences = new Dictionary<string, FileReferenceAccumulator>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var route in model.Routes)
+        {
+            var terms = ExtractTerms(route.Template, route.ComponentName);
+            chunks.Add(new AnalysisCorpusChunk
+            {
+                Id = $"route:{route.Id}",
+                Kind = AnalysisCorpusChunkKind.Route,
+                Title = $"Route {route.Template}",
+                Text = $"Route {route.Template} renders {route.ComponentName}. Parameters: {string.Join(", ", route.Parameters.Select(parameter => parameter.Name))}.",
+                FilePath = route.ComponentFile,
+                RelatedRoutes = [route.Template],
+                DomainTerms = terms
+            });
+            AddFileReference(fileReferences, route.ComponentFile, route.ComponentName, route.Template);
+        }
+
+        foreach (var page in model.Pages)
+        {
+            var terms = ExtractTerms(page.Route, page.ComponentName, page.Summary);
+            chunks.Add(new AnalysisCorpusChunk
+            {
+                Id = $"page:{page.Id}",
+                Kind = AnalysisCorpusChunkKind.Page,
+                Title = $"Page {page.ComponentName}",
+                Text = BuildPageText(page),
+                FilePath = page.FilePath,
+                RelatedRoutes = string.IsNullOrWhiteSpace(page.Route) ? [] : [page.Route],
+                RelatedServices = page.InjectedServices,
+                RelatedMethods = page.SuggestedActions,
+                DomainTerms = terms
+            });
+            AddFileReference(fileReferences, page.FilePath, page.ComponentName, page.Route);
+        }
+
+        foreach (var service in model.Services.Where(service => AnalysisModelFilters.IsDeveloperFacingService(service, model)))
+        {
+            var serviceTerms = ExtractTerms(service.TypeName, service.ImplementationType ?? string.Empty);
+            chunks.Add(new AnalysisCorpusChunk
+            {
+                Id = $"service:{service.TypeName}",
+                Kind = AnalysisCorpusChunkKind.Service,
+                Title = service.TypeName,
+                Text = BuildServiceText(service),
+                FilePath = service.FilePath,
+                RelatedServices = [service.TypeName],
+                RelatedMethods = service.Methods.Select(method => $"{service.TypeName}.{method.Name}").ToList(),
+                DomainTerms = serviceTerms
+            });
+            AddFileReference(fileReferences, service.FilePath, service.TypeName, null);
+
+            foreach (var method in service.Methods.Where(method => method.IsPublic && AnalysisModelFilters.IsDeveloperFacingMethod(method.Name)))
+            {
+                var action = model.Actions.FirstOrDefault(action =>
+                    action.SourceService.Equals(service.TypeName, StringComparison.OrdinalIgnoreCase) &&
+                    action.MethodName.Equals(method.Name, StringComparison.OrdinalIgnoreCase));
+                if (action is null || !AnalysisModelFilters.IsDeveloperFacingAction(action))
+                {
+                    continue;
+                }
+
+                var methodTerms = ExtractTerms(service.TypeName, method.Name, method.XmlDocSummary ?? string.Empty, action.Summary);
+                chunks.Add(new AnalysisCorpusChunk
+                {
+                    Id = $"method:{service.TypeName}.{method.Name}",
+                    Kind = AnalysisCorpusChunkKind.Method,
+                    Title = $"{service.TypeName}.{method.Name}",
+                    Text = BuildMethodText(service, method, action),
+                    FilePath = service.FilePath,
+                    RelatedRoutes = action.RelevantRoutes,
+                    RelatedServices = [service.TypeName],
+                    RelatedMethods = [$"{service.TypeName}.{method.Name}"],
+                    DomainTerms = methodTerms
+                });
+            }
+        }
+
+        foreach (var registration in model.DiRegistrations)
+        {
+            var terms = ExtractTerms(registration.ServiceType, registration.ImplementationType);
+            chunks.Add(new AnalysisCorpusChunk
+            {
+                Id = $"di:{registration.ServiceType}:{registration.ImplementationType}",
+                Kind = AnalysisCorpusChunkKind.DiRegistration,
+                Title = $"DI {registration.ServiceType}",
+                Text = $"{registration.Lifetime} registration maps {registration.ServiceType} to {registration.ImplementationType}.",
+                FilePath = registration.FilePath,
+                LineNumber = registration.LineNumber,
+                RelatedServices = [registration.ServiceType, registration.ImplementationType],
+                DomainTerms = terms
+            });
+            AddFileReference(fileReferences, registration.FilePath, registration.ImplementationType, null);
+        }
+
+        foreach (var action in model.Actions.Where(action => action.ExposureMode == ActionExposureMode.Confirmed))
+        {
+            var terms = ExtractTerms(action.SourceService, action.MethodName, action.Summary);
+            chunks.Add(new AnalysisCorpusChunk
+            {
+                Id = $"capability:{action.SourceService}.{action.MethodName}",
+                Kind = AnalysisCorpusChunkKind.Capability,
+                Title = $"Confirmed action {action.SourceService}.{action.MethodName}",
+                Text = $"{action.SourceService}.{action.MethodName} is already exposed to AgentBlazor. Requires approval: {action.RequiresApproval}. Summary: {action.Summary}.",
+                FilePath = action.FilePath,
+                RelatedRoutes = action.RelevantRoutes,
+                RelatedServices = [action.SourceService],
+                RelatedMethods = [$"{action.SourceService}.{action.MethodName}"],
+                DomainTerms = terms
+            });
+        }
+
+        foreach (var cluster in model.WorkflowClusters)
+        {
+            var terms = ExtractTerms(cluster.Name, cluster.SourceService, cluster.Summary)
+                .Concat(cluster.DomainTerms)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+            chunks.Add(new AnalysisCorpusChunk
+            {
+                Id = $"workflow:{cluster.Id}",
+                Kind = AnalysisCorpusChunkKind.WorkflowCluster,
+                Title = cluster.Name,
+                Text = BuildWorkflowClusterText(cluster),
+                FilePath = cluster.FilePath,
+                RelatedRoutes = cluster.RouteHints,
+                RelatedServices = cluster.RelatedServices,
+                RelatedMethods = cluster.Methods.Select(method => $"{method.Service}.{method.Method}").ToList(),
+                DomainTerms = terms
+            });
+        }
+
+        var routeCorrelations = BuildRouteCorrelations(model);
+        foreach (var correlation in routeCorrelations)
+        {
+            var terms = ExtractTerms(correlation.Route, correlation.ComponentName)
+                .Concat(correlation.Services.SelectMany(SplitIdentifier))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+            chunks.Add(new AnalysisCorpusChunk
+            {
+                Id = $"route-correlation:{NormalizeId(correlation.Route)}",
+                Kind = AnalysisCorpusChunkKind.RouteCorrelation,
+                Title = $"Route correlation {correlation.Route}",
+                Text = $"Route {correlation.Route} correlates {correlation.ComponentName} with services {string.Join(", ", correlation.Services)} and methods {string.Join(", ", correlation.Methods)}.",
+                FilePath = correlation.FilePath,
+                RelatedRoutes = [correlation.Route],
+                RelatedServices = correlation.Services,
+                RelatedMethods = correlation.Methods,
+                DomainTerms = terms
+            });
+        }
+
+        var domainTerms = chunks
+            .SelectMany(chunk => chunk.DomainTerms)
+            .Where(term => !IgnoredTerms.Contains(term))
+            .GroupBy(term => term, StringComparer.OrdinalIgnoreCase)
+            .OrderByDescending(group => group.Count())
+            .ThenBy(group => group.Key, StringComparer.OrdinalIgnoreCase)
+            .Select(group => group.Key)
+            .Take(40)
+            .ToList();
+
+        return new AnalysisCorpus
+        {
+            Chunks = chunks,
+            RouteCorrelations = routeCorrelations,
+            DomainTerms = domainTerms,
+            FileReferences = fileReferences.Values
+                .Select(reference => new FileReferenceModel
+                {
+                    Path = reference.Path,
+                    Symbols = reference.Symbols.OrderBy(value => value, StringComparer.OrdinalIgnoreCase).ToList(),
+                    Routes = reference.Routes.OrderBy(value => value, StringComparer.OrdinalIgnoreCase).ToList()
+                })
+                .OrderBy(reference => reference.Path, StringComparer.OrdinalIgnoreCase)
+                .ToList()
+        };
+    }
+
+    private static IReadOnlyList<RouteCorrelationModel> BuildRouteCorrelations(ProjectModel model)
+    {
+        var actionById = model.Actions
+            .GroupBy(action => action.Id, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(
+                group => group.Key,
+                group => group
+                    .OrderByDescending(action => action.ExposureMode == ActionExposureMode.Confirmed)
+                    .ThenByDescending(action => action.Score)
+                    .First(),
+                StringComparer.OrdinalIgnoreCase);
+        var correlations = new List<RouteCorrelationModel>();
+        foreach (var page in model.Pages.Where(page => !string.IsNullOrWhiteSpace(page.Route)))
+        {
+            var actions = page.SuggestedActions
+                .Select(actionId => actionById.TryGetValue(actionId, out var action) ? action : null)
+                .OfType<ActionModel>()
+                .ToList();
+            if (actions.Count == 0 && page.InjectedServices.Count == 0)
+            {
+                continue;
+            }
+
+            correlations.Add(new RouteCorrelationModel
+            {
+                Route = page.Route,
+                ComponentName = page.ComponentName,
+                FilePath = page.FilePath,
+                Services = actions
+                    .Select(action => action.SourceService)
+                    .Concat(page.InjectedServices)
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .OrderBy(value => value, StringComparer.OrdinalIgnoreCase)
+                    .ToList(),
+                Methods = actions
+                    .Select(action => $"{action.SourceService}.{action.MethodName}")
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .OrderBy(value => value, StringComparer.OrdinalIgnoreCase)
+                    .ToList()
+            });
+        }
+
+        return correlations;
+    }
+
+    private static string BuildPageText(PageModel page)
+        => $"Page {page.ComponentName} at route {page.Route}. Injected services: {string.Join(", ", page.InjectedServices)}. Suggested actions: {string.Join(", ", page.SuggestedActions)}. UI elements: {string.Join(", ", page.DetectedUiElements)}.";
+
+    private static string BuildServiceText(ServiceModel service)
+        => $"Service {service.TypeName} ({service.Lifetime}) in {service.FilePath}. Service types: {string.Join(", ", service.ServiceTypes)}. Public methods: {string.Join(", ", service.Methods.Where(method => method.IsPublic).Select(method => method.Name))}.";
+
+    private static string BuildMethodText(ServiceModel service, ServiceMethodModel method, ActionModel action)
+    {
+        var parameters = string.Join(", ", method.Parameters.Select(parameter => $"{parameter.TypeName} {parameter.Name}"));
+        return $"{service.TypeName}.{method.Name}({parameters}) returns {method.ReturnType}. Classification: {action.Classification}. Risk: {ActionRisk.Describe(ActionRisk.GetRiskBand(action))}. Requires approval: {action.RequiresApproval}. Routes: {string.Join(", ", action.RelevantRoutes)}. Summary: {FirstNonEmpty(action.Summary, method.XmlDocSummary, action.Name)}.";
+    }
+
+    private static string BuildWorkflowClusterText(WorkflowClusterModel cluster)
+    {
+        var sb = new StringBuilder();
+        sb.Append(cluster.Summary);
+        sb.Append(" Origin: ").Append(cluster.Origin).Append('.');
+        sb.Append(" Risk: ").Append(cluster.Risk).Append('.');
+        sb.Append(" Requires approval: ").Append(cluster.RequiresApproval).Append('.');
+        sb.Append(" Methods: ").Append(string.Join(" -> ", cluster.Methods.Select(method => $"{method.Service}.{method.Method}"))).Append('.');
+        sb.Append(" Evidence: ").Append(string.Join("; ", cluster.Evidence)).Append('.');
+        if (cluster.RouteHints.Count > 0)
+        {
+            sb.Append(" Routes: ").Append(string.Join(", ", cluster.RouteHints)).Append('.');
+        }
+
+        return sb.ToString();
+    }
+
+    public static IReadOnlyList<string> ExtractTerms(params string[] values)
+        => values
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .SelectMany(SplitIdentifier)
+            .Where(term => term.Length >= 4)
+            .Where(term => !IgnoredTerms.Contains(term))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+    private static IEnumerable<string> SplitIdentifier(string value)
+    {
+        var words = new List<string>();
+        var current = new StringBuilder();
+        foreach (var character in value)
+        {
+            if (!char.IsLetterOrDigit(character))
+            {
+                Flush();
+                continue;
+            }
+
+            if (current.Length > 0 && char.IsUpper(character) && !char.IsUpper(current[^1]))
+            {
+                Flush();
+            }
+
+            current.Append(char.ToLowerInvariant(character));
+        }
+
+        Flush();
+        return words;
+
+        void Flush()
+        {
+            if (current.Length == 0)
+            {
+                return;
+            }
+
+            words.Add(current.ToString());
+            current.Clear();
+        }
+    }
+
+    private static string NormalizeId(string value)
+        => string.Join('-', SplitIdentifier(value)).ToLowerInvariant();
+
+    private static string FirstNonEmpty(params string?[] values)
+        => values.FirstOrDefault(value => !string.IsNullOrWhiteSpace(value)) ?? string.Empty;
+
+    private static void AddFileReference(
+        Dictionary<string, FileReferenceAccumulator> references,
+        string path,
+        string? symbol,
+        string? route)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return;
+        }
+
+        if (!references.TryGetValue(path, out var reference))
+        {
+            reference = new FileReferenceAccumulator(path);
+            references[path] = reference;
+        }
+
+        if (!string.IsNullOrWhiteSpace(symbol))
+        {
+            reference.Symbols.Add(symbol);
+        }
+
+        if (!string.IsNullOrWhiteSpace(route))
+        {
+            reference.Routes.Add(route);
+        }
+    }
+
+    private sealed class FileReferenceAccumulator(string path)
+    {
+        public string Path { get; } = path;
+
+        public HashSet<string> Symbols { get; } = new(StringComparer.OrdinalIgnoreCase);
+
+        public HashSet<string> Routes { get; } = new(StringComparer.OrdinalIgnoreCase);
+    }
+}

--- a/src/AgentBlazor.Cli.Analysis/ExistingAppScaffoldApplier.cs
+++ b/src/AgentBlazor.Cli.Analysis/ExistingAppScaffoldApplier.cs
@@ -301,7 +301,7 @@ public sealed class ExistingAppScaffoldApplier
             .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
             ?.InformationalVersion
             ?? typeof(ExistingAppScaffoldApplier).Assembly.GetName().Version?.ToString()
-            ?? "0.2.21";
+            ?? "0.2.22";
 
         return version.Split('+', 2)[0];
     }

--- a/src/AgentBlazor.Cli.Analysis/ModelBuilder.cs
+++ b/src/AgentBlazor.Cli.Analysis/ModelBuilder.cs
@@ -18,6 +18,7 @@ public sealed class ModelBuilder
     private readonly DiRegistrationAnalyzer _diAnalyzer = new();
     private readonly RecommendationEngine _recommendationEngine = new();
     private readonly WorkflowClusterAnalyzer _workflowClusterAnalyzer = new();
+    private readonly AnalysisCorpusBuilder _corpusBuilder = new();
 
     public event Action<string>? OnProgress;
     public event Action<string>? OnWarning;
@@ -355,6 +356,7 @@ public sealed class ModelBuilder
             SolutionPath = solutionOrProjectPath,
             AppName = hostProject.Name,
             Description = appDescription,
+            DesiredAgentWorkflows = config?.DesiredAgentWorkflows ?? [],
             BlazorHostProject = hostProject.Name,
             GeneratedAtUtc = DateTimeOffset.UtcNow,
             Projects = projectNodes,
@@ -370,6 +372,10 @@ public sealed class ModelBuilder
         initialModel = initialModel with
         {
             WorkflowClusters = workflowClusters
+        };
+        initialModel = initialModel with
+        {
+            Corpus = _corpusBuilder.Build(initialModel)
         };
 
         // 12. Generate recommendations and coverage stats

--- a/src/AgentBlazor.Cli.Analysis/Models/AgentBlazorConfig.cs
+++ b/src/AgentBlazor.Cli.Analysis/Models/AgentBlazorConfig.cs
@@ -28,6 +28,12 @@ public sealed class AgentBlazorConfig
     public string? Description { get; init; }
 
     /// <summary>
+    /// Developer-stated workflows or business outcomes the agent should help with.
+    /// These are intent hints for workflow onboarding, not proof that the app supports them.
+    /// </summary>
+    public List<string>? DesiredAgentWorkflows { get; init; }
+
+    /// <summary>
     /// Debounce time in milliseconds for watch mode.
     /// Default: 500ms
     /// </summary>
@@ -139,12 +145,16 @@ public sealed class AgentBlazorConfig
     /// <summary>
     /// Creates a default configuration with common settings.
     /// </summary>
-    public static AgentBlazorConfig CreateDefault(string? hostProject = null, string? description = null)
+    public static AgentBlazorConfig CreateDefault(
+        string? hostProject = null,
+        string? description = null,
+        List<string>? desiredAgentWorkflows = null)
     {
         return new AgentBlazorConfig
         {
             HostProject = hostProject,
             Description = description,
+            DesiredAgentWorkflows = desiredAgentWorkflows,
             WatchDebounceMs = 500,
             AutoUpdateOnBuild = true
         };

--- a/src/AgentBlazor.Cli.Analysis/Models/ProjectModel.cs
+++ b/src/AgentBlazor.Cli.Analysis/Models/ProjectModel.cs
@@ -10,6 +10,7 @@ public sealed record ProjectModel
     public string SolutionPath { get; init; } = "";
     public string AppName { get; init; } = "";
     public string Description { get; init; } = "";
+    public IReadOnlyList<string> DesiredAgentWorkflows { get; init; } = [];
     public string BlazorHostProject { get; init; } = "";
     public DateTimeOffset GeneratedAtUtc { get; init; } = DateTimeOffset.UtcNow;
     public IReadOnlyList<ProjectNode> Projects { get; init; } = [];
@@ -18,6 +19,7 @@ public sealed record ProjectModel
     public IReadOnlyList<ServiceModel> Services { get; init; } = [];
     public IReadOnlyList<ActionModel> Actions { get; init; } = [];
     public IReadOnlyList<WorkflowClusterModel> WorkflowClusters { get; init; } = [];
+    public AnalysisCorpus Corpus { get; init; } = new();
     public IReadOnlyList<PageModel> Pages { get; init; } = [];
     public IReadOnlyList<DiRegistrationModel> DiRegistrations { get; init; } = [];
     public IReadOnlyList<RecommendationModel> Recommendations { get; init; } = [];
@@ -199,6 +201,74 @@ public enum ServiceLifetime
     Scoped,
     Transient,
     Singleton
+}
+
+public sealed record AnalysisCorpus
+{
+    public IReadOnlyList<AnalysisCorpusChunk> Chunks { get; init; } = [];
+
+    public IReadOnlyList<RouteCorrelationModel> RouteCorrelations { get; init; } = [];
+
+    public IReadOnlyList<string> DomainTerms { get; init; } = [];
+
+    public IReadOnlyList<FileReferenceModel> FileReferences { get; init; } = [];
+}
+
+public sealed record AnalysisCorpusChunk
+{
+    public string Id { get; init; } = "";
+
+    public AnalysisCorpusChunkKind Kind { get; init; }
+
+    public string Title { get; init; } = "";
+
+    public string Text { get; init; } = "";
+
+    public string FilePath { get; init; } = "";
+
+    public int? LineNumber { get; init; }
+
+    public IReadOnlyList<string> RelatedRoutes { get; init; } = [];
+
+    public IReadOnlyList<string> RelatedServices { get; init; } = [];
+
+    public IReadOnlyList<string> RelatedMethods { get; init; } = [];
+
+    public IReadOnlyList<string> DomainTerms { get; init; } = [];
+}
+
+public enum AnalysisCorpusChunkKind
+{
+    Route,
+    Page,
+    Service,
+    Method,
+    DiRegistration,
+    Capability,
+    WorkflowCluster,
+    RouteCorrelation
+}
+
+public sealed record RouteCorrelationModel
+{
+    public string Route { get; init; } = "";
+
+    public string ComponentName { get; init; } = "";
+
+    public string FilePath { get; init; } = "";
+
+    public IReadOnlyList<string> Services { get; init; } = [];
+
+    public IReadOnlyList<string> Methods { get; init; } = [];
+}
+
+public sealed record FileReferenceModel
+{
+    public string Path { get; init; } = "";
+
+    public IReadOnlyList<string> Symbols { get; init; } = [];
+
+    public IReadOnlyList<string> Routes { get; init; } = [];
 }
 
 /// <summary>

--- a/src/AgentBlazor.Cli.Analysis/SemanticRetrieval.cs
+++ b/src/AgentBlazor.Cli.Analysis/SemanticRetrieval.cs
@@ -1,0 +1,119 @@
+using System.Text;
+using AgentBlazor.Cli.Analysis.Models;
+
+namespace AgentBlazor.Cli.Analysis;
+
+public interface IAnalysisRetrieval
+{
+    IReadOnlyList<AnalysisRetrievalResult> Search(AnalysisCorpus corpus, string query, int maxResults = 8);
+}
+
+public sealed record AnalysisRetrievalResult
+{
+    public AnalysisCorpusChunk Chunk { get; init; } = new();
+
+    public double Score { get; init; }
+
+    public IReadOnlyList<string> MatchedTerms { get; init; } = [];
+}
+
+public sealed class LexicalAnalysisRetrieval : IAnalysisRetrieval
+{
+    public IReadOnlyList<AnalysisRetrievalResult> Search(AnalysisCorpus corpus, string query, int maxResults = 8)
+    {
+        ArgumentNullException.ThrowIfNull(corpus);
+        ArgumentException.ThrowIfNullOrWhiteSpace(query);
+
+        var queryTerms = Tokenize(query).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        if (queryTerms.Count == 0)
+        {
+            return [];
+        }
+
+        return corpus.Chunks
+            .Select(chunk => ScoreChunk(chunk, queryTerms))
+            .Where(result => result.Score > 0)
+            .OrderByDescending(result => result.Score)
+            .ThenBy(result => result.Chunk.Kind)
+            .ThenBy(result => result.Chunk.Title, StringComparer.OrdinalIgnoreCase)
+            .Take(Math.Max(1, maxResults))
+            .ToList();
+    }
+
+    private static AnalysisRetrievalResult ScoreChunk(
+        AnalysisCorpusChunk chunk,
+        HashSet<string> queryTerms)
+    {
+        var weightedText = new StringBuilder();
+        weightedText.Append(chunk.Title).Append(' ').Append(chunk.Title).Append(' ');
+        weightedText.Append(chunk.Text).Append(' ');
+        weightedText.AppendJoin(' ', chunk.DomainTerms).Append(' ');
+        weightedText.AppendJoin(' ', chunk.RelatedRoutes).Append(' ');
+        weightedText.AppendJoin(' ', chunk.RelatedServices).Append(' ');
+        weightedText.AppendJoin(' ', chunk.RelatedMethods);
+
+        var chunkTerms = Tokenize(weightedText.ToString()).ToList();
+        if (chunkTerms.Count == 0)
+        {
+            return new AnalysisRetrievalResult { Chunk = chunk };
+        }
+
+        var matchedTerms = chunkTerms
+            .Where(queryTerms.Contains)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        if (matchedTerms.Count == 0)
+        {
+            return new AnalysisRetrievalResult { Chunk = chunk };
+        }
+
+        var matchDensity = matchedTerms.Count / (double)queryTerms.Count;
+        var frequency = chunkTerms.Count(term => queryTerms.Contains(term)) / (double)chunkTerms.Count;
+        var kindBoost = chunk.Kind is AnalysisCorpusChunkKind.WorkflowCluster or AnalysisCorpusChunkKind.Method
+            ? 0.15
+            : 0.0;
+
+        return new AnalysisRetrievalResult
+        {
+            Chunk = chunk,
+            Score = Math.Round(matchDensity + frequency + kindBoost, 4),
+            MatchedTerms = matchedTerms
+        };
+    }
+
+    private static IEnumerable<string> Tokenize(string text)
+    {
+        var tokens = new List<string>();
+        var current = new StringBuilder();
+        foreach (var character in text)
+        {
+            if (!char.IsLetterOrDigit(character))
+            {
+                Flush();
+                continue;
+            }
+
+            if (current.Length > 0 && char.IsUpper(character) && !char.IsUpper(current[^1]))
+            {
+                Flush();
+            }
+
+            current.Append(char.ToLowerInvariant(character));
+        }
+
+        Flush();
+        return tokens;
+
+        void Flush()
+        {
+            if (current.Length < 3)
+            {
+                current.Clear();
+                return;
+            }
+
+            tokens.Add(current.ToString());
+            current.Clear();
+        }
+    }
+}

--- a/src/AgentBlazor.Cli.Analysis/SkillSystem.cs
+++ b/src/AgentBlazor.Cli.Analysis/SkillSystem.cs
@@ -1,0 +1,148 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace AgentBlazor.Cli.Analysis;
+
+public sealed class SkillViewStore
+{
+    public async Task<string> ViewAsync(
+        string agentBlazorDirectory,
+        string? skillName = null,
+        string? referencePath = null,
+        CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(agentBlazorDirectory);
+
+        var skillsDirectory = Path.Combine(agentBlazorDirectory, "skills");
+        if (string.IsNullOrWhiteSpace(skillName))
+        {
+            return await File.ReadAllTextAsync(Path.Combine(skillsDirectory, "index.json"), ct).ConfigureAwait(false);
+        }
+
+        var skillDirectory = ResolveSkillDirectory(skillsDirectory, skillName);
+        if (string.IsNullOrWhiteSpace(referencePath))
+        {
+            return await File.ReadAllTextAsync(Path.Combine(skillDirectory, "SKILL.md"), ct).ConfigureAwait(false);
+        }
+
+        var fullReferencePath = Path.GetFullPath(Path.Combine(skillDirectory, referencePath));
+        if (!IsInsideRoot(skillDirectory, fullReferencePath))
+        {
+            throw new InvalidOperationException("Skill reference path must stay inside the selected skill directory.");
+        }
+
+        return await File.ReadAllTextAsync(fullReferencePath, ct).ConfigureAwait(false);
+    }
+
+    private static string ResolveSkillDirectory(string skillsDirectory, string skillName)
+    {
+        var safeName = WorkflowOnboardingPlanner.ToSlug(skillName);
+        var directory = Path.Combine(skillsDirectory, safeName);
+        if (!Directory.Exists(directory))
+        {
+            throw new DirectoryNotFoundException($"Skill '{skillName}' was not found.");
+        }
+
+        return directory;
+    }
+
+    private static bool IsInsideRoot(string root, string path)
+    {
+        var fullRoot = Path.GetFullPath(root).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) + Path.DirectorySeparatorChar;
+        var fullPath = Path.GetFullPath(path);
+        return fullPath.StartsWith(fullRoot, StringComparison.OrdinalIgnoreCase);
+    }
+}
+
+public sealed class SkillCurator
+{
+    public async Task<SkillCuratorResult> CurateAsync(
+        string agentBlazorDirectory,
+        DateOnly today,
+        CancellationToken ct = default)
+    {
+        var skillsDirectory = Path.Combine(agentBlazorDirectory, "skills");
+        var metadataPath = Path.Combine(skillsDirectory, ".metadata.json");
+        if (!File.Exists(metadataPath))
+        {
+            return new SkillCuratorResult();
+        }
+
+        var root = JsonNode.Parse(await File.ReadAllTextAsync(metadataPath, ct).ConfigureAwait(false))?.AsObject()
+            ?? new JsonObject();
+        var skills = root["skills"]?.AsArray() ?? new JsonArray();
+        var markedStale = new List<string>();
+        var archived = new List<string>();
+
+        foreach (var node in skills.OfType<JsonObject>())
+        {
+            var name = node["name"]?.GetValue<string>() ?? string.Empty;
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                continue;
+            }
+
+            var pinned = node["pinned"]?.GetValue<bool>() ?? false;
+            if (pinned)
+            {
+                continue;
+            }
+
+            var lastActivity = ReadDate(node["lastExecuted"]?.GetValue<string?>()) ??
+                ReadDate(node["lastRead"]?.GetValue<string?>()) ??
+                ReadDate(node["lastReviewed"]?.GetValue<string?>()) ??
+                today;
+            var inactiveDays = today.DayNumber - lastActivity.DayNumber;
+            var currentState = node["state"]?.GetValue<string>() ?? "active";
+
+            if (inactiveDays >= 90)
+            {
+                var source = Path.Combine(skillsDirectory, name);
+                var archiveRoot = Path.Combine(skillsDirectory, ".archive");
+                var target = Path.Combine(archiveRoot, name);
+                if (Directory.Exists(source))
+                {
+                    Directory.CreateDirectory(archiveRoot);
+                    if (Directory.Exists(target))
+                    {
+                        Directory.Delete(target, recursive: true);
+                    }
+
+                    Directory.Move(source, target);
+                }
+
+                node["state"] = "archived";
+                node["archivedAt"] = $"{today:yyyy-MM-dd}";
+                archived.Add(name);
+                continue;
+            }
+
+            if (inactiveDays >= 30 && !string.Equals(currentState, "stale", StringComparison.OrdinalIgnoreCase))
+            {
+                node["state"] = "stale";
+                markedStale.Add(name);
+            }
+        }
+
+        await File.WriteAllTextAsync(
+            metadataPath,
+            root.ToJsonString(new JsonSerializerOptions { WriteIndented = true }) + Environment.NewLine,
+            ct).ConfigureAwait(false);
+
+        return new SkillCuratorResult
+        {
+            MarkedStale = markedStale,
+            Archived = archived
+        };
+    }
+
+    private static DateOnly? ReadDate(string? value)
+        => DateOnly.TryParse(value, out var date) ? date : null;
+}
+
+public sealed record SkillCuratorResult
+{
+    public IReadOnlyList<string> MarkedStale { get; init; } = [];
+
+    public IReadOnlyList<string> Archived { get; init; } = [];
+}

--- a/src/AgentBlazor.Cli.Analysis/WorkflowOnboarding.cs
+++ b/src/AgentBlazor.Cli.Analysis/WorkflowOnboarding.cs
@@ -1,0 +1,1163 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Net;
+using AgentBlazor.Cli.Analysis.Models;
+
+namespace AgentBlazor.Cli.Analysis;
+
+public sealed record WorkflowOnboardingCandidate
+{
+    public string Id { get; init; } = "";
+
+    public string Slug { get; init; } = "";
+
+    public string Name { get; init; } = "";
+
+    public string Description { get; init; } = "";
+
+    public string CapabilityClassName { get; init; } = "";
+
+    public string Risk { get; init; } = "safe read-only";
+
+    public bool RequiresApproval { get; init; }
+
+    public IReadOnlyList<string> Methods { get; init; } = [];
+
+    public IReadOnlyList<string> Routes { get; init; } = [];
+
+    public IReadOnlyList<string> Evidence { get; init; } = [];
+
+    public IReadOnlyList<AnalysisCorpusChunk> RetrievedEvidence { get; init; } = [];
+
+    public bool ExistingCapabilityOnly { get; init; }
+}
+
+public sealed record WorkflowOnboardingPlan
+{
+    public string SolutionRoot { get; init; } = "";
+
+    public string AgentBlazorDirectory { get; init; } = "";
+
+    public ProjectModel Model { get; init; } = new();
+
+    public IReadOnlyList<WorkflowOnboardingCandidate> Candidates { get; init; } = [];
+}
+
+public sealed record WorkflowReviewDecisions
+{
+    public IReadOnlySet<string> ApprovedIds { get; init; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+    public IReadOnlySet<string> RejectedIds { get; init; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+    public IReadOnlySet<string> PinnedIds { get; init; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+    public IReadOnlySet<string> UnpinnedIds { get; init; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+    public string? ReviewedBy { get; init; }
+
+    public static WorkflowReviewDecisions Empty { get; } = new();
+}
+
+internal sealed record WorkflowReviewCandidateState
+{
+    public string Status { get; init; } = "proposed";
+
+    public bool Pinned { get; init; }
+}
+
+public sealed class WorkflowOnboardingPlanner
+{
+    private readonly IAnalysisRetrieval _retrieval;
+
+    public WorkflowOnboardingPlanner()
+        : this(new LexicalAnalysisRetrieval())
+    {
+    }
+
+    public WorkflowOnboardingPlanner(IAnalysisRetrieval retrieval)
+    {
+        _retrieval = retrieval;
+    }
+
+    public WorkflowOnboardingPlan Plan(ProjectModel model, string solutionRoot)
+    {
+        ArgumentNullException.ThrowIfNull(model);
+        ArgumentException.ThrowIfNullOrWhiteSpace(solutionRoot);
+
+        var candidates = model.WorkflowClusters
+            .Where(cluster => cluster.Methods.Count >= 2)
+            .Select(cluster => FromCluster(model, cluster))
+            .Concat(BuildExistingCapabilityCandidates(model))
+            .GroupBy(candidate => candidate.Id, StringComparer.OrdinalIgnoreCase)
+            .Select(group => group.First())
+            .OrderBy(candidate => candidate.ExistingCapabilityOnly)
+            .ThenBy(candidate => RiskRank(candidate.Risk))
+            .ThenBy(candidate => candidate.Name, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        return new WorkflowOnboardingPlan
+        {
+            SolutionRoot = solutionRoot,
+            AgentBlazorDirectory = Path.Combine(solutionRoot, ".agentblazor"),
+            Model = model,
+            Candidates = candidates
+        };
+    }
+
+    private WorkflowOnboardingCandidate FromCluster(ProjectModel model, WorkflowClusterModel cluster)
+    {
+        var query = string.Join(
+            ' ',
+            cluster.Name,
+            cluster.Summary,
+            string.Join(' ', cluster.DomainTerms),
+            string.Join(' ', cluster.Methods.Select(method => method.Method)),
+            string.Join(' ', model.DesiredAgentWorkflows));
+        var retrieved = _retrieval.Search(model.Corpus, query, maxResults: 6)
+            .Select(result => result.Chunk)
+            .ToList();
+
+        return new WorkflowOnboardingCandidate
+        {
+            Id = cluster.Id,
+            Slug = ToSlug(cluster.Name),
+            Name = cluster.Name,
+            Description = cluster.Summary,
+            CapabilityClassName = ToPascalCase(cluster.Name) + "Capability",
+            Risk = cluster.Risk,
+            RequiresApproval = cluster.RequiresApproval,
+            Methods = cluster.Methods.Select(method => $"{method.Service}.{method.Method}").ToList(),
+            Routes = cluster.RouteHints,
+            Evidence = cluster.Evidence,
+            RetrievedEvidence = retrieved
+        };
+    }
+
+    private IEnumerable<WorkflowOnboardingCandidate> BuildExistingCapabilityCandidates(ProjectModel model)
+    {
+        var confirmedGroups = model.Actions
+            .Where(action => action.ExposureMode == ActionExposureMode.Confirmed)
+            .Where(AnalysisModelFilters.IsDeveloperFacingAction)
+            .GroupBy(action => action.SourceService, StringComparer.OrdinalIgnoreCase);
+
+        foreach (var group in confirmedGroups)
+        {
+            var actions = group
+                .OrderBy(action => action.MethodName, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+            if (actions.Count == 0)
+            {
+                continue;
+            }
+
+            var name = group.Key.EndsWith("Capability", StringComparison.OrdinalIgnoreCase)
+                ? group.Key[..^"Capability".Length]
+                : group.Key;
+            var displayName = SplitPascalCase(name);
+            yield return new WorkflowOnboardingCandidate
+            {
+                Id = "existing-" + ToSlug(group.Key),
+                Slug = ToSlug(displayName),
+                Name = displayName,
+                Description = $"Existing AgentBlazor capability {group.Key} with {actions.Count} confirmed action(s).",
+                CapabilityClassName = group.Key,
+                Risk = actions.Any(action => action.RequiresApproval || action.IsMutationLikely) ? "approval required" : "safe read-only",
+                RequiresApproval = actions.Any(action => action.RequiresApproval || action.IsMutationLikely),
+                Methods = actions.Select(action => $"{action.SourceService}.{action.MethodName}").ToList(),
+                Routes = actions.SelectMany(action => action.RelevantRoutes).Distinct(StringComparer.OrdinalIgnoreCase).ToList(),
+                Evidence = ["existing [AgentCapability] / [AgentAction] static evidence"],
+                RetrievedEvidence = _retrieval.Search(model.Corpus, group.Key, maxResults: 4).Select(result => result.Chunk).ToList(),
+                ExistingCapabilityOnly = true
+            };
+        }
+    }
+
+    private static int RiskRank(string risk)
+        => risk.Contains("high", StringComparison.OrdinalIgnoreCase) ? 3 :
+            risk.Contains("approval", StringComparison.OrdinalIgnoreCase) ? 2 :
+            risk.Contains("mutation", StringComparison.OrdinalIgnoreCase) ? 1 : 0;
+
+    public static string ToSlug(string value)
+    {
+        var words = SplitWords(value);
+        return words.Count == 0 ? "workflow" : string.Join('-', words).ToLowerInvariant();
+    }
+
+    private static string ToPascalCase(string value)
+        => string.Concat(SplitWords(value).Select(word => char.ToUpperInvariant(word[0]) + word[1..].ToLowerInvariant()));
+
+    private static string SplitPascalCase(string value)
+        => string.Join(' ', SplitWords(value).Select(word => char.ToUpperInvariant(word[0]) + word[1..].ToLowerInvariant()));
+
+    private static IReadOnlyList<string> SplitWords(string value)
+    {
+        var words = new List<string>();
+        var current = new StringBuilder();
+        foreach (var character in value)
+        {
+            if (!char.IsLetterOrDigit(character))
+            {
+                Flush();
+                continue;
+            }
+
+            if (current.Length > 0 && char.IsUpper(character) && !char.IsUpper(current[^1]))
+            {
+                Flush();
+            }
+
+            current.Append(char.ToLowerInvariant(character));
+        }
+
+        Flush();
+        return words;
+
+        void Flush()
+        {
+            if (current.Length == 0)
+            {
+                return;
+            }
+
+            words.Add(current.ToString());
+            current.Clear();
+        }
+    }
+}
+
+public sealed class WorkflowOnboardingArtifactWriter
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+
+    public IReadOnlySet<string> ReadApprovedCandidateIds(string agentBlazorDirectory)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(agentBlazorDirectory);
+
+        var reviewPath = Path.Combine(agentBlazorDirectory, "workflow-onboarding.json");
+        return ReadExistingReviewState(reviewPath)
+            .Where(pair => pair.Value.Status.Equals("approved", StringComparison.OrdinalIgnoreCase))
+            .Select(pair => pair.Key)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+    }
+
+    public IReadOnlyList<WorkflowArtifactChange> Preview(
+        WorkflowOnboardingPlan plan,
+        IReadOnlyList<WorkflowOnboardingCandidate> selected,
+        DateOnly today,
+        WorkflowReviewDecisions? decisions = null)
+        => BuildChanges(plan, selected, today, decisions ?? WorkflowReviewDecisions.Empty);
+
+    public async Task<IReadOnlyList<WorkflowArtifactChange>> ApplyAsync(
+        WorkflowOnboardingPlan plan,
+        IReadOnlyList<WorkflowOnboardingCandidate> selected,
+        DateOnly today,
+        WorkflowReviewDecisions? decisions = null,
+        CancellationToken ct = default)
+    {
+        var changes = BuildChanges(plan, selected, today, decisions ?? WorkflowReviewDecisions.Empty);
+        foreach (var change in changes)
+        {
+            if (!IsInsideRoot(plan.SolutionRoot, change.Path))
+            {
+                throw new InvalidOperationException($"Refusing to write outside the solution root: {change.Path}");
+            }
+
+            Directory.CreateDirectory(Path.GetDirectoryName(change.Path)!);
+            await File.WriteAllTextAsync(change.Path, change.UpdatedContent, ct).ConfigureAwait(false);
+        }
+
+        return changes;
+    }
+
+    private static IReadOnlyList<WorkflowArtifactChange> BuildChanges(
+        WorkflowOnboardingPlan plan,
+        IReadOnlyList<WorkflowOnboardingCandidate> selected,
+        DateOnly today,
+        WorkflowReviewDecisions decisions)
+    {
+        var changes = new List<WorkflowArtifactChange>();
+        var agentDir = plan.AgentBlazorDirectory;
+        var skillsDir = Path.Combine(agentDir, "skills");
+        var ordered = selected.OrderBy(candidate => candidate.Slug, StringComparer.OrdinalIgnoreCase).ToList();
+        var reviewPath = Path.Combine(agentDir, "workflow-onboarding.json");
+        var reviewState = ResolveReviewState(plan, ordered, decisions, reviewPath);
+        var reviewedBy = ResolveReviewedBy(reviewPath, decisions);
+
+        AddChange(
+            changes,
+            reviewPath,
+            BuildReviewJson(plan, reviewState, today, reviewedBy),
+            "Workflow onboarding review data");
+        AddChange(
+            changes,
+            Path.Combine(agentDir, "workflow-onboarding.md"),
+            BuildReviewMarkdown(plan, reviewState, today, reviewedBy),
+            "Workflow onboarding review report");
+        AddChange(
+            changes,
+            Path.Combine(agentDir, "workflow-onboarding.html"),
+            BuildReviewHtml(plan, reviewState, today, reviewedBy),
+            "Workflow onboarding review dashboard");
+        if (ordered.Count == 0)
+        {
+            return changes;
+        }
+
+        AddChange(changes, Path.Combine(agentDir, "SOUL.md"), BuildSoul(plan, ordered, today), "SOUL.md project constitution");
+        AddChange(changes, Path.Combine(skillsDir, "index.json"), BuildIndexJson(ordered), "Level 0 skill index");
+        var metadataPath = Path.Combine(skillsDir, ".metadata.json");
+        AddChange(changes, metadataPath, BuildMetadataJson(ordered, today, metadataPath), "Skill usage and curator metadata");
+
+        foreach (var candidate in ordered)
+        {
+            var skillDir = Path.Combine(skillsDir, candidate.Slug);
+            AddChange(changes, Path.Combine(skillDir, "SKILL.md"), BuildSkill(candidate, today), $"Workflow skill {candidate.Name}");
+            if (candidate.RetrievedEvidence.Count > 0)
+            {
+                AddChange(
+                    changes,
+                    Path.Combine(skillDir, "references", "evidence.md"),
+                    BuildEvidenceReference(candidate),
+                    $"Evidence reference for {candidate.Name}");
+            }
+        }
+
+        return changes;
+    }
+
+    private static void AddChange(List<WorkflowArtifactChange> changes, string path, string updated, string summary)
+    {
+        var original = File.Exists(path) ? File.ReadAllText(path) : string.Empty;
+        if (string.Equals(original, updated, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        changes.Add(new WorkflowArtifactChange
+        {
+            Path = path,
+            OriginalContent = original,
+            UpdatedContent = updated,
+            ChangeKind = File.Exists(path) ? WorkflowArtifactChangeKind.Update : WorkflowArtifactChangeKind.Create,
+            Summary = summary
+        });
+    }
+
+    private static string BuildSoul(WorkflowOnboardingPlan plan, IReadOnlyList<WorkflowOnboardingCandidate> selected, DateOnly today)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("# AgentBlazor SOUL");
+        sb.AppendLine();
+        sb.AppendLine($"Last reviewed: {today:yyyy-MM-dd}");
+        sb.AppendLine();
+        sb.AppendLine("## Domain");
+        sb.AppendLine();
+        sb.AppendLine($"- App: {plan.Model.AppName}");
+        sb.AppendLine($"- Host project: {plan.Model.BlazorHostProject}");
+        sb.AppendLine($"- Description: {plan.Model.Description}");
+        if (plan.Model.Corpus.DomainTerms.Count > 0)
+        {
+            sb.AppendLine($"- Domain terms: {string.Join(", ", plan.Model.Corpus.DomainTerms.Take(16))}");
+        }
+        if (plan.Model.DesiredAgentWorkflows.Count > 0)
+        {
+            sb.AppendLine("- Developer-stated agent goals:");
+            foreach (var goal in plan.Model.DesiredAgentWorkflows)
+            {
+                sb.AppendLine($"  - {goal}");
+            }
+        }
+
+        sb.AppendLine();
+        sb.AppendLine("## Approved Workflow Scope");
+        if (selected.Count == 0)
+        {
+            sb.AppendLine();
+            sb.AppendLine("- No workflows have been approved for scaffolding yet.");
+        }
+        else
+        {
+            foreach (var candidate in selected)
+            {
+                sb.AppendLine($"- {candidate.Name} (`{candidate.Id}`): {candidate.Description}");
+            }
+        }
+
+        sb.AppendLine();
+        sb.AppendLine("## Restrictions");
+        sb.AppendLine();
+        sb.AppendLine("- Do not execute mutating workflow steps unless the skill and CLI session require approval.");
+        sb.AppendLine("- Do not modify files outside the detected solution root without explicit developer approval.");
+        sb.AppendLine("- Do not invent services, routes, methods, entities, or policies that are not present in static analysis evidence.");
+        sb.AppendLine("- Keep provider secrets and environment-specific configuration under developer control.");
+        sb.AppendLine();
+        sb.AppendLine("## Safety Boundaries");
+        sb.AppendLine();
+        sb.AppendLine("- Prefer read-only inspection before proposing mutations.");
+        sb.AppendLine("- Surface high-risk, admin, tenant, auth, database, cache, and permission changes as manual review.");
+        sb.AppendLine("- Preserve existing manual `[AgentCapability]` and `[AgentAction]` workflows.");
+        return sb.ToString();
+    }
+
+    private static string BuildReviewJson(
+        WorkflowOnboardingPlan plan,
+        IReadOnlyDictionary<string, WorkflowReviewCandidateState> reviewState,
+        DateOnly today,
+        string? reviewedBy)
+    {
+        var approvedCandidateIds = ReviewIdsByStatus(reviewState, "approved");
+        var rejectedCandidateIds = ReviewIdsByStatus(reviewState, "rejected");
+        var pinnedCandidateIds = reviewState
+            .Where(pair => pair.Value.Pinned)
+            .Select(pair => pair.Key)
+            .OrderBy(id => id, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        var payload = new
+        {
+            schemaVersion = 1,
+            generatedAt = $"{today:yyyy-MM-dd}",
+            reviewedBy,
+            review = new
+            {
+                reviewedBy,
+                generatedAt = $"{today:yyyy-MM-dd}",
+                approvedCandidateIds,
+                rejectedCandidateIds,
+                pinnedCandidateIds
+            },
+            app = new
+            {
+                name = plan.Model.AppName,
+                hostProject = plan.Model.BlazorHostProject,
+                description = plan.Model.Description,
+                desiredAgentWorkflows = plan.Model.DesiredAgentWorkflows,
+                domainTerms = plan.Model.Corpus.DomainTerms.Take(24).ToList()
+            },
+            candidates = plan.Candidates
+                .OrderBy(candidate => candidate.Name, StringComparer.OrdinalIgnoreCase)
+                .Select(candidate => new
+                {
+                    id = candidate.Id,
+                    slug = candidate.Slug,
+                    name = candidate.Name,
+                    description = candidate.Description,
+                    status = reviewState.TryGetValue(candidate.Id, out var state) ? state.Status : "proposed",
+                    pinned = state?.Pinned ?? false,
+                    risk = candidate.Risk,
+                    requiresApproval = candidate.RequiresApproval,
+                    capabilityClassName = candidate.CapabilityClassName,
+                    requiredApprovals = BuildRequiredApprovals(candidate),
+                    methods = candidate.Methods,
+                    routes = candidate.Routes,
+                    evidence = candidate.Evidence,
+                    fileReferences = candidate.RetrievedEvidence
+                        .Where(chunk => !string.IsNullOrWhiteSpace(chunk.FilePath))
+                        .Select(chunk => NormalizeReviewPath(plan.SolutionRoot, chunk.FilePath))
+                        .Distinct(StringComparer.OrdinalIgnoreCase)
+                        .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+                        .ToList(),
+                    retrievedEvidence = candidate.RetrievedEvidence
+                        .Select(chunk => new
+                        {
+                            kind = chunk.Kind.ToString(),
+                            title = chunk.Title,
+                            filePath = string.IsNullOrWhiteSpace(chunk.FilePath)
+                                ? null
+                                : NormalizeReviewPath(plan.SolutionRoot, chunk.FilePath),
+                            routes = chunk.RelatedRoutes,
+                            services = chunk.RelatedServices,
+                            methods = chunk.RelatedMethods
+                        })
+                        .ToList()
+                })
+                .ToList()
+        };
+
+        return JsonSerializer.Serialize(payload, JsonOptions) + Environment.NewLine;
+    }
+
+    private static string BuildReviewMarkdown(
+        WorkflowOnboardingPlan plan,
+        IReadOnlyDictionary<string, WorkflowReviewCandidateState> reviewState,
+        DateOnly today,
+        string? reviewedBy)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("# AgentBlazor Workflow Onboarding Review");
+        sb.AppendLine();
+        sb.AppendLine($"Generated: {today:yyyy-MM-dd}");
+        sb.AppendLine($"Reviewed by: {MarkdownValueOrPending(reviewedBy)}");
+        sb.AppendLine();
+        sb.AppendLine("## App Context");
+        sb.AppendLine();
+        sb.AppendLine($"- App: {plan.Model.AppName}");
+        sb.AppendLine($"- Host project: {plan.Model.BlazorHostProject}");
+        sb.AppendLine($"- Description: {plan.Model.Description}");
+        if (plan.Model.DesiredAgentWorkflows.Count > 0)
+        {
+            sb.AppendLine("- Developer-stated agent goals:");
+            foreach (var goal in plan.Model.DesiredAgentWorkflows)
+            {
+                sb.AppendLine($"  - {goal}");
+            }
+        }
+
+        if (plan.Model.Corpus.DomainTerms.Count > 0)
+        {
+            sb.AppendLine($"- Domain terms: {string.Join(", ", plan.Model.Corpus.DomainTerms.Take(24))}");
+        }
+
+        sb.AppendLine();
+        sb.AppendLine("## Candidate Summary");
+        sb.AppendLine();
+        sb.AppendLine("| Status | Candidate | Risk | Methods | Routes |");
+        sb.AppendLine("| --- | --- | --- | ---: | --- |");
+        foreach (var candidate in plan.Candidates.OrderBy(candidate => candidate.Name, StringComparer.OrdinalIgnoreCase))
+        {
+            var state = reviewState.TryGetValue(candidate.Id, out var item)
+                ? item
+                : new WorkflowReviewCandidateState();
+            var status = state.Pinned ? $"{state.Status}, pinned" : state.Status;
+            var routes = candidate.Routes.Count == 0 ? "-" : string.Join(", ", candidate.Routes.Select(route => $"`{route}`"));
+            sb.AppendLine($"| {status} | `{candidate.Id}` {EscapeMarkdownTable(candidate.Name)} | {EscapeMarkdownTable(candidate.Risk)} | {candidate.Methods.Count} | {routes} |");
+        }
+
+        foreach (var candidate in plan.Candidates.OrderBy(candidate => candidate.Name, StringComparer.OrdinalIgnoreCase))
+        {
+            var state = reviewState.TryGetValue(candidate.Id, out var item)
+                ? item
+                : new WorkflowReviewCandidateState();
+            sb.AppendLine();
+            sb.AppendLine($"## {candidate.Name}");
+            sb.AppendLine();
+            sb.AppendLine($"- Status: {state.Status}");
+            sb.AppendLine($"- Pinned: {state.Pinned.ToString().ToLowerInvariant()}");
+            sb.AppendLine($"- Candidate id: `{candidate.Id}`");
+            sb.AppendLine($"- Slug: `{candidate.Slug}`");
+            sb.AppendLine($"- Risk: {candidate.Risk}");
+            sb.AppendLine($"- Suggested capability class: `{candidate.CapabilityClassName}`");
+            sb.AppendLine($"- Required approvals: {string.Join(", ", BuildRequiredApprovals(candidate))}");
+            if (candidate.Routes.Count > 0)
+            {
+                sb.AppendLine($"- Routes: {string.Join(", ", candidate.Routes.Select(route => $"`{route}`"))}");
+            }
+            sb.AppendLine();
+            sb.AppendLine(candidate.Description);
+            sb.AppendLine();
+            sb.AppendLine("### Methods");
+            foreach (var method in candidate.Methods)
+            {
+                sb.AppendLine($"- `{method}`");
+            }
+
+            sb.AppendLine();
+            sb.AppendLine("### Evidence");
+            foreach (var evidence in candidate.Evidence.DefaultIfEmpty("static analysis evidence"))
+            {
+                sb.AppendLine($"- {evidence}");
+            }
+
+            var files = candidate.RetrievedEvidence
+                .Where(chunk => !string.IsNullOrWhiteSpace(chunk.FilePath))
+                .Select(chunk => NormalizeReviewPath(plan.SolutionRoot, chunk.FilePath))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+            if (files.Count > 0)
+            {
+                sb.AppendLine();
+                sb.AppendLine("### File References");
+                foreach (var file in files)
+                {
+                    sb.AppendLine($"- `{file}`");
+                }
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    private static string BuildReviewHtml(
+        WorkflowOnboardingPlan plan,
+        IReadOnlyDictionary<string, WorkflowReviewCandidateState> reviewState,
+        DateOnly today,
+        string? reviewedBy)
+    {
+        var candidates = plan.Candidates
+            .OrderBy(candidate => candidate.Name, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        var approvedCount = candidates.Count(candidate =>
+            reviewState.TryGetValue(candidate.Id, out var state) &&
+            state.Status.Equals("approved", StringComparison.OrdinalIgnoreCase));
+        var rejectedCount = candidates.Count(candidate =>
+            reviewState.TryGetValue(candidate.Id, out var state) &&
+            state.Status.Equals("rejected", StringComparison.OrdinalIgnoreCase));
+        var approvalRequiredCount = candidates.Count(candidate => candidate.RequiresApproval);
+
+        var sb = new StringBuilder();
+        sb.AppendLine("<!doctype html>");
+        sb.AppendLine("<html lang=\"en\">");
+        sb.AppendLine("<head>");
+        sb.AppendLine("  <meta charset=\"utf-8\">");
+        sb.AppendLine("  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">");
+        sb.AppendLine("  <title>AgentBlazor Workflow Onboarding Review</title>");
+        sb.AppendLine("  <style>");
+        sb.AppendLine("    :root { color-scheme: light; --ink: #172033; --muted: #5b6575; --line: #d9dee8; --surface: #f6f8fb; --accent: #0f766e; --warn: #a16207; --danger: #b42318; }");
+        sb.AppendLine("    * { box-sizing: border-box; }");
+        sb.AppendLine("    body { margin: 0; font-family: Arial, Helvetica, sans-serif; color: var(--ink); background: #ffffff; line-height: 1.45; }");
+        sb.AppendLine("    header { padding: 28px 32px 18px; border-bottom: 1px solid var(--line); background: var(--surface); }");
+        sb.AppendLine("    main { padding: 24px 32px 40px; max-width: 1180px; }");
+        sb.AppendLine("    h1 { margin: 0 0 10px; font-size: 28px; letter-spacing: 0; }");
+        sb.AppendLine("    h2 { margin: 30px 0 12px; font-size: 20px; letter-spacing: 0; }");
+        sb.AppendLine("    h3 { margin: 0 0 8px; font-size: 17px; letter-spacing: 0; }");
+        sb.AppendLine("    p { margin: 0 0 10px; }");
+        sb.AppendLine("    code { font-family: Consolas, Monaco, monospace; font-size: 0.95em; }");
+        sb.AppendLine("    table { width: 100%; border-collapse: collapse; margin-top: 12px; }");
+        sb.AppendLine("    th, td { padding: 10px 12px; border-bottom: 1px solid var(--line); text-align: left; vertical-align: top; }");
+        sb.AppendLine("    th { font-size: 12px; color: var(--muted); text-transform: uppercase; background: var(--surface); }");
+        sb.AppendLine("    ul { margin: 8px 0 0; padding-left: 20px; }");
+        sb.AppendLine("    .meta { color: var(--muted); }");
+        sb.AppendLine("    .metrics { display: grid; grid-template-columns: repeat(auto-fit, minmax(170px, 1fr)); gap: 12px; margin-top: 18px; max-width: 780px; }");
+        sb.AppendLine("    .metric { border: 1px solid var(--line); background: #fff; padding: 14px; border-radius: 6px; }");
+        sb.AppendLine("    .metric strong { display: block; font-size: 24px; }");
+        sb.AppendLine("    .candidate { border: 1px solid var(--line); border-radius: 6px; padding: 16px; margin: 14px 0; }");
+        sb.AppendLine("    .badge { display: inline-block; padding: 2px 8px; border-radius: 999px; font-size: 12px; font-weight: 700; background: #e8eef8; color: #24324a; }");
+        sb.AppendLine("    .approved { background: #dff3ed; color: var(--accent); }");
+        sb.AppendLine("    .rejected { background: #fee4e2; color: var(--danger); }");
+        sb.AppendLine("    .proposed { background: #fff3d6; color: var(--warn); }");
+        sb.AppendLine("    .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 14px; }");
+        sb.AppendLine("    @media (max-width: 720px) { header, main { padding-left: 18px; padding-right: 18px; } table { font-size: 14px; } th, td { padding: 8px; } }");
+        sb.AppendLine("  </style>");
+        sb.AppendLine("</head>");
+        sb.AppendLine("<body>");
+        sb.AppendLine("<header>");
+        sb.AppendLine("  <h1>AgentBlazor Workflow Onboarding Review</h1>");
+        sb.AppendLine($"  <p class=\"meta\">Generated {Html(today.ToString("yyyy-MM-dd"))} for {Html(plan.Model.AppName)} ({Html(plan.Model.BlazorHostProject)})</p>");
+        sb.AppendLine($"  <p class=\"meta\">Reviewed by: {Html(string.IsNullOrWhiteSpace(reviewedBy) ? "pending" : reviewedBy)}</p>");
+        sb.AppendLine("  <div class=\"metrics\">");
+        AppendMetric(sb, "Candidates", candidates.Count.ToString());
+        AppendMetric(sb, "Approved", approvedCount.ToString());
+        AppendMetric(sb, "Rejected", rejectedCount.ToString());
+        AppendMetric(sb, "Require Approval", approvalRequiredCount.ToString());
+        sb.AppendLine("  </div>");
+        sb.AppendLine("</header>");
+        sb.AppendLine("<main>");
+        sb.AppendLine("  <section>");
+        sb.AppendLine("    <h2>App Context</h2>");
+        sb.AppendLine($"    <p>{Html(plan.Model.Description)}</p>");
+        if (plan.Model.DesiredAgentWorkflows.Count > 0)
+        {
+            sb.AppendLine("    <p class=\"meta\">Developer-stated agent goals</p>");
+            AppendList(sb, plan.Model.DesiredAgentWorkflows);
+        }
+        if (plan.Model.Corpus.DomainTerms.Count > 0)
+        {
+            sb.AppendLine($"    <p class=\"meta\">Domain terms: {Html(string.Join(", ", plan.Model.Corpus.DomainTerms.Take(24)))}</p>");
+        }
+        sb.AppendLine("  </section>");
+        sb.AppendLine("  <section>");
+        sb.AppendLine("    <h2>Review Queue</h2>");
+        sb.AppendLine("    <table>");
+        sb.AppendLine("      <thead><tr><th>Status</th><th>Candidate</th><th>Risk</th><th>Methods</th><th>Routes</th></tr></thead>");
+        sb.AppendLine("      <tbody>");
+        foreach (var candidate in candidates)
+        {
+            var state = reviewState.TryGetValue(candidate.Id, out var item)
+                ? item
+                : new WorkflowReviewCandidateState();
+            var status = state.Pinned ? $"{state.Status}, pinned" : state.Status;
+            var routes = candidate.Routes.Count == 0 ? "-" : string.Join(", ", candidate.Routes);
+            sb.AppendLine("        <tr>");
+            sb.AppendLine($"          <td><span class=\"badge {HtmlAttribute(state.Status)}\">{Html(status)}</span></td>");
+            sb.AppendLine($"          <td><code>{Html(candidate.Id)}</code><br>{Html(candidate.Name)}</td>");
+            sb.AppendLine($"          <td>{Html(candidate.Risk)}</td>");
+            sb.AppendLine($"          <td>{candidate.Methods.Count}</td>");
+            sb.AppendLine($"          <td>{Html(routes)}</td>");
+            sb.AppendLine("        </tr>");
+        }
+        sb.AppendLine("      </tbody>");
+        sb.AppendLine("    </table>");
+        sb.AppendLine("  </section>");
+        sb.AppendLine("  <section>");
+        sb.AppendLine("    <h2>Evidence</h2>");
+        foreach (var candidate in candidates)
+        {
+            AppendCandidateHtml(sb, plan, reviewState, candidate);
+        }
+        sb.AppendLine("  </section>");
+        sb.AppendLine("</main>");
+        sb.AppendLine("</body>");
+        sb.AppendLine("</html>");
+        return sb.ToString();
+    }
+
+    private static void AppendMetric(StringBuilder sb, string label, string value)
+    {
+        sb.AppendLine("    <div class=\"metric\">");
+        sb.AppendLine($"      <strong>{Html(value)}</strong>");
+        sb.AppendLine($"      <span>{Html(label)}</span>");
+        sb.AppendLine("    </div>");
+    }
+
+    private static void AppendCandidateHtml(
+        StringBuilder sb,
+        WorkflowOnboardingPlan plan,
+        IReadOnlyDictionary<string, WorkflowReviewCandidateState> reviewState,
+        WorkflowOnboardingCandidate candidate)
+    {
+        var state = reviewState.TryGetValue(candidate.Id, out var item)
+            ? item
+            : new WorkflowReviewCandidateState();
+        sb.AppendLine("    <article class=\"candidate\">");
+        sb.AppendLine($"      <h3>{Html(candidate.Name)} <span class=\"badge {HtmlAttribute(state.Status)}\">{Html(state.Status)}</span></h3>");
+        sb.AppendLine($"      <p>{Html(candidate.Description)}</p>");
+        sb.AppendLine("      <div class=\"grid\">");
+        sb.AppendLine("        <div>");
+        sb.AppendLine("          <p class=\"meta\">Methods</p>");
+        AppendList(sb, candidate.Methods);
+        sb.AppendLine("        </div>");
+        sb.AppendLine("        <div>");
+        sb.AppendLine("          <p class=\"meta\">Required approvals</p>");
+        AppendList(sb, BuildRequiredApprovals(candidate));
+        sb.AppendLine("        </div>");
+        sb.AppendLine("      </div>");
+        if (candidate.Evidence.Count > 0)
+        {
+            sb.AppendLine("      <p class=\"meta\">Static evidence</p>");
+            AppendList(sb, candidate.Evidence);
+        }
+
+        var files = candidate.RetrievedEvidence
+            .Where(chunk => !string.IsNullOrWhiteSpace(chunk.FilePath))
+            .Select(chunk => NormalizeReviewPath(plan.SolutionRoot, chunk.FilePath))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        if (files.Count > 0)
+        {
+            sb.AppendLine("      <p class=\"meta\">File references</p>");
+            AppendList(sb, files);
+        }
+        sb.AppendLine("    </article>");
+    }
+
+    private static void AppendList(StringBuilder sb, IEnumerable<string> values)
+    {
+        sb.AppendLine("      <ul>");
+        foreach (var value in values)
+        {
+            sb.AppendLine($"        <li>{Html(value)}</li>");
+        }
+        sb.AppendLine("      </ul>");
+    }
+
+    private static string Html(string value)
+        => WebUtility.HtmlEncode(value);
+
+    private static string HtmlAttribute(string value)
+        => Html(WorkflowOnboardingPlanner.ToSlug(value));
+
+    private static IReadOnlyList<string> ReviewIdsByStatus(
+        IReadOnlyDictionary<string, WorkflowReviewCandidateState> reviewState,
+        string status)
+        => reviewState
+            .Where(pair => pair.Value.Status.Equals(status, StringComparison.OrdinalIgnoreCase))
+            .Select(pair => pair.Key)
+            .OrderBy(id => id, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+    private static string MarkdownValueOrPending(string? value)
+        => string.IsNullOrWhiteSpace(value) ? "_pending_" : value;
+
+    private static string NormalizeReviewPath(string solutionRoot, string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return path;
+        }
+
+        if (!Path.IsPathRooted(path))
+        {
+            return path.Replace(Path.DirectorySeparatorChar, '/');
+        }
+
+        var fullRoot = Path.GetFullPath(solutionRoot);
+        var fullPath = Path.GetFullPath(path);
+        if (!fullPath.StartsWith(fullRoot.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase))
+        {
+            return fullPath.Replace(Path.DirectorySeparatorChar, '/');
+        }
+
+        return Path.GetRelativePath(fullRoot, fullPath)
+            .Replace(Path.DirectorySeparatorChar, '/');
+    }
+
+    private static IReadOnlyDictionary<string, WorkflowReviewCandidateState> ResolveReviewState(
+        WorkflowOnboardingPlan plan,
+        IReadOnlyList<WorkflowOnboardingCandidate> selected,
+        WorkflowReviewDecisions decisions,
+        string reviewPath)
+    {
+        var existing = ReadExistingReviewState(reviewPath);
+        var approvedIds = selected
+            .Select(candidate => candidate.Id)
+            .Concat(decisions.ApprovedIds)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        return plan.Candidates.ToDictionary(
+            candidate => candidate.Id,
+            candidate =>
+            {
+                existing.TryGetValue(candidate.Id, out var current);
+                var status = current?.Status ?? "proposed";
+                var pinned = current?.Pinned ?? false;
+
+                if (approvedIds.Contains(candidate.Id) || approvedIds.Contains(candidate.Slug))
+                {
+                    status = "approved";
+                }
+                else if (decisions.RejectedIds.Contains(candidate.Id) || decisions.RejectedIds.Contains(candidate.Slug))
+                {
+                    status = "rejected";
+                }
+
+                if (decisions.PinnedIds.Contains(candidate.Id) || decisions.PinnedIds.Contains(candidate.Slug))
+                {
+                    pinned = true;
+                }
+                else if (decisions.UnpinnedIds.Contains(candidate.Id) || decisions.UnpinnedIds.Contains(candidate.Slug))
+                {
+                    pinned = false;
+                }
+
+                return new WorkflowReviewCandidateState
+                {
+                    Status = IsKnownReviewStatus(status) ? status : "proposed",
+                    Pinned = pinned
+                };
+            },
+            StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static Dictionary<string, WorkflowReviewCandidateState> ReadExistingReviewState(string reviewPath)
+    {
+        var result = new Dictionary<string, WorkflowReviewCandidateState>(StringComparer.OrdinalIgnoreCase);
+        if (!File.Exists(reviewPath))
+        {
+            return result;
+        }
+
+        using var document = JsonDocument.Parse(File.ReadAllText(reviewPath));
+        if (!document.RootElement.TryGetProperty("candidates", out var candidates) ||
+            candidates.ValueKind != JsonValueKind.Array)
+        {
+            return result;
+        }
+
+        foreach (var candidate in candidates.EnumerateArray())
+        {
+            var id = ReadString(candidate, "id");
+            if (string.IsNullOrWhiteSpace(id))
+            {
+                continue;
+            }
+
+            var status = ReadString(candidate, "status");
+            result[id] = new WorkflowReviewCandidateState
+            {
+                Status = IsKnownReviewStatus(status) ? status : "proposed",
+                Pinned = ReadBool(candidate, "pinned")
+            };
+        }
+
+        return result;
+    }
+
+    private static string? ResolveReviewedBy(string reviewPath, WorkflowReviewDecisions decisions)
+    {
+        if (!string.IsNullOrWhiteSpace(decisions.ReviewedBy))
+        {
+            return decisions.ReviewedBy;
+        }
+
+        return ReadExistingReviewedBy(reviewPath);
+    }
+
+    private static string? ReadExistingReviewedBy(string reviewPath)
+    {
+        if (!File.Exists(reviewPath))
+        {
+            return null;
+        }
+
+        using var document = JsonDocument.Parse(File.ReadAllText(reviewPath));
+        if (document.RootElement.TryGetProperty("reviewedBy", out var topLevelReviewer) &&
+            topLevelReviewer.ValueKind == JsonValueKind.String)
+        {
+            var value = topLevelReviewer.GetString();
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                return value;
+            }
+        }
+
+        if (document.RootElement.TryGetProperty("review", out var review) &&
+            review.ValueKind == JsonValueKind.Object &&
+            review.TryGetProperty("reviewedBy", out var reviewer) &&
+            reviewer.ValueKind == JsonValueKind.String)
+        {
+            var value = reviewer.GetString();
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                return value;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool IsKnownReviewStatus(string status)
+        => status.Equals("proposed", StringComparison.OrdinalIgnoreCase) ||
+            status.Equals("approved", StringComparison.OrdinalIgnoreCase) ||
+            status.Equals("rejected", StringComparison.OrdinalIgnoreCase);
+
+    private static string BuildIndexJson(IReadOnlyList<WorkflowOnboardingCandidate> selected)
+    {
+        var payload = new
+        {
+            schemaVersion = 1,
+            generatedBy = "agentblazor scaffold workflows",
+            skills = selected.Select(candidate => new
+            {
+                name = candidate.Slug,
+                displayName = candidate.Name,
+                description = candidate.Description,
+                category = "workflow",
+                risk = candidate.Risk,
+                platforms = new[] { "blazor" },
+                workflowIds = new[] { candidate.Id },
+                skillPath = $"{candidate.Slug}/SKILL.md"
+            }).ToList()
+        };
+
+        return JsonSerializer.Serialize(payload, JsonOptions) + Environment.NewLine;
+    }
+
+    private static IReadOnlyList<string> BuildRequiredApprovals(WorkflowOnboardingCandidate candidate)
+        => candidate.RequiresApproval
+            ? ["analysis artifacts", "skill files", "capability/workflow classes", "Program.cs/service wiring", "validation commands"]
+            : ["analysis artifacts", "skill files", "validation commands"];
+
+    private static string EscapeMarkdownTable(string value)
+        => value.Replace("|", "\\|", StringComparison.Ordinal);
+
+    private static string BuildMetadataJson(IReadOnlyList<WorkflowOnboardingCandidate> selected, DateOnly today, string metadataPath)
+    {
+        var existing = ReadExistingMetadata(metadataPath);
+        var payload = new
+        {
+            schemaVersion = 1,
+            generatedAt = $"{today:yyyy-MM-dd}",
+            curator = new
+            {
+                staleAfterDays = 30,
+                archiveAfterAdditionalDays = 60
+            },
+            skills = selected.Select(candidate => new
+            {
+                name = candidate.Slug,
+                workflowIds = new[] { candidate.Id },
+                pinned = existing.TryGetValue(candidate.Slug, out var item) && item.Pinned,
+                readCount = item?.ReadCount ?? 0,
+                executionCount = item?.ExecutionCount ?? 0,
+                lastRead = item?.LastRead,
+                lastExecuted = item?.LastExecuted,
+                lastReviewed = item?.LastReviewed ?? $"{today:yyyy-MM-dd}",
+                state = item?.State == "archived" ? "active" : item?.State ?? "active"
+            }).ToList()
+        };
+
+        return JsonSerializer.Serialize(payload, JsonOptions) + Environment.NewLine;
+    }
+
+    private static Dictionary<string, ExistingSkillMetadata> ReadExistingMetadata(string metadataPath)
+    {
+        var result = new Dictionary<string, ExistingSkillMetadata>(StringComparer.OrdinalIgnoreCase);
+        if (!File.Exists(metadataPath))
+        {
+            return result;
+        }
+
+        using var document = JsonDocument.Parse(File.ReadAllText(metadataPath));
+        if (!document.RootElement.TryGetProperty("skills", out var skills) ||
+            skills.ValueKind != JsonValueKind.Array)
+        {
+            return result;
+        }
+
+        foreach (var skill in skills.EnumerateArray())
+        {
+            var name = ReadString(skill, "name");
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                continue;
+            }
+
+            result[name] = new ExistingSkillMetadata
+            {
+                Pinned = ReadBool(skill, "pinned"),
+                ReadCount = ReadInt(skill, "readCount"),
+                ExecutionCount = ReadInt(skill, "executionCount"),
+                LastRead = ReadNullableString(skill, "lastRead"),
+                LastExecuted = ReadNullableString(skill, "lastExecuted"),
+                LastReviewed = ReadNullableString(skill, "lastReviewed"),
+                State = ReadNullableString(skill, "state")
+            };
+        }
+
+        return result;
+    }
+
+    private static string ReadString(JsonElement element, string name)
+        => element.TryGetProperty(name, out var property) && property.ValueKind == JsonValueKind.String
+            ? property.GetString() ?? string.Empty
+            : string.Empty;
+
+    private static string? ReadNullableString(JsonElement element, string name)
+        => element.TryGetProperty(name, out var property) && property.ValueKind == JsonValueKind.String
+            ? property.GetString()
+            : null;
+
+    private static bool ReadBool(JsonElement element, string name)
+        => element.TryGetProperty(name, out var property) && property.ValueKind == JsonValueKind.True;
+
+    private static int ReadInt(JsonElement element, string name)
+        => element.TryGetProperty(name, out var property) && property.TryGetInt32(out var value)
+            ? value
+            : 0;
+
+    private static string BuildSkill(WorkflowOnboardingCandidate candidate, DateOnly today)
+    {
+        var approvals = candidate.RequiresApproval
+            ? "[\"analysis artifacts\", \"skill files\", \"capability/workflow classes\", \"Program.cs/service wiring\", \"validation commands\"]"
+            : "[\"analysis artifacts\", \"skill files\", \"validation commands\"]";
+        var workflowIds = string.Join(", ", candidate.Methods.Select(method => $"\"{method}\""));
+        var sb = new StringBuilder();
+        sb.AppendLine("---");
+        sb.AppendLine($"name: {candidate.Slug}");
+        sb.AppendLine($"description: {EscapeYaml(candidate.Description)}");
+        sb.AppendLine("category: workflow");
+        sb.AppendLine($"risk: {EscapeYaml(candidate.Risk)}");
+        sb.AppendLine("platforms: [\"blazor\"]");
+        sb.AppendLine($"workflowIds: [\"{candidate.Id}\"]");
+        sb.AppendLine($"requiredApprovals: {approvals}");
+        sb.AppendLine("pinned: false");
+        sb.AppendLine($"lastReviewed: {today:yyyy-MM-dd}");
+        sb.AppendLine("---");
+        sb.AppendLine();
+        sb.AppendLine($"# {candidate.Name}");
+        sb.AppendLine();
+        sb.AppendLine(candidate.Description);
+        sb.AppendLine();
+        sb.AppendLine("## Allowed Workflow");
+        sb.AppendLine();
+        sb.AppendLine($"- Capability class: `{candidate.CapabilityClassName}`");
+        sb.AppendLine($"- Methods: {workflowIds}");
+        if (candidate.Routes.Count > 0)
+        {
+            sb.AppendLine($"- Routes: {string.Join(", ", candidate.Routes.Select(route => $"`{route}`"))}");
+        }
+
+        sb.AppendLine();
+        sb.AppendLine("## Evidence");
+        foreach (var evidence in candidate.Evidence.DefaultIfEmpty("static analysis evidence"))
+        {
+            sb.AppendLine($"- {evidence}");
+        }
+
+        sb.AppendLine();
+        sb.AppendLine("## Restrictions");
+        sb.AppendLine();
+        sb.AppendLine("- Use only the methods listed in this skill unless the developer approves a new workflow scope.");
+        sb.AppendLine("- Require approval before mutating state when `risk` is not `safe read-only`.");
+        sb.AppendLine("- Prefer `skill_view(name, file_path)` for deep evidence files instead of loading all references by default.");
+        return sb.ToString();
+    }
+
+    private static string BuildEvidenceReference(WorkflowOnboardingCandidate candidate)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"# Evidence for {candidate.Name}");
+        sb.AppendLine();
+        foreach (var chunk in candidate.RetrievedEvidence)
+        {
+            sb.AppendLine($"## {chunk.Title}");
+            sb.AppendLine();
+            sb.AppendLine($"- Kind: {chunk.Kind}");
+            if (!string.IsNullOrWhiteSpace(chunk.FilePath))
+            {
+                sb.AppendLine($"- File: `{chunk.FilePath}`");
+            }
+            if (chunk.RelatedRoutes.Count > 0)
+            {
+                sb.AppendLine($"- Routes: {string.Join(", ", chunk.RelatedRoutes.Select(route => $"`{route}`"))}");
+            }
+            sb.AppendLine();
+            sb.AppendLine(chunk.Text);
+            sb.AppendLine();
+        }
+
+        return sb.ToString();
+    }
+
+    private static bool IsInsideRoot(string root, string path)
+    {
+        var fullRoot = Path.GetFullPath(root).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) + Path.DirectorySeparatorChar;
+        var fullPath = Path.GetFullPath(path);
+        return fullPath.StartsWith(fullRoot, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string EscapeYaml(string value)
+        => "\"" + value.Replace("\\", "\\\\", StringComparison.Ordinal).Replace("\"", "\\\"", StringComparison.Ordinal) + "\"";
+}
+
+public sealed record WorkflowArtifactChange
+{
+    public string Path { get; init; } = "";
+
+    public WorkflowArtifactChangeKind ChangeKind { get; init; }
+
+    public string Summary { get; init; } = "";
+
+    public string OriginalContent { get; init; } = "";
+
+    public string UpdatedContent { get; init; } = "";
+}
+
+public enum WorkflowArtifactChangeKind
+{
+    Create,
+    Update
+}
+
+internal sealed record ExistingSkillMetadata
+{
+    public bool Pinned { get; init; }
+
+    public int ReadCount { get; init; }
+
+    public int ExecutionCount { get; init; }
+
+    public string? LastRead { get; init; }
+
+    public string? LastExecuted { get; init; }
+
+    public string? LastReviewed { get; init; }
+
+    public string? State { get; init; }
+}

--- a/src/AgentBlazor.Cli.Analysis/WorkflowSuggestions/WorkflowSuggestionPromptBuilder.cs
+++ b/src/AgentBlazor.Cli.Analysis/WorkflowSuggestions/WorkflowSuggestionPromptBuilder.cs
@@ -5,6 +5,18 @@ namespace AgentBlazor.Cli.Analysis.WorkflowSuggestions;
 
 public sealed class WorkflowSuggestionPromptBuilder
 {
+    private readonly IAnalysisRetrieval _retrieval;
+
+    public WorkflowSuggestionPromptBuilder()
+        : this(new LexicalAnalysisRetrieval())
+    {
+    }
+
+    public WorkflowSuggestionPromptBuilder(IAnalysisRetrieval retrieval)
+    {
+        _retrieval = retrieval;
+    }
+
     public string Build(ProjectModel model)
     {
         ArgumentNullException.ThrowIfNull(model);
@@ -60,10 +72,21 @@ public sealed class WorkflowSuggestionPromptBuilder
         sb.AppendLine("Static analysis summary:");
         sb.AppendLine($"Application: {model.AppName}");
         sb.AppendLine($"Host project: {model.BlazorHostProject}");
+        sb.AppendLine($"App description: {model.Description}");
+        if (model.DesiredAgentWorkflows.Count > 0)
+        {
+            sb.AppendLine("Developer-stated agent workflow goals:");
+            foreach (var goal in model.DesiredAgentWorkflows)
+            {
+                sb.AppendLine($"- {goal}");
+            }
+        }
+
         sb.AppendLine();
         AppendRoutes(sb, model);
         AppendConfirmedActions(sb, model);
         AppendWorkflowClusters(sb, model);
+        AppendRetrievedEvidence(sb, model);
         AppendServices(sb, model);
         return sb.ToString();
     }
@@ -83,6 +106,50 @@ public sealed class WorkflowSuggestionPromptBuilder
 
         sb.AppendLine();
     }
+
+    private void AppendRetrievedEvidence(StringBuilder sb, ProjectModel model)
+    {
+        if (model.Corpus.Chunks.Count == 0)
+        {
+            return;
+        }
+
+        var query = string.Join(
+            ' ',
+            model.WorkflowClusters.Select(cluster => cluster.Name)
+                .Concat(model.WorkflowClusters.SelectMany(cluster => cluster.DomainTerms))
+                .Concat(model.DesiredAgentWorkflows)
+                .Concat(model.Routes.Select(route => route.Template))
+                .Take(80));
+        if (string.IsNullOrWhiteSpace(query))
+        {
+            query = model.AppName;
+        }
+
+        var results = _retrieval.Search(model.Corpus, query, maxResults: 10);
+        if (results.Count == 0)
+        {
+            return;
+        }
+
+        sb.AppendLine("Retrieved evidence:");
+        foreach (var result in results)
+        {
+            var chunk = result.Chunk;
+            sb.AppendLine($"- [{chunk.Kind}] {chunk.Title}: {Truncate(chunk.Text, 260)}");
+            if (!string.IsNullOrWhiteSpace(chunk.FilePath))
+            {
+                sb.AppendLine($"  file={chunk.FilePath}");
+            }
+        }
+
+        sb.AppendLine();
+    }
+
+    private static string Truncate(string value, int maxLength)
+        => value.Length <= maxLength
+            ? value
+            : value[..maxLength].TrimEnd() + "...";
 
     private static void AppendConfirmedActions(StringBuilder sb, ProjectModel model)
     {

--- a/src/AgentBlazor.Cli/Commands/InitCommand.cs
+++ b/src/AgentBlazor.Cli/Commands/InitCommand.cs
@@ -24,6 +24,10 @@ public sealed class InitCommand : AsyncCommand<InitCommand.Settings>
         [Description("Short description of the application")]
         public string? Description { get; init; }
 
+        [CommandOption("--agent-goals <GOALS>")]
+        [Description("Comma- or semicolon-separated workflows the app agent should help users accomplish")]
+        public string? AgentGoals { get; init; }
+
         [CommandOption("-y|--non-interactive")]
         [Description("Skip interactive prompts and use defaults")]
         public bool NonInteractive { get; init; }
@@ -67,6 +71,8 @@ public sealed class InitCommand : AsyncCommand<InitCommand.Settings>
                     "A Blazor application");
             }
             description ??= "A Blazor application";
+            var desiredAgentWorkflows = ResolveAgentGoals(settings.AgentGoals, config?.DesiredAgentWorkflows, settings.NonInteractive);
+            var effectiveConfig = MergeConfig(config, desiredAgentWorkflows);
 
             // Build the model
             var warnings = new List<string>();
@@ -79,7 +85,7 @@ public sealed class InitCommand : AsyncCommand<InitCommand.Settings>
                 .Spinner(Spinner.Known.Dots)
                 .StartAsync("Analyzing project...", async ctx =>
                 {
-                    model = await modelBuilder.BuildModelAsync(path, hostProject, description, config);
+                    model = await modelBuilder.BuildModelAsync(path, hostProject, description, effectiveConfig);
 
                     // Write outputs
                     var outputDir = System.IO.Path.GetDirectoryName(path)!;
@@ -139,6 +145,7 @@ public sealed class InitCommand : AsyncCommand<InitCommand.Settings>
                 {
                     HostProject = model.BlazorHostProject,
                     Description = description,
+                    DesiredAgentWorkflows = desiredAgentWorkflows.Count == 0 ? null : desiredAgentWorkflows.ToList(),
                     WatchDebounceMs = 500,
                     AutoUpdateOnBuild = true
                 };
@@ -177,6 +184,72 @@ public sealed class InitCommand : AsyncCommand<InitCommand.Settings>
             }
             return 1;
         }
+    }
+
+    private static IReadOnlyList<string> ResolveAgentGoals(
+        string? explicitGoals,
+        IReadOnlyList<string>? configuredGoals,
+        bool nonInteractive)
+    {
+        var goals = ParseAgentGoals(explicitGoals);
+        if (goals.Count > 0)
+        {
+            return goals;
+        }
+
+        if (configuredGoals is { Count: > 0 })
+        {
+            return configuredGoals
+                .Where(goal => !string.IsNullOrWhiteSpace(goal))
+                .Select(goal => goal.Trim())
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        }
+
+        if (nonInteractive || Console.IsInputRedirected || Console.IsOutputRedirected)
+        {
+            return [];
+        }
+
+        var answer = AnsiConsole.Prompt(
+            new TextPrompt<string>("[yellow]What workflows should the app agent help users accomplish?[/] [grey](optional; comma-separated)[/]")
+                .AllowEmpty());
+        return ParseAgentGoals(answer);
+    }
+
+    private static IReadOnlyList<string> ParseAgentGoals(string? value)
+        => string.IsNullOrWhiteSpace(value)
+            ? []
+            : value
+                .Split([',', ';'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Where(goal => !string.IsNullOrWhiteSpace(goal))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+    private static AgentBlazorConfig? MergeConfig(
+        AgentBlazorConfig? config,
+        IReadOnlyList<string> desiredAgentWorkflows)
+    {
+        if (desiredAgentWorkflows.Count == 0)
+        {
+            return config;
+        }
+
+        return new AgentBlazorConfig
+        {
+            HostProject = config?.HostProject,
+            Description = config?.Description,
+            DesiredAgentWorkflows = desiredAgentWorkflows.ToList(),
+            WatchDebounceMs = config?.WatchDebounceMs,
+            AdditionalServiceSuffixes = config?.AdditionalServiceSuffixes,
+            AdditionalDomainVerbs = config?.AdditionalDomainVerbs,
+            ExcludeMethodPatterns = config?.ExcludeMethodPatterns,
+            ExcludeServicePatterns = config?.ExcludeServicePatterns,
+            ExcludeDirectories = config?.ExcludeDirectories,
+            AutoUpdateOnBuild = config?.AutoUpdateOnBuild,
+            AnalyzeProvider = config?.AnalyzeProvider,
+            AnalyzeModel = config?.AnalyzeModel
+        };
     }
 
     private static void RenderSetupSummary(

--- a/src/AgentBlazor.Cli/Commands/ScaffoldCommand.cs
+++ b/src/AgentBlazor.Cli/Commands/ScaffoldCommand.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using AgentBlazor.Cli.Analysis;
+using AgentBlazor.Cli.Analysis.Blazor;
 using AgentBlazor.Cli.Analysis.Models;
 using Spectre.Console;
 using Spectre.Console.Cli;
@@ -11,8 +12,12 @@ public sealed class ScaffoldCommand : AsyncCommand<ScaffoldCommand.Settings>
     public sealed class Settings : CommandSettings
     {
         [CommandArgument(0, "[path]")]
-        [Description("Path to solution (.sln/.slnx) or project (.csproj) file")]
+        [Description("Path to solution/project, or 'workflows' for workflow onboarding")]
         public string? Path { get; init; }
+
+        [CommandArgument(1, "[workflow-path]")]
+        [Description("Path to solution/project when using 'scaffold workflows'")]
+        public string? WorkflowPath { get; init; }
 
         [CommandOption("--host <PROJECT>")]
         [Description("Name of the Blazor host project (auto-detected if not specified)")]
@@ -38,6 +43,46 @@ public sealed class ScaffoldCommand : AsyncCommand<ScaffoldCommand.Settings>
         [Description("Scaffold provider registration: openai, azure-openai, or ollama")]
         public string? Provider { get; init; }
 
+        [CommandOption("--description <DESCRIPTION>")]
+        [Description("Short description of the application for workflow onboarding")]
+        public string? Description { get; init; }
+
+        [CommandOption("--agent-goals <GOALS>")]
+        [Description("Comma- or semicolon-separated workflows the app agent should help users accomplish")]
+        public string? AgentGoals { get; init; }
+
+        [CommandOption("--save-config")]
+        [Description("Save workflow onboarding intent to .agentblazorc")]
+        public bool SaveConfig { get; init; }
+
+        [CommandOption("--scan-scope <SCOPE>")]
+        [Description("Workflow analysis scan scope: references or solution")]
+        public string ScanScope { get; init; } = "references";
+
+        [CommandOption("--workflow <IDS>")]
+        [Description("Comma-separated workflow candidate ids or slugs to apply in non-interactive mode")]
+        public string? WorkflowIds { get; init; }
+
+        [CommandOption("--apply-approved")]
+        [Description("Apply workflows already marked approved in .agentblazor/workflow-onboarding.json")]
+        public bool ApplyApproved { get; init; }
+
+        [CommandOption("--reject <IDS>")]
+        [Description("Comma-separated workflow candidate ids or slugs to mark rejected in the review artifact")]
+        public string? RejectWorkflowIds { get; init; }
+
+        [CommandOption("--pin <IDS>")]
+        [Description("Comma-separated workflow candidate ids or slugs to pin in the review artifact")]
+        public string? PinWorkflowIds { get; init; }
+
+        [CommandOption("--unpin <IDS>")]
+        [Description("Comma-separated workflow candidate ids or slugs to unpin in the review artifact")]
+        public string? UnpinWorkflowIds { get; init; }
+
+        [CommandOption("--reviewed-by <NAME>")]
+        [Description("Reviewer identity to record in workflow onboarding review artifacts")]
+        public string? ReviewedBy { get; init; }
+
         [CommandOption("-y|--non-interactive")]
         [Description("Skip interactive prompts and use defaults")]
         public bool NonInteractive { get; init; }
@@ -47,6 +92,11 @@ public sealed class ScaffoldCommand : AsyncCommand<ScaffoldCommand.Settings>
     {
         try
         {
+            if (string.Equals(settings.Path, "workflows", StringComparison.OrdinalIgnoreCase))
+            {
+                return await ExecuteWorkflowScaffoldAsync(settings);
+            }
+
             var path = await CommandPathResolver.ResolvePathAsync(settings.Path, settings.NonInteractive);
             if (path is null)
             {
@@ -107,6 +157,404 @@ public sealed class ScaffoldCommand : AsyncCommand<ScaffoldCommand.Settings>
             }
 
             return 1;
+        }
+    }
+
+    private static async Task<int> ExecuteWorkflowScaffoldAsync(Settings settings)
+    {
+        var path = await CommandPathResolver.ResolvePathAsync(settings.WorkflowPath, settings.NonInteractive);
+        if (path is null)
+        {
+            AnsiConsole.MarkupLine("[red]No solution or project file found.[/]");
+            return 1;
+        }
+
+        var provider = ScaffoldProviders.ParseOrThrow(settings.Provider);
+        var scanScope = ParseScanScope(settings.ScanScope);
+        var solutionRoot = Path.GetDirectoryName(path)!;
+        var config = await AgentBlazorConfig.ReadAsync(solutionRoot);
+        var hostProject = settings.HostProject ?? config?.HostProject;
+        var description = ResolveDescription(settings.Description, config?.Description, settings.NonInteractive);
+        var desiredAgentWorkflows = ResolveAgentGoals(settings.AgentGoals, config?.DesiredAgentWorkflows, settings.NonInteractive);
+        var effectiveConfig = MergeConfig(config, description, desiredAgentWorkflows);
+
+        ScaffoldPlan baselinePlan = null!;
+        WorkflowOnboardingPlan workflowPlan = null!;
+        await AnsiConsole.Status()
+            .Spinner(Spinner.Known.Dots)
+            .StartAsync("Analyzing workflows...", async status =>
+            {
+                status.Status("Checking baseline install readiness...");
+                baselinePlan = await new ExistingAppScaffoldPlanner().PlanAsync(path, hostProject);
+                if (baselinePlan.IsBlocked)
+                {
+                    return;
+                }
+
+                status.Status("Building workflow analysis corpus...");
+                var analyzer = new BlazorProjectAnalyzer();
+                var analysis = await analyzer.AnalyzeAsync(
+                    path,
+                    baselinePlan.HostProjectName,
+                    description,
+                    effectiveConfig,
+                    includeReadiness: false,
+                    scanScope: scanScope);
+                workflowPlan = new WorkflowOnboardingPlanner().Plan(analysis.Model, solutionRoot);
+            });
+
+        if (settings.SaveConfig)
+        {
+            await effectiveConfig.WriteAsync(solutionRoot);
+            AnsiConsole.MarkupLine("[grey]Saved workflow onboarding intent to .agentblazorc[/]");
+        }
+
+        if (baselinePlan.IsBlocked)
+        {
+            RenderBlockedPlan(baselinePlan);
+            return 2;
+        }
+
+        var writer = new WorkflowOnboardingArtifactWriter();
+        var selected = SelectWorkflowCandidates(workflowPlan, settings, writer);
+        var reviewDecisions = BuildReviewDecisions(workflowPlan, selected, settings);
+        var hasReviewActions = HasReviewActions(settings);
+        if (settings.Approve &&
+            settings.ApplyApproved &&
+            selected.Count == 0 &&
+            string.IsNullOrWhiteSpace(settings.WorkflowIds))
+        {
+            AnsiConsole.MarkupLine("[red]No approved workflow candidates were found in .agentblazor/workflow-onboarding.json.[/]");
+            RenderWorkflowReport(workflowPlan, baselinePlan, provider, selected);
+            return 2;
+        }
+
+        if (settings.Approve &&
+            settings.NonInteractive &&
+            string.IsNullOrWhiteSpace(settings.WorkflowIds) &&
+            !settings.ApplyApproved &&
+            !hasReviewActions)
+        {
+            AnsiConsole.MarkupLine("[red]Non-interactive workflow scaffold requires --workflow <id-or-slug> with --approve.[/]");
+            RenderWorkflowReport(workflowPlan, baselinePlan, provider, selected);
+            return 2;
+        }
+
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var changes = writer.Preview(workflowPlan, selected, today, reviewDecisions);
+
+        if (!settings.Approve)
+        {
+            RenderWorkflowPreview(workflowPlan, baselinePlan, provider, selected, changes, settings.Diff);
+            return 0;
+        }
+
+        if (selected.Count == 0 && !hasReviewActions)
+        {
+            AnsiConsole.MarkupLine("[yellow]No workflow candidates selected; no artifacts were applied.[/]");
+            RenderWorkflowReport(workflowPlan, baselinePlan, provider, selected);
+            return 0;
+        }
+
+        reviewDecisions = reviewDecisions with
+        {
+            ReviewedBy = ResolveReviewedByForApply(settings, reviewDecisions)
+        };
+        changes = writer.Preview(workflowPlan, selected, today, reviewDecisions);
+        if (changes.Count == 0)
+        {
+            RenderWorkflowApplyResult(workflowPlan, baselinePlan, provider, selected, changes);
+            return 0;
+        }
+
+        if (settings.Diff && changes.Count > 0)
+        {
+            RenderWorkflowDiffs(changes);
+        }
+
+        var agentLoop = new AgentLoop(workflowPlan.SolutionRoot);
+        var proposal = agentLoop.ProposePatch(
+            "Apply AgentBlazor workflow onboarding artifacts",
+            changes.Select(ToAgentChange).ToList());
+        _ = agentLoop.ToPreview(proposal);
+        var applyResult = await agentLoop.ApplyApprovedPatchAsync(proposal.Id, reviewDecisions.ReviewedBy!);
+        var audit = await agentLoop.WriteAuditAsync(
+            "workflow-onboarding",
+            reviewDecisions.ReviewedBy!,
+            proposal,
+            applyResult,
+            DateTimeOffset.UtcNow,
+            BuildWorkflowAuditMetadata(selected, reviewDecisions));
+        RenderWorkflowApplyResult(workflowPlan, baselinePlan, provider, selected, changes, audit);
+        return 0;
+    }
+
+    private static IReadOnlyDictionary<string, IReadOnlyList<string>> BuildWorkflowAuditMetadata(
+        IReadOnlyList<WorkflowOnboardingCandidate> selected,
+        WorkflowReviewDecisions decisions)
+        => new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["selectedWorkflowIds"] = selected
+                .Select(candidate => candidate.Id)
+                .OrderBy(id => id, StringComparer.OrdinalIgnoreCase)
+                .ToList(),
+            ["approvedWorkflowIds"] = decisions.ApprovedIds
+                .OrderBy(id => id, StringComparer.OrdinalIgnoreCase)
+                .ToList(),
+            ["rejectedWorkflowIds"] = decisions.RejectedIds
+                .OrderBy(id => id, StringComparer.OrdinalIgnoreCase)
+                .ToList(),
+            ["pinnedWorkflowIds"] = decisions.PinnedIds
+                .OrderBy(id => id, StringComparer.OrdinalIgnoreCase)
+                .ToList(),
+            ["unpinnedWorkflowIds"] = decisions.UnpinnedIds
+                .OrderBy(id => id, StringComparer.OrdinalIgnoreCase)
+                .ToList()
+        };
+
+    private static AgentProposedFileChange ToAgentChange(WorkflowArtifactChange change)
+        => new()
+        {
+            Path = change.Path,
+            ChangeKind = change.ChangeKind == WorkflowArtifactChangeKind.Create
+                ? AgentPatchChangeKind.Create
+                : AgentPatchChangeKind.Update,
+            OriginalContent = change.OriginalContent,
+            UpdatedContent = change.UpdatedContent
+        };
+
+    private static string ResolveReviewedByForApply(Settings settings, WorkflowReviewDecisions decisions)
+    {
+        if (!string.IsNullOrWhiteSpace(decisions.ReviewedBy))
+        {
+            return decisions.ReviewedBy;
+        }
+
+        if (settings.NonInteractive || Console.IsInputRedirected || Console.IsOutputRedirected)
+        {
+            throw new InvalidOperationException("Workflow artifact application requires --reviewed-by <name> for the audit record.");
+        }
+
+        return AnsiConsole.Ask<string>("Reviewer identity for workflow artifact audit:");
+    }
+
+    private static IReadOnlyList<WorkflowOnboardingCandidate> SelectWorkflowCandidates(
+        WorkflowOnboardingPlan plan,
+        Settings settings,
+        WorkflowOnboardingArtifactWriter writer)
+    {
+        if (!string.IsNullOrWhiteSpace(settings.WorkflowIds) || settings.ApplyApproved)
+        {
+            var requested = ParseCandidateIds(settings.WorkflowIds);
+            if (settings.ApplyApproved)
+            {
+                requested.UnionWith(writer.ReadApprovedCandidateIds(plan.AgentBlazorDirectory));
+            }
+
+            var selected = plan.Candidates
+                .Where(candidate => requested.Contains(candidate.Id) || requested.Contains(candidate.Slug))
+                .ToList();
+            if (!string.IsNullOrWhiteSpace(settings.WorkflowIds))
+            {
+                var explicitIds = ParseCandidateIds(settings.WorkflowIds);
+                var missing = explicitIds
+                    .Where(id => selected.All(candidate =>
+                        !candidate.Id.Equals(id, StringComparison.OrdinalIgnoreCase) &&
+                        !candidate.Slug.Equals(id, StringComparison.OrdinalIgnoreCase)))
+                    .ToList();
+                if (missing.Count > 0)
+                {
+                    throw new InvalidOperationException($"Unknown workflow candidate(s): {string.Join(", ", missing)}");
+                }
+            }
+
+            return selected;
+        }
+
+        if (!settings.Approve || settings.NonInteractive || Console.IsInputRedirected || Console.IsOutputRedirected)
+        {
+            return [];
+        }
+
+        if (plan.Candidates.Count == 0)
+        {
+            return [];
+        }
+
+        return AnsiConsole.Prompt(
+            new MultiSelectionPrompt<WorkflowOnboardingCandidate>()
+                .Title("Select workflows to scaffold")
+                .NotRequired()
+                .UseConverter(candidate => $"{candidate.Name} [{candidate.Id}]")
+                .AddChoices(plan.Candidates));
+    }
+
+    private static WorkflowReviewDecisions BuildReviewDecisions(
+        WorkflowOnboardingPlan plan,
+        IReadOnlyList<WorkflowOnboardingCandidate> selected,
+        Settings settings)
+    {
+        var approvedIds = selected.Select(candidate => candidate.Id).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var rejectedIds = ParseCandidateIds(settings.RejectWorkflowIds);
+        var pinnedIds = ParseCandidateIds(settings.PinWorkflowIds);
+        var unpinnedIds = ParseCandidateIds(settings.UnpinWorkflowIds);
+        ValidateCandidateIds(plan, rejectedIds, "--reject");
+        ValidateCandidateIds(plan, pinnedIds, "--pin");
+        ValidateCandidateIds(plan, unpinnedIds, "--unpin");
+
+        var conflictingStatusIds = approvedIds
+            .Intersect(rejectedIds, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        if (conflictingStatusIds.Count > 0)
+        {
+            throw new InvalidOperationException($"Workflow candidates cannot be both approved and rejected: {string.Join(", ", conflictingStatusIds)}");
+        }
+
+        var conflictingPinIds = pinnedIds
+            .Intersect(unpinnedIds, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        if (conflictingPinIds.Count > 0)
+        {
+            throw new InvalidOperationException($"Workflow candidates cannot be both pinned and unpinned: {string.Join(", ", conflictingPinIds)}");
+        }
+
+        return new WorkflowReviewDecisions
+        {
+            ApprovedIds = approvedIds,
+            RejectedIds = rejectedIds,
+            PinnedIds = pinnedIds,
+            UnpinnedIds = unpinnedIds,
+            ReviewedBy = string.IsNullOrWhiteSpace(settings.ReviewedBy)
+                ? null
+                : settings.ReviewedBy.Trim()
+        };
+    }
+
+    private static bool HasReviewActions(Settings settings)
+        => !string.IsNullOrWhiteSpace(settings.RejectWorkflowIds) ||
+            !string.IsNullOrWhiteSpace(settings.PinWorkflowIds) ||
+            !string.IsNullOrWhiteSpace(settings.UnpinWorkflowIds);
+
+    private static HashSet<string> ParseCandidateIds(string? ids)
+        => string.IsNullOrWhiteSpace(ids)
+            ? new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            : ids.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+    private static void ValidateCandidateIds(
+        WorkflowOnboardingPlan plan,
+        HashSet<string> requestedIds,
+        string optionName)
+    {
+        if (requestedIds.Count == 0)
+        {
+            return;
+        }
+
+        var known = plan.Candidates
+            .SelectMany(candidate => new[] { candidate.Id, candidate.Slug })
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var missing = requestedIds
+            .Where(id => !known.Contains(id))
+            .ToList();
+        if (missing.Count > 0)
+        {
+            throw new InvalidOperationException($"Unknown workflow candidate(s) for {optionName}: {string.Join(", ", missing)}");
+        }
+    }
+
+    private static void RenderWorkflowReport(
+        WorkflowOnboardingPlan workflowPlan,
+        ScaffoldPlan baselinePlan,
+        ScaffoldProvider? provider,
+        IReadOnlyList<WorkflowOnboardingCandidate> selected)
+    {
+        AnsiConsole.Write(new Rule("[blue]AgentBlazor Workflow Onboarding[/]").RuleStyle("blue"));
+        AnsiConsole.MarkupLine($"[blue]Host:[/] {Markup.Escape(workflowPlan.Model.BlazorHostProject)}");
+        AnsiConsole.MarkupLine($"[blue]Workflow candidates:[/] {workflowPlan.Candidates.Count}");
+        AnsiConsole.MarkupLine($"[blue]Selected workflows:[/] {selected.Count}");
+        AnsiConsole.MarkupLine($"[blue]Baseline scaffold items:[/] {baselinePlan.Items.Count}");
+        if (provider is { } providerChoice)
+        {
+            AnsiConsole.MarkupLine($"[blue]Provider:[/] {Markup.Escape(providerChoice.ToDisplayName())}");
+        }
+    }
+
+    private static void RenderWorkflowPreview(
+        WorkflowOnboardingPlan workflowPlan,
+        ScaffoldPlan baselinePlan,
+        ScaffoldProvider? provider,
+        IReadOnlyList<WorkflowOnboardingCandidate> selected,
+        IReadOnlyList<WorkflowArtifactChange> changes,
+        bool showDiff)
+    {
+        RenderWorkflowReport(workflowPlan, baselinePlan, provider, selected);
+        AnsiConsole.WriteLine();
+        if (baselinePlan.Items.Count > 0)
+        {
+            AnsiConsole.MarkupLine("[yellow]Baseline wiring:[/] not applied by `scaffold workflows`; run baseline `agentblazor scaffold --approve` separately when desired.");
+        }
+
+        if (workflowPlan.Candidates.Count == 0)
+        {
+            AnsiConsole.MarkupLine("[green]No workflow candidates found.[/]");
+            return;
+        }
+
+        var table = new Table().RoundedBorder();
+        table.AddColumn("Candidate");
+        table.AddColumn("Risk");
+        table.AddColumn("Methods");
+        table.AddColumn("Evidence");
+        foreach (var candidate in workflowPlan.Candidates)
+        {
+            table.AddRow(
+                $"{Markup.Escape(candidate.Name)}\n[grey]{Markup.Escape(candidate.Id)}[/]",
+                Markup.Escape(candidate.Risk),
+                Markup.Escape(string.Join(", ", candidate.Methods.Take(5))),
+                Markup.Escape(string.Join("; ", candidate.Evidence.Take(2))));
+        }
+
+        AnsiConsole.Write(table);
+        AnsiConsole.WriteLine();
+        if (changes.Count > 0)
+        {
+            AnsiConsole.MarkupLine($"[yellow]Proposed workflow review/artifact changes:[/] {changes.Count}");
+            foreach (var change in changes)
+            {
+                AnsiConsole.MarkupLine($"{GetWorkflowChangeKindMarkup(change.ChangeKind)} {Markup.Escape(change.Path)} [grey]{Markup.Escape(change.Summary)}[/]");
+            }
+        }
+        if (selected.Count == 0)
+        {
+            AnsiConsole.MarkupLine("[grey]No workflows selected for SOUL/skill generation. Use --workflow <id-or-slug> --approve, or approve interactively.[/]");
+        }
+
+        if (showDiff && changes.Count > 0)
+        {
+            AnsiConsole.WriteLine();
+            RenderWorkflowDiffs(changes);
+        }
+    }
+
+    private static void RenderWorkflowApplyResult(
+        WorkflowOnboardingPlan workflowPlan,
+        ScaffoldPlan baselinePlan,
+        ScaffoldProvider? provider,
+        IReadOnlyList<WorkflowOnboardingCandidate> selected,
+        IReadOnlyList<WorkflowArtifactChange> changes,
+        AgentAuditRecord? audit = null)
+    {
+        RenderWorkflowReport(workflowPlan, baselinePlan, provider, selected);
+        AnsiConsole.WriteLine();
+        AnsiConsole.MarkupLine($"[green]Workflow artifacts applied:[/] {changes.Count}");
+        foreach (var change in changes)
+        {
+            AnsiConsole.MarkupLine($"{GetWorkflowChangeKindMarkup(change.ChangeKind)} {Markup.Escape(change.Path)} [grey]{Markup.Escape(change.Summary)}[/]");
+        }
+        if (audit is not null)
+        {
+            AnsiConsole.MarkupLine($"[grey]Audit:[/] {Markup.Escape(audit.Path)}");
         }
     }
 
@@ -366,6 +814,41 @@ public sealed class ScaffoldCommand : AsyncCommand<ScaffoldCommand.Settings>
         }
     }
 
+    private static void RenderWorkflowDiffs(IReadOnlyList<WorkflowArtifactChange> changes)
+    {
+        AnsiConsole.Write(new Rule("[blue]Workflow Artifact Diff[/]").RuleStyle("blue"));
+
+        foreach (var change in changes)
+        {
+            AnsiConsole.MarkupLine($"[blue]{Markup.Escape(change.Path)}[/] [grey]({change.ChangeKind})[/]");
+            foreach (var line in BuildDiffLines(change.OriginalContent, change.UpdatedContent))
+            {
+                switch (line.Kind)
+                {
+                    case DiffLineKind.Removed:
+                        AnsiConsole.MarkupLine($"[red]- {Markup.Escape(line.Text)}[/]");
+                        break;
+                    case DiffLineKind.Added:
+                        AnsiConsole.MarkupLine($"[green]+ {Markup.Escape(line.Text)}[/]");
+                        break;
+                    default:
+                        AnsiConsole.MarkupLine($"[grey]  {Markup.Escape(line.Text)}[/]");
+                        break;
+                }
+            }
+
+            AnsiConsole.WriteLine();
+        }
+    }
+
+    private static string GetWorkflowChangeKindMarkup(WorkflowArtifactChangeKind changeKind) =>
+        changeKind switch
+        {
+            WorkflowArtifactChangeKind.Create => "[green]CREATE[/]",
+            WorkflowArtifactChangeKind.Update => "[yellow]UPDATE[/]",
+            _ => "[grey]?[/]"
+        };
+
     private static IReadOnlyList<DiffLine> BuildDiffLines(string original, string updated)
     {
         var oldLines = NormalizeLines(original);
@@ -482,4 +965,91 @@ public sealed class ScaffoldCommand : AsyncCommand<ScaffoldCommand.Settings>
 
     private static string QuoteIfNeeded(string value)
         => value.Contains(' ', StringComparison.Ordinal) ? $"\"{value}\"" : value;
+
+    private static AnalysisScanScope ParseScanScope(string? value)
+        => value?.Trim().ToLowerInvariant() switch
+        {
+            null or "" or "references" or "reference" or "refs" => AnalysisScanScope.References,
+            "solution" or "all" => AnalysisScanScope.Solution,
+            _ => throw new InvalidOperationException(
+                $"Unsupported scan scope '{value}'. Use 'references' or 'solution'.")
+        };
+
+    private static string ResolveDescription(string? explicitDescription, string? configuredDescription, bool nonInteractive)
+    {
+        var description = explicitDescription ?? configuredDescription;
+        if (!string.IsNullOrWhiteSpace(description))
+        {
+            return description;
+        }
+
+        if (nonInteractive || Console.IsInputRedirected || Console.IsOutputRedirected)
+        {
+            return "A Blazor application";
+        }
+
+        return AnsiConsole.Ask(
+            "[yellow]Describe this app in 1-3 sentences. Include the domain, primary users, and work they do here:[/]",
+            "A Blazor application");
+    }
+
+    private static IReadOnlyList<string> ResolveAgentGoals(
+        string? explicitGoals,
+        IReadOnlyList<string>? configuredGoals,
+        bool nonInteractive)
+    {
+        var goals = ParseAgentGoals(explicitGoals);
+        if (goals.Count > 0)
+        {
+            return goals;
+        }
+
+        if (configuredGoals is { Count: > 0 })
+        {
+            return configuredGoals
+                .Where(goal => !string.IsNullOrWhiteSpace(goal))
+                .Select(goal => goal.Trim())
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        }
+
+        if (nonInteractive || Console.IsInputRedirected || Console.IsOutputRedirected)
+        {
+            return [];
+        }
+
+        var answer = AnsiConsole.Prompt(
+            new TextPrompt<string>("[yellow]What workflows should the app agent help users accomplish?[/] [grey](optional; comma-separated)[/]")
+                .AllowEmpty());
+        return ParseAgentGoals(answer);
+    }
+
+    private static IReadOnlyList<string> ParseAgentGoals(string? value)
+        => string.IsNullOrWhiteSpace(value)
+            ? []
+            : value
+                .Split([',', ';'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Where(goal => !string.IsNullOrWhiteSpace(goal))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+    private static AgentBlazorConfig MergeConfig(
+        AgentBlazorConfig? config,
+        string description,
+        IReadOnlyList<string> desiredAgentWorkflows)
+        => new()
+        {
+            HostProject = config?.HostProject,
+            Description = description,
+            DesiredAgentWorkflows = desiredAgentWorkflows.Count == 0 ? null : desiredAgentWorkflows.ToList(),
+            WatchDebounceMs = config?.WatchDebounceMs,
+            AdditionalServiceSuffixes = config?.AdditionalServiceSuffixes,
+            AdditionalDomainVerbs = config?.AdditionalDomainVerbs,
+            ExcludeMethodPatterns = config?.ExcludeMethodPatterns,
+            ExcludeServicePatterns = config?.ExcludeServicePatterns,
+            ExcludeDirectories = config?.ExcludeDirectories,
+            AutoUpdateOnBuild = config?.AutoUpdateOnBuild,
+            AnalyzeProvider = config?.AnalyzeProvider,
+            AnalyzeModel = config?.AnalyzeModel
+        };
 }

--- a/src/AgentBlazor.Cli/Commands/UpdateCommand.cs
+++ b/src/AgentBlazor.Cli/Commands/UpdateCommand.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Security.Cryptography;
+using System.Text.Json;
 using Spectre.Console;
 using Spectre.Console.Cli;
 using AgentBlazor.Cli.Analysis;
@@ -112,6 +113,7 @@ public sealed class UpdateCommand : AsyncCommand<UpdateCommand.Settings>
 
             await markdownGenerator.GenerateAsync(model, outputDir);
             await modelWriter.WriteStateAsync(model, outputDir);
+            var workflowArtifactCount = await RefreshWorkflowArtifactsIfPresentAsync(model, outputDir, settings.NonInteractive);
 
             // Report warnings
             if (!settings.Quiet && warnings.Count > 0)
@@ -133,6 +135,10 @@ public sealed class UpdateCommand : AsyncCommand<UpdateCommand.Settings>
                 AnsiConsole.WriteLine();
                 AnsiConsole.MarkupLine("[green]Updated.[/]");
                 AnsiConsole.MarkupLine($"[blue]Routes:[/] {model.Routes.Count}  [blue]Actions:[/] {model.Actions.Count(a => a.ExposureMode != ActionExposureMode.Ignored)}");
+                if (workflowArtifactCount > 0)
+                {
+                    AnsiConsole.MarkupLine($"[blue]Workflow artifacts refreshed:[/] {workflowArtifactCount}");
+                }
             }
 
             return 0;
@@ -171,6 +177,81 @@ public sealed class UpdateCommand : AsyncCommand<UpdateCommand.Settings>
             }
             return 1;
         }
+    }
+
+    private static async Task<int> RefreshWorkflowArtifactsIfPresentAsync(
+        ProjectModel model,
+        string outputDir,
+        bool nonInteractive)
+    {
+        var agentDir = Path.Combine(outputDir, ".agentblazor");
+        var soulPath = Path.Combine(agentDir, "SOUL.md");
+        var metadataPath = Path.Combine(agentDir, "skills", ".metadata.json");
+        if (!File.Exists(soulPath) && !File.Exists(metadataPath))
+        {
+            return 0;
+        }
+
+        var plan = new WorkflowOnboardingPlanner().Plan(model, outputDir);
+        var approvedIds = await ReadApprovedWorkflowIdsAsync(metadataPath);
+        var selected = approvedIds.Count == 0
+            ? plan.Candidates
+            : plan.Candidates
+                .Where(candidate => approvedIds.Contains(candidate.Id) || approvedIds.Contains(candidate.Slug))
+                .ToList();
+
+        if (selected.Count == 0 && nonInteractive)
+        {
+            return 0;
+        }
+
+        var changes = await new WorkflowOnboardingArtifactWriter().ApplyAsync(
+            plan,
+            selected,
+            DateOnly.FromDateTime(DateTime.UtcNow));
+        await new SkillCurator().CurateAsync(agentDir, DateOnly.FromDateTime(DateTime.UtcNow));
+        return changes.Count;
+    }
+
+    private static async Task<HashSet<string>> ReadApprovedWorkflowIdsAsync(string metadataPath)
+    {
+        var ids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (!File.Exists(metadataPath))
+        {
+            return ids;
+        }
+
+        using var document = JsonDocument.Parse(await File.ReadAllTextAsync(metadataPath));
+        if (!document.RootElement.TryGetProperty("skills", out var skills) ||
+            skills.ValueKind != JsonValueKind.Array)
+        {
+            return ids;
+        }
+
+        foreach (var skill in skills.EnumerateArray())
+        {
+            if (skill.TryGetProperty("name", out var name) && name.ValueKind == JsonValueKind.String)
+            {
+                ids.Add(name.GetString() ?? string.Empty);
+            }
+
+            if (!skill.TryGetProperty("workflowIds", out var workflowIds) ||
+                workflowIds.ValueKind != JsonValueKind.Array)
+            {
+                continue;
+            }
+
+            foreach (var workflowId in workflowIds.EnumerateArray())
+            {
+                if (workflowId.ValueKind == JsonValueKind.String)
+                {
+                    ids.Add(workflowId.GetString() ?? string.Empty);
+                }
+            }
+        }
+
+        ids.Remove(string.Empty);
+        return ids;
     }
 
     private static string? FindAgentBlazorDirectory()

--- a/src/AgentBlazor.Cli/PACKAGE_README.md
+++ b/src/AgentBlazor.Cli/PACKAGE_README.md
@@ -11,7 +11,7 @@ dotnet tool install --global AgentBlazor.Cli
 If you prefer a pinned install:
 
 ```bash
-dotnet tool install --global AgentBlazor.Cli --version 0.2.21
+dotnet tool install --global AgentBlazor.Cli --version 0.2.22
 ```
 
 Example:
@@ -21,6 +21,15 @@ agentblazor init ./MySolution.slnx --host MyBlazorApp
 agentblazor scaffold ./MySolution.slnx --host MyBlazorApp --provider openai --diff
 agentblazor scaffold ./MySolution.slnx --host MyBlazorApp --provider openai --approve
 ```
+
+Workflow onboarding preview:
+
+```bash
+agentblazor scaffold workflows ./MySolution.slnx --host MyBlazorApp --description "Inventory operations app" --agent-goals "prepare restock plans" --diff --non-interactive
+agentblazor scaffold workflows ./MySolution.slnx --host MyBlazorApp --workflow inventory-pipeline --reviewed-by "Asha Dev" --approve --non-interactive
+```
+
+`scaffold workflows` analyzes app routes, services, DI registrations, existing `[AgentCapability]` / `[AgentAction]` workflows, and multi-method process clusters. It writes review artifacts under `.agentblazor/workflow-onboarding.json`, `.agentblazor/workflow-onboarding.md`, and `.agentblazor/workflow-onboarding.html`. Approved workflows generate `.agentblazor/SOUL.md`, `.agentblazor/skills/index.json`, skill folders, references, metadata, and an audit record under `.agentblazor/audit/`.
 
 Read-only analysis:
 
@@ -62,6 +71,8 @@ Version `0.2.19` adds workflow-cluster context before LLM suggestion generation.
 
 Version `0.2.20` tightens clustered workflow analysis by preferring non-admin process clusters in the LLM prompt, validating cluster-backed suggestions against the whole pipeline instead of every method verb, and falling back to preferred static clusters when LLM suggestions are only sensitive or supporting surfaces.
 
+Version `0.2.22` adds the CLI V2 workflow onboarding path: `agentblazor scaffold workflows`, review artifacts, SOUL/skill generation, reviewer-gated approval, agent-loop patch application, audit output, and packaged V2 workflow smoke coverage.
+
 Version `0.2.21` is a corrective package release for `0.2.20`; it carries the same clustered workflow ranking fixes and ensures the packaged CLI executable reports the same version as the NuGet package.
 
 Reports put top workflow recommendations and install blockers before the detailed inventory, show workflow clusters before LLM suggestions, separate preferred process clusters from sensitive/supporting clusters in the prompt, filter helper/framework noise, classify remaining services by likely agent fit, show AgentBlazor action adoption, and call out `RequiresApproval = true` guidance for workflow suggestions that reference mutating methods.
@@ -72,6 +83,7 @@ Docs:
 
 - Repository: https://github.com/ashpeterson/AgentBlazor
 - Advanced CLI guide: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/advanced/cli.md
+- 0.2.22 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.22.md
 - 0.2.21 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.21.md
 - 0.2.20 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.20.md
 - 0.2.19 release notes: https://github.com/ashpeterson/AgentBlazor/blob/master/docs/releases/0.2.19.md

--- a/src/AgentBlazor.Cli/Program.cs
+++ b/src/AgentBlazor.Cli/Program.cs
@@ -7,7 +7,7 @@ var version = typeof(ScaffoldCommand).Assembly
     .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
     ?.InformationalVersion
     ?? typeof(ScaffoldCommand).Assembly.GetName().Version?.ToString()
-    ?? "0.2.21";
+    ?? "0.2.22";
 version = version.Split('+', 2)[0];
 
 app.Configure(config =>
@@ -19,7 +19,8 @@ app.Configure(config =>
         .WithDescription("Initialize AgentBlazor for an existing Blazor app and show the next installer steps")
         .WithExample("init")
         .WithExample("init", "./MySolution.sln")
-        .WithExample("init", "--description", "My app description");
+        .WithExample("init", "--description", "My app description")
+        .WithExample("init", "--description", "Inventory operations app", "--agent-goals", "approve supplier transfers, prepare restock plans", "--save-config");
 
     config.AddCommand<AnalyzeCommand>("analyze")
         .WithDescription("Analyze an existing Blazor app and write a read-only markdown report")
@@ -48,11 +49,15 @@ app.Configure(config =>
         .WithExample("validate", "./MySolution.slnx", "--host", "MyBlazorApp");
 
     config.AddCommand<ScaffoldCommand>("scaffold")
-        .WithDescription("Preview the baseline AgentBlazor install edits for an existing Blazor app")
+        .WithDescription("Preview baseline AgentBlazor install edits or V2 workflow onboarding artifacts")
         .WithExample("scaffold")
         .WithExample("scaffold", "./MySolution.slnx", "--host", "MyBlazorApp")
         .WithExample("scaffold", "./MySolution.slnx", "--host", "MyBlazorApp", "--provider", "openai", "--diff")
-        .WithExample("scaffold", "./MySolution.slnx", "--host", "MyBlazorApp", "--provider", "openai", "--approve");
+        .WithExample("scaffold", "./MySolution.slnx", "--host", "MyBlazorApp", "--provider", "openai", "--approve")
+        .WithExample("scaffold", "workflows", "./MySolution.slnx", "--host", "MyBlazorApp", "--provider", "openai", "--diff")
+        .WithExample("scaffold", "workflows", "./MySolution.slnx", "--description", "Inventory operations app", "--agent-goals", "approve supplier transfers", "--save-config")
+        .WithExample("scaffold", "workflows", "./MySolution.slnx", "--reject", "low-value-workflow", "--pin", "inventory-approval", "--reviewed-by", "Asha Dev", "--approve", "--non-interactive")
+        .WithExample("scaffold", "workflows", "./MySolution.slnx", "--apply-approved", "--approve", "--non-interactive");
 });
 
 return await app.RunAsync(args);

--- a/src/AgentBlazor.Cli/README.md
+++ b/src/AgentBlazor.Cli/README.md
@@ -42,6 +42,8 @@ Version `0.2.20` tightens clustered workflow analysis by preferring non-admin pr
 
 Version `0.2.21` is a corrective package release for `0.2.20`; it carries the same clustered workflow ranking fixes and ensures the packaged CLI executable reports the same version as the NuGet package.
 
+Version `0.2.22` adds the CLI V2 workflow onboarding path through `agentblazor scaffold workflows`, including review artifacts, SOUL/skill generation, reviewer-gated approval, agent-loop patch application, audit output, and packaged V2 workflow smoke coverage.
+
 Current reports put top workflow recommendations and install blockers before the detailed inventory. Workflow clusters are shown before LLM suggestions, preferred process clusters are separated from sensitive/supporting clusters in the prompt, and the service inventory is classified by agent fit so data-access, admin/sensitive, integration, and workflow surfaces are easier to review without treating every public service as an equal first action candidate.
 
 See:

--- a/tests/AgentBlazor.Cli.Analysis.Tests/AgentLoopTests.cs
+++ b/tests/AgentBlazor.Cli.Analysis.Tests/AgentLoopTests.cs
@@ -1,0 +1,182 @@
+namespace AgentBlazor.Cli.Analysis.Tests;
+
+public sealed class AgentLoopTests
+{
+    [Fact]
+    public async Task ReadFileAsync_ReadsOnlyInsideSolutionRoot()
+    {
+        var root = CreateTempDirectory();
+        try
+        {
+            var filePath = Path.Combine(root, "Program.cs");
+            await File.WriteAllTextAsync(filePath, "Console.WriteLine(\"hello\");");
+
+            var loop = new AgentLoop(root);
+            var read = await loop.ReadFileAsync("Program.cs");
+
+            Assert.Equal("Program.cs", read.RelativePath);
+            Assert.Contains("hello", read.Content);
+            await Assert.ThrowsAsync<InvalidOperationException>(() => loop.ReadFileAsync("../outside.txt"));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task ProposePatch_RendersPreviewAndDoesNotWriteBeforeApproval()
+    {
+        var root = CreateTempDirectory();
+        try
+        {
+            var filePath = Path.Combine(root, "Services", "Orders.cs");
+            Directory.CreateDirectory(Path.GetDirectoryName(filePath)!);
+            await File.WriteAllTextAsync(filePath, "old");
+
+            var loop = new AgentLoop(root);
+            var proposal = loop.ProposePatch(
+                "Update order workflow",
+                [
+                    new AgentProposedFileChange
+                    {
+                        Path = "Services/Orders.cs",
+                        OriginalContent = "old",
+                        UpdatedContent = "new"
+                    }
+                ]);
+
+            var diff = loop.RenderDiff(proposal);
+            var preview = loop.ToPreview(proposal);
+
+            Assert.Equal("old", await File.ReadAllTextAsync(filePath));
+            Assert.Contains("--- Services/Orders.cs", diff);
+            Assert.Contains("-old", diff);
+            Assert.Contains("+new", diff);
+            var change = Assert.Single(preview.Changes);
+            Assert.Equal(filePath, change.Path);
+            Assert.Equal("Update order workflow", change.Summary);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task ApplyApprovedPatchAsync_WritesOnlyAfterApprovalAndRecordsTranscript()
+    {
+        var root = CreateTempDirectory();
+        try
+        {
+            var loop = new AgentLoop(root);
+            var proposal = loop.ProposePatch(
+                "Create workflow notes",
+                [
+                    new AgentProposedFileChange
+                    {
+                        Path = ".agentblazor/notes.md",
+                        UpdatedContent = "# Notes"
+                    }
+                ]);
+
+            await Assert.ThrowsAsync<ArgumentException>(() =>
+                loop.ApplyApprovedPatchAsync(proposal.Id, ""));
+
+            var result = await loop.ApplyApprovedPatchAsync(proposal.Id, "Riley Reviewer");
+
+            Assert.Equal("Riley Reviewer", result.ApprovedBy);
+            Assert.Equal("# Notes", await File.ReadAllTextAsync(Path.Combine(root, ".agentblazor", "notes.md")));
+            Assert.Contains(loop.Transcript, item => item.Tool == "propose_patch");
+            Assert.Contains(loop.Transcript, item => item.Tool == "apply_approved_patch");
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task WriteAuditAsync_WritesRelativeAuditRecord()
+    {
+        var root = CreateTempDirectory();
+        try
+        {
+            var loop = new AgentLoop(root);
+            var proposal = loop.ProposePatch(
+                "Create workflow notes",
+                [
+                    new AgentProposedFileChange
+                    {
+                        Path = ".agentblazor/notes.md",
+                        UpdatedContent = "# Notes"
+                    }
+                ]);
+            _ = loop.ToPreview(proposal);
+            var result = await loop.ApplyApprovedPatchAsync(proposal.Id, "Riley Reviewer");
+
+            var audit = await loop.WriteAuditAsync(
+                "workflow-onboarding",
+                "Riley Reviewer",
+                proposal,
+                result,
+                new DateTimeOffset(2026, 6, 18, 12, 0, 0, TimeSpan.Zero));
+
+            Assert.Equal(".agentblazor/audit/workflow-onboarding-20260618120000.json", audit.Path);
+            var auditJson = await File.ReadAllTextAsync(Path.Combine(root, audit.Path));
+            Assert.Contains("\"kind\": \"workflow-onboarding\"", auditJson);
+            Assert.Contains("\"reviewedBy\": \"Riley Reviewer\"", auditJson);
+            Assert.Contains("\"proposedFiles\"", auditJson);
+            Assert.Contains(".agentblazor/notes.md", auditJson);
+            Assert.Contains("apply_approved_patch", auditJson);
+            Assert.DoesNotContain(root, auditJson);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task ProposePatch_RejectsOutsideRootAndStaleOriginalContent()
+    {
+        var root = CreateTempDirectory();
+        try
+        {
+            await File.WriteAllTextAsync(Path.Combine(root, "existing.txt"), "current");
+            var loop = new AgentLoop(root);
+
+            Assert.Throws<InvalidOperationException>(() => loop.ProposePatch(
+                "Outside root",
+                [
+                    new AgentProposedFileChange
+                    {
+                        Path = "../outside.txt",
+                        UpdatedContent = "bad"
+                    }
+                ]));
+
+            Assert.Throws<InvalidOperationException>(() => loop.ProposePatch(
+                "Stale patch",
+                [
+                    new AgentProposedFileChange
+                    {
+                        Path = "existing.txt",
+                        OriginalContent = "old",
+                        UpdatedContent = "new"
+                    }
+                ]));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    private static string CreateTempDirectory()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"agentblazor-agent-loop-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(path);
+        return path;
+    }
+}

--- a/tests/AgentBlazor.Cli.Analysis.Tests/WorkflowOnboardingTests.cs
+++ b/tests/AgentBlazor.Cli.Analysis.Tests/WorkflowOnboardingTests.cs
@@ -1,0 +1,302 @@
+using System.Text.Json;
+using AgentBlazor.Cli.Analysis.Models;
+
+namespace AgentBlazor.Cli.Analysis.Tests;
+
+public sealed class WorkflowOnboardingTests
+{
+    [Fact]
+    public void CorpusBuilder_CreatesRetrievableWorkflowEvidence()
+    {
+        var model = CreateWorkflowModel();
+        var corpus = new AnalysisCorpusBuilder().Build(model);
+        var results = new LexicalAnalysisRetrieval().Search(corpus, "revision promote package", maxResults: 3);
+
+        Assert.Contains(corpus.Chunks, chunk => chunk.Kind == AnalysisCorpusChunkKind.WorkflowCluster);
+        Assert.Contains(results, result => result.Chunk.Title == "Revision Submission Pipeline");
+        Assert.Contains("RevisionSubmissionService.PromoteAsync", corpus.Chunks.SelectMany(chunk => chunk.RelatedMethods));
+    }
+
+    [Fact]
+    public void ArtifactWriter_GeneratesDeterministicSoulAndSkillFiles()
+    {
+        var root = CreateTempDirectory();
+        try
+        {
+            var model = CreateWorkflowModel() with
+            {
+                Corpus = new AnalysisCorpusBuilder().Build(CreateWorkflowModel())
+            };
+            var plan = new WorkflowOnboardingPlanner().Plan(model, root);
+            var selected = Assert.Single(plan.Candidates);
+            var writer = new WorkflowOnboardingArtifactWriter();
+            var first = writer.Preview(plan, [selected], new DateOnly(2026, 6, 12));
+            var second = writer.Preview(plan, [selected], new DateOnly(2026, 6, 12));
+
+            Assert.Equal(
+                first.Select(change => (change.Path, change.UpdatedContent)),
+                second.Select(change => (change.Path, change.UpdatedContent)));
+            Assert.Contains(first, change => change.Path.EndsWith(Path.Combine(".agentblazor", "SOUL.md"), StringComparison.Ordinal));
+            Assert.Contains("help release managers promote revisions", first.Single(change => change.Path.EndsWith("SOUL.md", StringComparison.Ordinal)).UpdatedContent);
+            Assert.Contains(first, change => change.Path.EndsWith(Path.Combine(".agentblazor", "workflow-onboarding.json"), StringComparison.Ordinal));
+            Assert.Contains(first, change => change.Path.EndsWith(Path.Combine(".agentblazor", "workflow-onboarding.md"), StringComparison.Ordinal));
+            Assert.Contains(first, change => change.Path.EndsWith(Path.Combine(".agentblazor", "workflow-onboarding.html"), StringComparison.Ordinal));
+            Assert.Contains("\"status\": \"approved\"", first.Single(change => change.Path.EndsWith("workflow-onboarding.json", StringComparison.Ordinal)).UpdatedContent);
+            Assert.Contains("AgentBlazor Workflow Onboarding Review", first.Single(change => change.Path.EndsWith("workflow-onboarding.html", StringComparison.Ordinal)).UpdatedContent);
+            Assert.Contains(first, change => change.Path.EndsWith(Path.Combine("skills", selected.Slug, "SKILL.md"), StringComparison.Ordinal));
+            Assert.Contains("requiredApprovals", first.Single(change => change.Path.EndsWith("SKILL.md", StringComparison.Ordinal)).UpdatedContent);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ArtifactWriter_WithNoSelectedWorkflow_GeneratesOnlyReviewArtifacts()
+    {
+        var root = CreateTempDirectory();
+        try
+        {
+            var model = CreateWorkflowModel();
+            var plan = new WorkflowOnboardingPlanner().Plan(model, root);
+            var changes = new WorkflowOnboardingArtifactWriter()
+                .Preview(plan, [], new DateOnly(2026, 6, 12));
+
+            Assert.Equal(3, changes.Count);
+            Assert.Contains(changes, change => change.Path.EndsWith(Path.Combine(".agentblazor", "workflow-onboarding.json"), StringComparison.Ordinal));
+            Assert.Contains(changes, change => change.Path.EndsWith(Path.Combine(".agentblazor", "workflow-onboarding.md"), StringComparison.Ordinal));
+            Assert.Contains(changes, change => change.Path.EndsWith(Path.Combine(".agentblazor", "workflow-onboarding.html"), StringComparison.Ordinal));
+            Assert.Contains("\"status\": \"proposed\"", changes.Single(change => change.Path.EndsWith("workflow-onboarding.json", StringComparison.Ordinal)).UpdatedContent);
+            Assert.Contains("Require Approval", changes.Single(change => change.Path.EndsWith("workflow-onboarding.html", StringComparison.Ordinal)).UpdatedContent);
+            Assert.DoesNotContain(changes, change => change.Path.EndsWith("SOUL.md", StringComparison.Ordinal));
+            Assert.DoesNotContain(changes, change => change.Path.EndsWith("SKILL.md", StringComparison.Ordinal));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ArtifactWriter_PreservesAndAppliesReviewDecisions()
+    {
+        var root = CreateTempDirectory();
+        try
+        {
+            var model = CreateWorkflowModel();
+            var plan = new WorkflowOnboardingPlanner().Plan(model, root);
+            var writer = new WorkflowOnboardingArtifactWriter();
+            var decisions = new WorkflowReviewDecisions
+            {
+                RejectedIds = new HashSet<string>(["revision-submission-pipeline"], StringComparer.OrdinalIgnoreCase),
+                PinnedIds = new HashSet<string>(["revision-submission-pipeline"], StringComparer.OrdinalIgnoreCase),
+                ReviewedBy = "Riley Reviewer"
+            };
+
+            var changes = writer.Preview(plan, [], new DateOnly(2026, 6, 12), decisions);
+            var review = changes.Single(change => change.Path.EndsWith("workflow-onboarding.json", StringComparison.Ordinal)).UpdatedContent;
+
+            Assert.Contains("\"reviewedBy\": \"Riley Reviewer\"", review);
+            Assert.Contains("\"rejectedCandidateIds\"", review);
+            Assert.Contains("\"status\": \"rejected\"", review);
+            Assert.Contains("\"pinned\": true", review);
+            Assert.Contains("Reviewed by: Riley Reviewer", changes.Single(change => change.Path.EndsWith("workflow-onboarding.md", StringComparison.Ordinal)).UpdatedContent);
+            Assert.Contains("Reviewed by: Riley Reviewer", changes.Single(change => change.Path.EndsWith("workflow-onboarding.html", StringComparison.Ordinal)).UpdatedContent);
+            Assert.Contains("rejected, pinned", changes.Single(change => change.Path.EndsWith("workflow-onboarding.html", StringComparison.Ordinal)).UpdatedContent);
+            Assert.DoesNotContain(changes, change => change.Path.EndsWith("SOUL.md", StringComparison.Ordinal));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task SkillViewStore_LoadsIndexSkillAndReferenceWithinSkillRoot()
+    {
+        var root = CreateTempDirectory();
+        try
+        {
+            var model = CreateWorkflowModel() with
+            {
+                Corpus = new AnalysisCorpusBuilder().Build(CreateWorkflowModel())
+            };
+            var plan = new WorkflowOnboardingPlanner().Plan(model, root);
+            var selected = Assert.Single(plan.Candidates);
+            await new WorkflowOnboardingArtifactWriter().ApplyAsync(plan, [selected], new DateOnly(2026, 6, 12));
+
+            var store = new SkillViewStore();
+            var index = await store.ViewAsync(Path.Combine(root, ".agentblazor"));
+            var skill = await store.ViewAsync(Path.Combine(root, ".agentblazor"), selected.Slug);
+            var reference = await store.ViewAsync(Path.Combine(root, ".agentblazor"), selected.Slug, "references/evidence.md");
+
+            Assert.Contains(selected.Slug, index);
+            Assert.Contains($"# {selected.Name}", skill);
+            Assert.Contains("Evidence for", reference);
+            await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                store.ViewAsync(Path.Combine(root, ".agentblazor"), selected.Slug, "../index.json"));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task SkillCurator_MarksStalePreservesPinnedAndArchivesEligibleSkills()
+    {
+        var root = CreateTempDirectory();
+        try
+        {
+            var skillsDir = Path.Combine(root, ".agentblazor", "skills");
+            Directory.CreateDirectory(Path.Combine(skillsDir, "stale-skill"));
+            Directory.CreateDirectory(Path.Combine(skillsDir, "pinned-skill"));
+            Directory.CreateDirectory(Path.Combine(skillsDir, "archive-skill"));
+            await File.WriteAllTextAsync(Path.Combine(skillsDir, ".metadata.json"), """
+            {
+              "schemaVersion": 1,
+              "skills": [
+                { "name": "stale-skill", "pinned": false, "readCount": 0, "executionCount": 0, "lastReviewed": "2026-05-01", "state": "active" },
+                { "name": "pinned-skill", "pinned": true, "readCount": 0, "executionCount": 0, "lastReviewed": "2026-02-01", "state": "active" },
+                { "name": "archive-skill", "pinned": false, "readCount": 0, "executionCount": 0, "lastReviewed": "2026-02-01", "state": "stale" }
+              ]
+            }
+            """);
+
+            var result = await new SkillCurator().CurateAsync(Path.Combine(root, ".agentblazor"), new DateOnly(2026, 6, 12));
+
+            Assert.Contains("stale-skill", result.MarkedStale);
+            Assert.DoesNotContain("pinned-skill", result.Archived);
+            Assert.Contains("archive-skill", result.Archived);
+            Assert.True(Directory.Exists(Path.Combine(skillsDir, ".archive", "archive-skill")));
+
+            using var metadata = JsonDocument.Parse(await File.ReadAllTextAsync(Path.Combine(skillsDir, ".metadata.json")));
+            var pinned = metadata.RootElement.GetProperty("skills").EnumerateArray()
+                .Single(skill => skill.GetProperty("name").GetString() == "pinned-skill");
+            Assert.Equal("active", pinned.GetProperty("state").GetString());
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    private static ProjectModel CreateWorkflowModel()
+    {
+        var cluster = new WorkflowClusterModel
+        {
+            Id = "revision-submission-pipeline",
+            Name = "Revision Submission Pipeline",
+            SourceService = "RevisionSubmissionService",
+            FilePath = "Services/RevisionSubmissionService.cs",
+            Summary = "Revision submission appears to be a package lifecycle.",
+            Risk = "approval required",
+            RequiresApproval = true,
+            Evidence = ["same service contains 4 lifecycle methods"],
+            RouteHints = ["/revisions"],
+            DomainTerms = ["Revision", "Submission"],
+            RelatedServices = ["RevisionSubmissionService"],
+            Methods =
+            [
+                CreateClusterMethod("GeneratePackageAsync", "generate"),
+                CreateClusterMethod("SubmitAsync", "submit"),
+                CreateClusterMethod("CheckStatusAsync", "status"),
+                CreateClusterMethod("PromoteAsync", "promote")
+            ]
+        };
+
+        var model = new ProjectModel
+        {
+            AppName = "RevisionApp",
+            Description = "Revision workflow app",
+            DesiredAgentWorkflows = ["help release managers promote revisions"],
+            BlazorHostProject = "RevisionApp",
+            Routes =
+            [
+                new RouteModel
+                {
+                    Id = "revisions",
+                    Template = "/revisions",
+                    ComponentName = "RevisionPage",
+                    ComponentFile = "Pages/Revisions.razor"
+                }
+            ],
+            Pages =
+            [
+                new PageModel
+                {
+                    Id = "revisions",
+                    Route = "/revisions",
+                    ComponentName = "RevisionPage",
+                    FilePath = "Pages/Revisions.razor",
+                    InjectedServices = ["RevisionSubmissionService"]
+                }
+            ],
+            Services =
+            [
+                new ServiceModel
+                {
+                    TypeName = "RevisionSubmissionService",
+                    FilePath = "Services/RevisionSubmissionService.cs",
+                    Methods =
+                    [
+                        CreateMethod("GeneratePackageAsync"),
+                        CreateMethod("SubmitAsync"),
+                        CreateMethod("CheckStatusAsync"),
+                        CreateMethod("PromoteAsync")
+                    ]
+                }
+            ],
+            Actions =
+            [
+                CreateAction("GeneratePackageAsync", true),
+                CreateAction("SubmitAsync", true),
+                CreateAction("CheckStatusAsync", false),
+                CreateAction("PromoteAsync", true)
+            ],
+            WorkflowClusters = [cluster]
+        };
+
+        return model with { Corpus = new AnalysisCorpusBuilder().Build(model) };
+    }
+
+    private static WorkflowClusterMethodModel CreateClusterMethod(string method, string role) => new()
+    {
+        Service = "RevisionSubmissionService",
+        Method = method,
+        Role = role,
+        Classification = ActionClassification.Workflow,
+        Risk = "approval required"
+    };
+
+    private static ServiceMethodModel CreateMethod(string name) => new()
+    {
+        Name = name,
+        ReturnType = "Task",
+        IsPublic = true,
+        IsAsync = true
+    };
+
+    private static ActionModel CreateAction(string method, bool mutation) => new()
+    {
+        Id = "revision-submission-service-" + WorkflowOnboardingPlanner.ToSlug(method),
+        Name = method,
+        SourceService = "RevisionSubmissionService",
+        MethodName = method,
+        FilePath = "Services/RevisionSubmissionService.cs",
+        Classification = mutation ? ActionClassification.Workflow : ActionClassification.Query,
+        ExposureMode = ActionExposureMode.Suggested,
+        IsMutationLikely = mutation,
+        RequiresApproval = mutation,
+        Score = 0.8,
+        RelevantRoutes = ["/revisions"]
+    };
+
+    private static string CreateTempDirectory()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"agentblazor-workflow-onboarding-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(path);
+        return path;
+    }
+}

--- a/tests/AgentBlazor.Cli.IntegrationTests/ScaffoldWorkflowsCommandTests.cs
+++ b/tests/AgentBlazor.Cli.IntegrationTests/ScaffoldWorkflowsCommandTests.cs
@@ -1,0 +1,352 @@
+using System.Diagnostics;
+using System.Text.Json;
+
+namespace AgentBlazor.Cli.IntegrationTests;
+
+public sealed class ScaffoldWorkflowsCommandTests
+{
+    [Fact]
+    public async Task ScaffoldWorkflowsApproveNonInteractive_WithoutWorkflowSelection_RefusesApply()
+    {
+        var repoRoot = FindRepoRoot();
+        var tempDir = CreateTempDirectory();
+        try
+        {
+            CopyDirectory(
+                Path.Combine(repoRoot, "tests", "cli-targets", "realistic-blazor-app"),
+                tempDir);
+
+            var result = await RunCliAsync(
+                repoRoot,
+                "scaffold",
+                "workflows",
+                Path.Combine(tempDir, "RealisticBlazorApp.csproj"),
+                "--approve",
+                "--non-interactive");
+
+            Assert.Equal(2, result.ExitCode);
+            Assert.Contains("requires --workflow", result.Output, StringComparison.OrdinalIgnoreCase);
+            Assert.False(File.Exists(Path.Combine(tempDir, ".agentblazor", "SOUL.md")));
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task ScaffoldWorkflowsApproveNonInteractive_WithWorkflowSelection_WritesSoulAndSkillArtifacts()
+    {
+        var repoRoot = FindRepoRoot();
+        var tempDir = CreateTempDirectory();
+        try
+        {
+            CopyDirectory(
+                Path.Combine(repoRoot, "tests", "cli-targets", "realistic-blazor-app"),
+                tempDir);
+
+            var result = await RunCliAsync(
+                repoRoot,
+                "scaffold",
+                "workflows",
+                Path.Combine(tempDir, "RealisticBlazorApp.csproj"),
+                "--workflow",
+                "same-service-lifecycle-inventory-pipeline",
+                "--description",
+                "Inventory operations app for warehouse managers.",
+                "--agent-goals",
+                "approve supplier transfers;prepare restock plans",
+                "--save-config",
+                "--reviewed-by",
+                "Riley Reviewer",
+                "--approve",
+                "--non-interactive");
+
+            Assert.Equal(0, result.ExitCode);
+            Assert.Contains("Workflow artifacts applied", result.Output, StringComparison.OrdinalIgnoreCase);
+
+            var agentDir = Path.Combine(tempDir, ".agentblazor");
+            var skillDir = Path.Combine(agentDir, "skills", "inventory-pipeline");
+            var reviewJsonPath = Path.Combine(agentDir, "workflow-onboarding.json");
+            var reviewMarkdownPath = Path.Combine(agentDir, "workflow-onboarding.md");
+            var reviewHtmlPath = Path.Combine(agentDir, "workflow-onboarding.html");
+            var soulPath = Path.Combine(agentDir, "SOUL.md");
+            var indexPath = Path.Combine(agentDir, "skills", "index.json");
+            var metadataPath = Path.Combine(agentDir, "skills", ".metadata.json");
+            var skillPath = Path.Combine(skillDir, "SKILL.md");
+            var evidencePath = Path.Combine(skillDir, "references", "evidence.md");
+            var configPath = Path.Combine(tempDir, ".agentblazorc");
+            var auditDir = Path.Combine(agentDir, "audit");
+
+            Assert.True(File.Exists(reviewJsonPath));
+            Assert.True(File.Exists(reviewMarkdownPath));
+            Assert.True(File.Exists(reviewHtmlPath));
+            Assert.True(File.Exists(soulPath));
+            Assert.True(File.Exists(indexPath));
+            Assert.True(File.Exists(metadataPath));
+            Assert.True(File.Exists(skillPath));
+            Assert.True(File.Exists(evidencePath));
+            Assert.True(File.Exists(configPath));
+            var auditPath = Assert.Single(Directory.GetFiles(auditDir, "workflow-onboarding-*.json"));
+
+            Assert.Contains("Inventory Pipeline", await File.ReadAllTextAsync(soulPath));
+            Assert.Contains("Inventory operations app for warehouse managers.", await File.ReadAllTextAsync(soulPath));
+            Assert.Contains("approve supplier transfers", await File.ReadAllTextAsync(soulPath));
+            Assert.Contains("Workflow Onboarding Review", await File.ReadAllTextAsync(reviewMarkdownPath));
+            var reviewMarkdown = await File.ReadAllTextAsync(reviewMarkdownPath);
+            var reviewHtml = await File.ReadAllTextAsync(reviewHtmlPath);
+            Assert.Contains("Reviewed by: Riley Reviewer", reviewMarkdown);
+            Assert.Contains("Inventory Pipeline", reviewHtml);
+            Assert.Contains("Reviewed by: Riley Reviewer", reviewHtml);
+            var reviewJson = await File.ReadAllTextAsync(reviewJsonPath);
+            Assert.Contains("\"reviewedBy\": \"Riley Reviewer\"", reviewJson);
+            Assert.Contains("\"approvedCandidateIds\"", reviewJson);
+            Assert.Contains("\"status\": \"approved\"", reviewJson);
+            Assert.Contains("Services/InventoryWorkflowService.cs", reviewJson);
+            Assert.DoesNotContain(tempDir, reviewJson);
+            Assert.Contains("requiredApprovals", await File.ReadAllTextAsync(skillPath));
+            Assert.Contains("InventoryWorkflowService.PrepareRestockPlanAsync", await File.ReadAllTextAsync(evidencePath));
+            var auditJson = await File.ReadAllTextAsync(auditPath);
+            Assert.Contains("\"kind\": \"workflow-onboarding\"", auditJson);
+            Assert.Contains("\"reviewedBy\": \"Riley Reviewer\"", auditJson);
+            Assert.Contains("propose_patch", auditJson);
+            Assert.Contains("apply_approved_patch", auditJson);
+            Assert.DoesNotContain(tempDir, auditJson);
+
+            using var index = JsonDocument.Parse(await File.ReadAllTextAsync(indexPath));
+            var skill = Assert.Single(index.RootElement.GetProperty("skills").EnumerateArray());
+            Assert.Equal("inventory-pipeline", skill.GetProperty("name").GetString());
+            Assert.Equal("inventory-pipeline/SKILL.md", skill.GetProperty("skillPath").GetString());
+
+            using var config = JsonDocument.Parse(await File.ReadAllTextAsync(configPath));
+            Assert.Equal("Inventory operations app for warehouse managers.", config.RootElement.GetProperty("description").GetString());
+            Assert.Contains(config.RootElement.GetProperty("desiredAgentWorkflows").EnumerateArray(), goal =>
+                goal.GetString() == "prepare restock plans");
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task ScaffoldWorkflowsApproveNonInteractive_WithReviewActions_UpdatesReviewOnly()
+    {
+        var repoRoot = FindRepoRoot();
+        var tempDir = CreateTempDirectory();
+        try
+        {
+            CopyDirectory(
+                Path.Combine(repoRoot, "tests", "cli-targets", "realistic-blazor-app"),
+                tempDir);
+
+            var result = await RunCliAsync(
+                repoRoot,
+                "scaffold",
+                "workflows",
+                Path.Combine(tempDir, "RealisticBlazorApp.csproj"),
+                "--reject",
+                "existing-support-queue-capabilities",
+                "--pin",
+                "existing-support-queue-capabilities",
+                "--reviewed-by",
+                "Riley Reviewer",
+                "--approve",
+                "--non-interactive");
+
+            Assert.Equal(0, result.ExitCode);
+            Assert.Contains("Workflow artifacts applied", result.Output, StringComparison.OrdinalIgnoreCase);
+
+            var agentDir = Path.Combine(tempDir, ".agentblazor");
+            var reviewJsonPath = Path.Combine(agentDir, "workflow-onboarding.json");
+            var reviewMarkdownPath = Path.Combine(agentDir, "workflow-onboarding.md");
+            var reviewHtmlPath = Path.Combine(agentDir, "workflow-onboarding.html");
+            var soulPath = Path.Combine(agentDir, "SOUL.md");
+            var auditDir = Path.Combine(agentDir, "audit");
+
+            Assert.True(File.Exists(reviewJsonPath));
+            Assert.True(File.Exists(reviewMarkdownPath));
+            Assert.True(File.Exists(reviewHtmlPath));
+            Assert.False(File.Exists(soulPath));
+            var auditPath = Assert.Single(Directory.GetFiles(auditDir, "workflow-onboarding-*.json"));
+
+            var reviewJson = await File.ReadAllTextAsync(reviewJsonPath);
+            Assert.Contains("\"reviewedBy\": \"Riley Reviewer\"", reviewJson);
+            Assert.Contains("\"id\": \"existing-support-queue-capabilities\"", reviewJson);
+            Assert.Contains("\"status\": \"rejected\"", reviewJson);
+            Assert.Contains("\"pinned\": true", reviewJson);
+            Assert.Contains("rejected, pinned", await File.ReadAllTextAsync(reviewMarkdownPath));
+            Assert.Contains("rejected, pinned", await File.ReadAllTextAsync(reviewHtmlPath));
+            Assert.Contains("existing-support-queue-capabilities", await File.ReadAllTextAsync(auditPath));
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task ScaffoldWorkflowsApplyApproved_UsesExistingReviewArtifact()
+    {
+        var repoRoot = FindRepoRoot();
+        var tempDir = CreateTempDirectory();
+        try
+        {
+            CopyDirectory(
+                Path.Combine(repoRoot, "tests", "cli-targets", "realistic-blazor-app"),
+                tempDir);
+            var agentDir = Path.Combine(tempDir, ".agentblazor");
+            Directory.CreateDirectory(agentDir);
+            await File.WriteAllTextAsync(Path.Combine(agentDir, "workflow-onboarding.json"), """
+            {
+              "schemaVersion": 1,
+              "candidates": [
+                {
+                  "id": "same-service-lifecycle-inventory-pipeline",
+                  "slug": "inventory-pipeline",
+                  "status": "approved",
+                  "pinned": true
+                }
+              ]
+            }
+            """);
+
+            var result = await RunCliAsync(
+                repoRoot,
+                "scaffold",
+                "workflows",
+                Path.Combine(tempDir, "RealisticBlazorApp.csproj"),
+                "--apply-approved",
+                "--reviewed-by",
+                "Riley Reviewer",
+                "--approve",
+                "--non-interactive");
+
+            Assert.Equal(0, result.ExitCode);
+            Assert.Contains("Workflow artifacts applied", result.Output, StringComparison.OrdinalIgnoreCase);
+
+            var soulPath = Path.Combine(agentDir, "SOUL.md");
+            var skillPath = Path.Combine(agentDir, "skills", "inventory-pipeline", "SKILL.md");
+            var reviewJson = await File.ReadAllTextAsync(Path.Combine(agentDir, "workflow-onboarding.json"));
+
+            Assert.True(File.Exists(soulPath));
+            Assert.True(File.Exists(skillPath));
+            Assert.Contains("Inventory Pipeline", await File.ReadAllTextAsync(soulPath));
+            Assert.Contains("\"status\": \"approved\"", reviewJson);
+            Assert.Contains("\"pinned\": true", reviewJson);
+            Assert.Contains("\"reviewedBy\": \"Riley Reviewer\"", reviewJson);
+            Assert.Single(Directory.GetFiles(Path.Combine(agentDir, "audit"), "workflow-onboarding-*.json"));
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task ScaffoldWorkflowsApproveNonInteractive_WithWorkflowSelectionWithoutReviewer_RefusesApply()
+    {
+        var repoRoot = FindRepoRoot();
+        var tempDir = CreateTempDirectory();
+        try
+        {
+            CopyDirectory(
+                Path.Combine(repoRoot, "tests", "cli-targets", "realistic-blazor-app"),
+                tempDir);
+
+            var result = await RunCliAsync(
+                repoRoot,
+                "scaffold",
+                "workflows",
+                Path.Combine(tempDir, "RealisticBlazorApp.csproj"),
+                "--workflow",
+                "same-service-lifecycle-inventory-pipeline",
+                "--approve",
+                "--non-interactive");
+
+            Assert.Equal(1, result.ExitCode);
+            Assert.Contains("requires --reviewed-by", result.Output, StringComparison.OrdinalIgnoreCase);
+            Assert.False(File.Exists(Path.Combine(tempDir, ".agentblazor", "SOUL.md")));
+            Assert.False(Directory.Exists(Path.Combine(tempDir, ".agentblazor", "audit")));
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    private static async Task<CliResult> RunCliAsync(string repoRoot, params string[] arguments)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            WorkingDirectory = repoRoot,
+            RedirectStandardError = true,
+            RedirectStandardOutput = true
+        };
+        startInfo.ArgumentList.Add("run");
+        startInfo.ArgumentList.Add("--project");
+        startInfo.ArgumentList.Add(Path.Combine(repoRoot, "src", "AgentBlazor.Cli", "AgentBlazor.Cli.csproj"));
+        startInfo.ArgumentList.Add("--no-restore");
+        startInfo.ArgumentList.Add("--");
+        foreach (var argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        using var process = Process.Start(startInfo) ?? throw new InvalidOperationException("Failed to start CLI process.");
+        var outputTask = process.StandardOutput.ReadToEndAsync();
+        var errorTask = process.StandardError.ReadToEndAsync();
+        var exitTask = process.WaitForExitAsync();
+        var completed = await Task.WhenAny(exitTask, Task.Delay(TimeSpan.FromSeconds(90)));
+        if (completed != exitTask)
+        {
+            process.Kill(entireProcessTree: true);
+            throw new TimeoutException("CLI process did not exit within 90 seconds.");
+        }
+
+        var output = await outputTask;
+        var error = await errorTask;
+        return new CliResult(process.ExitCode, output + error);
+    }
+
+    private static string FindRepoRoot()
+    {
+        var directory = new DirectoryInfo(Directory.GetCurrentDirectory());
+        while (directory is not null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "AgentBlazor.sln")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not find AgentBlazor repository root.");
+    }
+
+    private static string CreateTempDirectory()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"agentblazor-cli-workflows-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private static void CopyDirectory(string sourceDirectory, string destinationDirectory)
+    {
+        Directory.CreateDirectory(destinationDirectory);
+        foreach (var directory in Directory.EnumerateDirectories(sourceDirectory, "*", SearchOption.AllDirectories))
+        {
+            Directory.CreateDirectory(Path.Combine(destinationDirectory, Path.GetRelativePath(sourceDirectory, directory)));
+        }
+
+        foreach (var file in Directory.EnumerateFiles(sourceDirectory, "*", SearchOption.AllDirectories))
+        {
+            var destination = Path.Combine(destinationDirectory, Path.GetRelativePath(sourceDirectory, file));
+            File.Copy(file, destination, overwrite: true);
+        }
+    }
+
+    private sealed record CliResult(int ExitCode, string Output);
+}


### PR DESCRIPTION
## Summary
- release AgentBlazor 0.2.22 with CLI V2 workflow onboarding
- add scaffold workflows review artifacts, SOUL/skill generation, reviewer-gated approval, agent-loop patch application, and audit output
- add packaged V2 workflow smoke coverage to the NuGet publish workflow

## Verification
- dotnet build src/AgentBlazor.Cli/AgentBlazor.Cli.csproj --no-restore
- dotnet test tests/AgentBlazor.Cli.Analysis.Tests/AgentBlazor.Cli.Analysis.Tests.csproj --no-restore --filter "FullyQualifiedName~AgentLoopTests|FullyQualifiedName~WorkflowOnboardingTests" --logger "console;verbosity=minimal"
- dotnet test tests/AgentBlazor.Cli.IntegrationTests/AgentBlazor.Cli.IntegrationTests.csproj --no-restore --filter FullyQualifiedName~ScaffoldWorkflowsCommandTests --logger "console;verbosity=minimal"
- AGENTBLAZOR_CLI_PACKAGE_VERSION=0.2.22 scripts/smoke-test-cli-v2-workflows.sh
- git diff --check