### PR TITLE
Make V2 workflow smoke portable

### DIFF
--- a/scripts/smoke-test-cli-v2-workflows.sh
+++ b/scripts/smoke-test-cli-v2-workflows.sh
@@ -27,13 +27,13 @@ assert_file() {
 assert_contains() {
   local path="$1"
   local pattern="$2"
-  rg -q --fixed-strings "$pattern" "$path" || fail "Expected '$path' to contain '$pattern'."
+  grep -F -q -- "$pattern" "$path" || fail "Expected '$path' to contain '$pattern'."
 }
 
 assert_not_contains() {
   local path="$1"
   local pattern="$2"
-  if rg -q --fixed-strings "$pattern" "$path"; then
+  if grep -F -q -- "$pattern" "$path"; then
     fail "Expected '$path' not to contain '$pattern'."
   fi
 }
@@ -168,7 +168,7 @@ reviewer_gate_output="$("$cli_exe" scaffold workflows "$reviewer_gate_app/Realis
 reviewer_gate_exit=$?
 set -e
 [[ "$reviewer_gate_exit" -ne 0 ]] || fail "Workflow approval without --reviewed-by should fail."
-printf '%s\n' "$reviewer_gate_output" | rg -q --fixed-strings 'requires --reviewed-by' ||
+printf '%s\n' "$reviewer_gate_output" | grep -F -q -- 'requires --reviewed-by' ||
   fail "Reviewer gate output did not mention --reviewed-by."
 
 log "CLI V2 workflow package smoke passed for AgentBlazor.Cli $package_version"


### PR DESCRIPTION
## Summary
- replace rg usage in the V2 workflow smoke script with portable grep
- fixes the publish workflow runner failure where rg is unavailable

## Verification
- AGENTBLAZOR_CLI_PACKAGE_VERSION=0.2.22 scripts/smoke-test-cli-v2-workflows.sh
- git diff --check